### PR TITLE
Add default URI

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Defaults.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Defaults.kt
@@ -1,0 +1,6 @@
+package io.music_assistant.client.api
+
+object Defaults {
+    const val URI = "homeassistant.local"
+    const val PORT = 8095
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.music_assistant.client.api.ConnectionInfo
+import io.music_assistant.client.api.Defaults
 import io.music_assistant.client.data.model.server.ServerInfo
 import io.music_assistant.client.data.model.server.User
 import io.music_assistant.client.ui.compose.auth.AuthenticationPanel
@@ -117,8 +118,8 @@ fun SettingsScreen(goHome: () -> Unit, exitApp: () -> Unit) {
                     .padding(horizontal = 16.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                var ipAddress by remember { mutableStateOf("homeassistant.local") }
-                var port by remember { mutableStateOf("8095") }
+                var ipAddress by remember { mutableStateOf(Defaults.URI) }
+                var port by remember { mutableStateOf(Defaults.PORT.toString()) }
                 var isTls by remember { mutableStateOf(false) }
 
                 LaunchedEffect(savedConnectionInfo) {


### PR DESCRIPTION
This should make it a little swifter to set the app up for most people (making the assumption that most people are deploying with Home Assistant and leaving the default hostname unchanged).