### PR TITLE
Use kotlin.math.PI in MediaItemShapes.kt

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/MediaItemShapes.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/MediaItemShapes.kt
@@ -140,7 +140,7 @@ class WavyHexagonShape : Shape {
 
             // Calculate 6 points of hexagon
             val points = List(6) { i ->
-                val angle = (i * 60f - 30f) * (Math.PI / 180f).toFloat()
+                val angle = (i * 60f - 30f) * (kotlin.math.PI / 180f).toFloat()
                 Offset(
                     centerX + radius * kotlin.math.cos(angle),
                     centerY + radius * kotlin.math.sin(angle)
@@ -169,8 +169,8 @@ class WavyHexagonShape : Shape {
 
                     // Calculate perpendicular offset for sine wave
                     val edgeAngle = kotlin.math.atan2(next.y - current.y, next.x - current.x)
-                    val perpAngle = edgeAngle + Math.PI.toFloat() / 2f
-                    val waveOffset = amplitude * kotlin.math.sin((t * frequency * 2.0 * Math.PI).toFloat())
+                    val perpAngle = edgeAngle + kotlin.math.PI.toFloat() / 2f
+                    val waveOffset = amplitude * kotlin.math.sin((t * frequency * 2.0 * kotlin.math.PI).toFloat())
 
                     val x = baseX + waveOffset * kotlin.math.cos(perpAngle)
                     val y = baseY + waveOffset * kotlin.math.sin(perpAngle)


### PR DESCRIPTION
Replace uses of java.lang.Math with kotlin.math equivalents in MediaItemShapes.kt. This resolves #72 