### PR TITLE
feat(sendspin): add support for custom host and TLS (WSS) in Sendspin Player

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -354,9 +354,10 @@ class MainDataSource(
             enabled = true,
             bufferCapacityMicros = 500_000, // 500ms
             codecPreference = settings.sendspinCodecPreference.value,
-            serverHost = serverHost,
+            serverHost = settings.sendspinHost.value.takeIf { it.isNotEmpty() } ?: serverHost,
             serverPort = settings.sendspinPort.value,
-            serverPath = settings.sendspinPath.value
+            serverPath = settings.sendspinPath.value,
+            useTls = settings.sendspinUseTls.value
         )
 
         log.i { "Initializing Sendspin client: $serverHost:${config.serverPort}" }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/SendspinConfig.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/SendspinConfig.kt
@@ -12,13 +12,15 @@ data class SendspinConfig(
     val codecPreference: Codec,
 
     // Server connection settings
-    val serverHost: String = "", // Will use MA server IP from general settings
-    val serverPort: Int = 8927, // Default Sendspin port for Music Assistant
-    val serverPath: String = "/sendspin" // WebSocket endpoint path
+    val serverHost: String = "", 
+    val serverPort: Int = 8927, 
+    val serverPath: String = "/sendspin",
+    val useTls: Boolean = false
 ) {
     fun buildServerUrl(): String {
         return if (serverHost.isNotEmpty()) {
-            "ws://$serverHost:$serverPort$serverPath"
+            val protocol = if (useTls) "wss" else "ws"
+            "$protocol://$serverHost:$serverPort$serverPath"
         } else {
             ""
         }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/SettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/SettingsRepository.kt
@@ -140,4 +140,24 @@ class SettingsRepository(
         settings.putString("sendspin_codec_preference", codec.name)
         _sendspinCodecPreference.update { codec }
     }
+
+    private val _sendspinHost = MutableStateFlow(
+        settings.getString("sendspin_host", "")
+    )
+    val sendspinHost = _sendspinHost.asStateFlow()
+
+    fun setSendspinHost(host: String) {
+        settings.putString("sendspin_host", host)
+        _sendspinHost.update { host }
+    }
+
+    private val _sendspinUseTls = MutableStateFlow(
+        settings.getBoolean("sendspin_use_tls", false)
+    )
+    val sendspinUseTls = _sendspinUseTls.asStateFlow()
+
+    fun setSendspinUseTls(enabled: Boolean) {
+        settings.putBoolean("sendspin_use_tls", enabled)
+        _sendspinUseTls.update { enabled }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
@@ -433,15 +433,16 @@ private fun SendspinSection(
             )
         )
 
+        val sendspinHost by viewModel.sendspinHost.collectAsStateWithLifecycle()
+        val sendspinUseTls by viewModel.sendspinUseTls.collectAsStateWithLifecycle()
+
         TextField(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = 12.dp),
-            value = sendspinPort.toString(),
-            onValueChange = {
-                it.toIntOrNull()?.let { port -> viewModel.setSendspinPort(port) }
-            },
-            label = { Text("Port (8927 by default)") },
+            value = sendspinHost,
+            onValueChange = { viewModel.setSendspinHost(it) },
+            label = { Text("Custom Host (leave empty for default)") },
             singleLine = true,
             enabled = !sendspinEnabled,
             colors = TextFieldDefaults.colors(
@@ -451,21 +452,64 @@ private fun SendspinSection(
             )
         )
 
-        TextField(
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            TextField(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(bottom = 12.dp),
+                value = sendspinPort.toString(),
+                onValueChange = {
+                    it.toIntOrNull()?.let { port -> viewModel.setSendspinPort(port) }
+                },
+                label = { Text("Port (8927 by default)") },
+                singleLine = true,
+                enabled = !sendspinEnabled,
+                colors = TextFieldDefaults.colors(
+                    focusedTextColor = MaterialTheme.colorScheme.onBackground,
+                    unfocusedTextColor = MaterialTheme.colorScheme.onBackground,
+                    disabledTextColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                )
+            )
+
+            TextField(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(bottom = 12.dp),
+                value = sendspinPath,
+                onValueChange = { viewModel.setSendspinPath(it) },
+                label = { Text("Path") },
+                singleLine = true,
+                enabled = !sendspinEnabled,
+                colors = TextFieldDefaults.colors(
+                    focusedTextColor = MaterialTheme.colorScheme.onBackground,
+                    unfocusedTextColor = MaterialTheme.colorScheme.onBackground,
+                    disabledTextColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                )
+            )
+        }
+
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(bottom = 16.dp),
-            value = sendspinPath,
-            onValueChange = { viewModel.setSendspinPath(it) },
-            label = { Text("Path (/sendspin by default)") },
-            singleLine = true,
-            enabled = !sendspinEnabled,
-            colors = TextFieldDefaults.colors(
-                focusedTextColor = MaterialTheme.colorScheme.onBackground,
-                unfocusedTextColor = MaterialTheme.colorScheme.onBackground,
-                disabledTextColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                .padding(bottom = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Checkbox(
+                checked = sendspinUseTls,
+                onCheckedChange = { viewModel.setSendspinUseTls(it) },
+                enabled = !sendspinEnabled
             )
-        )
+            Text(
+                text = "Use secure connection (WSS/TLS)",
+                color = if (sendspinEnabled)
+                    MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
+                else
+                    MaterialTheme.colorScheme.onBackground
+            )
+        }
 
         // Codec selection
         Row(
@@ -475,14 +519,21 @@ private fun SendspinSection(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(
-                text = sendspinCodecPreference.uiTitle(),
-                style = MaterialTheme.typography.bodyLarge,
-                color = if (sendspinEnabled)
-                    MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
-                else
-                    MaterialTheme.colorScheme.onBackground
-            )
+            Column {
+                Text(
+                    text = "Codec preference",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = sendspinCodecPreference.uiTitle(),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = if (sendspinEnabled)
+                        MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
+                    else
+                        MaterialTheme.colorScheme.onBackground
+                )
+            }
 
             OverflowMenu(
                 modifier = Modifier,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsViewModel.kt
@@ -38,10 +38,14 @@ class SettingsViewModel(
     val sendspinPort = settings.sendspinPort
     val sendspinPath = settings.sendspinPath
     val sendspinCodecPreference = settings.sendspinCodecPreference
+    val sendspinHost = settings.sendspinHost
+    val sendspinUseTls = settings.sendspinUseTls
 
     fun setSendspinEnabled(enabled: Boolean) = settings.setSendspinEnabled(enabled)
     fun setSendspinDeviceName(name: String) = settings.setSendspinDeviceName(name)
     fun setSendspinPort(port: Int) = settings.setSendspinPort(port)
     fun setSendspinPath(path: String) = settings.setSendspinPath(path)
     fun setSendspinCodecPreference(codec: Codec) = settings.setSendspinCodecPreference(codec)
+    fun setSendspinHost(host: String) = settings.setSendspinHost(host)
+    fun setSendspinUseTls(enabled: Boolean) = settings.setSendspinUseTls(enabled)
 }


### PR DESCRIPTION
# Pull Request: Support for Custom Host and TLS/WSS in Sendspin Player

## Problem

Currently, the Sendspin local player in the Music Assistant mobile app has two major limitations:

1. **Hardcoded Protocol**: It strictly uses `ws://` (unencrypted WebSocket).
2. **Hardcoded Host**: It always attempts to connect to the same host as the main Music Assistant server.

This configuration fails for users who access their Music Assistant instance through a **Reverse Proxy** (e.g., Nginx, Cloudflare, HAProxy, NPM). In these environments:

- The dashboard is typically served over **HTTPS/WSS**.
- The Sendspin port (`8927`) might be mapped to a different public port (like `443`) or requires SSL termination at the proxy level.
- Browsers and mobile frameworks often block mixing unencrypted `ws://` connections when the main session is over `https://`.

## Solution

This PR introduces flexibility to the Sendspin connection logic, allowing it to work in complex network environments without breaking the "plug-and-play" experience for local users.

### Key Changes

- **Custom Host Support**: Users can now specify a different hostname for the Sendspin player. If left empty, it defaults to the main server host (preserving existing behavior).
- **TLS/WSS Push**: Added a toggle to enable **Secure WebSockets (`wss://`)**. This is essential for connections through SSL-enabled proxies.
- **UI Refinement**:
  - Reorganized the Local Player settings to group connection parameters (Port, Path, Host, TLS).
  - Improved layout using a grid-like structure (Port and Path on the same row) to keep the settings screen concise.
- **Persistence**: Both settings are saved in the `SettingsRepository` and persist across app restarts.

## How to test

1. Go to **Settings** > **Local Player**.
2. To use through a proxy (e.g., `ma.domain.com` over 443):
   - Set **Port** to `443`.
   - Set **Host** to `ma.domain.com` (or leave blank if it's the same as the server).
   - Toggle **Use secure connection (WSS/TLS)** to ON.
3. Enable the player. Connection should now establish successfully via `wss://ma.domain.com:443/sendspin`.

## Technical impact

- **Zero Breaking Changes**: Default values (empty host, TLS OFF) ensure that local network users are unaffected by this update.
- **Code Quality**: Follows the existing Material3 design patterns and Kotlin Multiplatform (KMP) architecture used in the project.