### PR TITLE
Basic Debug Release Pipeline

### DIFF
--- a/.github/workflows/debug-apk-release.yml
+++ b/.github/workflows/debug-apk-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build-and-release:

--- a/.github/workflows/debug-apk-release.yml
+++ b/.github/workflows/debug-apk-release.yml
@@ -1,0 +1,48 @@
+name: Debug APK Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Get short SHA
+        id: vars
+        run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: debug-main-${{ steps.vars.outputs.sha }}
+          name: Debug APK Release (${{ steps.vars.outputs.sha }})
+          body: |
+            This is an automated debug APK release generated from a push to main.
+            **This is a debug build and NOT for production use.**
+          draft: false
+          prerelease: true
+
+      - name: Upload APK to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: composeApp/build/outputs/apk/debug/composeApp-debug.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 


### PR DESCRIPTION
## Add GitHub Actions Workflow for Debug APK Release

### Overview

This PR introduces a GitHub Actions workflow that automatically builds and releases a debug APK every time a pull request is merged into the `main` branch.

### Details

- **Trigger:** Runs on every push to `main` (i.e., after a PR is merged).
- **Build:** Executes `./gradlew assembleDebug` to generate a debug APK.
- **Release:**  
  - Creates a GitHub Release with a tag like `debug-main-<shortsha>`.
  - Clearly marks the release as a debug build in the name and description.
  - Attaches the generated debug APK as a release asset.
- **Purpose:**  
  - Makes it easy to download and test the latest debug build from the Releases page.
  - Ensures every main branch commit has a corresponding debug APK for QA and development.