### PR TITLE
Fix descenders being cut off in group button

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/PlayersPager.kt
@@ -501,7 +501,11 @@ private fun GroupButton(player: PlayerData, isLocalPlayer: Boolean, onShowGroup:
     ) {
         val playerName: @Composable (Color) -> Unit = { textColor ->
             Text(
+                modifier = Modifier.align(Alignment.Center),
                 text = player.player.displayName + (if (isLocalPlayer) " (local)" else ""),
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center,
+                fontWeight = FontWeight.Medium,
                 color = textColor,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis


### PR DESCRIPTION
This reworks the group button to give each consistent height, while also avoiding descenders getting cut off:

<img width="175" height="91" alt="Screenshot 2026-02-18 at 11 42 19" src="https://github.com/user-attachments/assets/121a68c5-c033-4038-80a8-4f4b824d9335" />

The above happens because Compose `Button` has a min height that will always get used, so setting a fixed height (as was happening before) throws off alignment.

This change does end up reverting this component to the larger size it was before. If that seems too big, I can just make custom components (avoiding the Material min sizing).
