### PR TITLE
Add previews for item screens

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/AppMediaItemFixtures.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/AppMediaItemFixtures.kt
@@ -1,5 +1,7 @@
 package io.music_assistant.client.data.model.client
 
+import io.music_assistant.client.data.model.server.MediaItemChapter
+
 object AppMediaItemFixtures {
     fun album(name: String, artist: String): AppMediaItem.Album {
         return AppMediaItem.Album(
@@ -92,7 +94,7 @@ object AppMediaItemFixtures {
         }
     }
 
-    fun audiobook(name: String): AppMediaItem.Audiobook {
+    fun audiobook(name: String, chapters: List<String>): AppMediaItem.Audiobook {
         return AppMediaItem.Audiobook(
             itemId = "blah",
             provider = "blah",
@@ -105,9 +107,20 @@ object AppMediaItemFixtures {
             duration = null,
             authors = null,
             narrators = null,
-            chapters = null,
+            chapters = chapters(chapters),
             fullyPlayed = null,
             resumePositionMs = null
         )
+    }
+
+    private fun chapters(chapters: List<String>): List<MediaItemChapter> {
+        return chapters.mapIndexed { index, chapter ->
+            MediaItemChapter(
+                position = index,
+                chapter,
+                start = index.toDouble(),
+                end = (index + 1).toDouble()
+            )
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -753,24 +753,20 @@ private fun PreviewPodcastGrid() {
 
 @Preview
 @Composable
-private fun PreviewAudiobook(isRowMode: Boolean = true) {
+private fun PreviewAudiobook() {
     AppTheme(darkTheme = false) {
         Scaffold {
             ItemDetails(
                 state = ItemDetailsViewModel.State(
                     SessionState.Disconnected.NoServerData,
-                    DataState.Data(AppMediaItemFixtures.audiobook("Title")),
+                    DataState.Data(AppMediaItemFixtures.audiobook(
+                        "Title",
+                        listOf("Chapter 1", "Chapter 2")
+                    )),
                     DataState.NoData(),
                     DataState.NoData()
-                ),
-                isRowMode = isRowMode
+                )
             )
         }
     }
-}
-
-@Preview
-@Composable
-private fun PreviewAudiobookGrid() {
-    PreviewAudiobook(isRowMode = false)
 }


### PR DESCRIPTION
Work towards #108

This adds `@Preview` (and fixture helpers) for item screens to make it easier to iterate on them. I mostly reverse engineered the structure from reading `ItemDetailsViewModel`, but let me know if there's anything crucial missing. 