### PR TITLE
Tweak compact player spacing

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/PlayerControls.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/PlayerControls.kt
@@ -51,7 +51,7 @@ fun PlayerControls(
         modifier = modifier
             .wrapContentSize(),
         horizontalArrangement = Arrangement.spacedBy(
-            16.dp,
+            8.dp,
             alignment = Alignment.CenterHorizontally
         ),
         verticalAlignment = Alignment.CenterVertically,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/PlayerItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/PlayerItems.kt
@@ -141,6 +141,7 @@ fun CompactPlayerItem(
         }
 
         PlayerControls(
+            modifier = Modifier.padding(start = 16.dp),
             playerData = item,
             playerAction = playerAction,
             showAdditionalButtons = showAdditionalControls,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/PlayerItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/PlayerItems.kt
@@ -109,7 +109,7 @@ fun CompactPlayerItem(
             }
 
             // Track info
-            Column(modifier = Modifier.padding(start = 16.dp)) {
+            Column(modifier = Modifier.padding(horizontal = 16.dp)) {
                 Text(
                     text = track?.name ?: "--idle--",
                     style = MaterialTheme.typography.bodyLarge,
@@ -141,7 +141,6 @@ fun CompactPlayerItem(
         }
 
         PlayerControls(
-            modifier = Modifier.padding(start = 16.dp),
             playerData = item,
             playerAction = playerAction,
             showAdditionalButtons = showAdditionalControls,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -76,35 +77,37 @@ fun ItemDetailsScreen(
         }
     }
 
-    ItemDetails(
-        state,
-        serverUrl,
-        onBack,
-        isRowMode,
-        toastState,
-        onNavigateToItem,
-        actionsViewModel::getEditablePlaylists,
-        actionsViewModel::addToPlaylist,
-        actionsViewModel::onLibraryClick,
-        actionsViewModel::onFavoriteClick,
-        actionsViewModel::onMarkPlayed,
-        actionsViewModel::onMarkUnplayed,
-        { id, pos ->
-            actionsViewModel.removeFromPlaylist(
-                id,
-                pos,
-                viewModel::reload
-            )
-        },
-        { modifier, provider ->
-            actionsViewModel.getProviderIcon(provider)
-                ?.let { ProviderIcon(modifier, it) }
-        },
-        viewModel::onPlayClick,
-        viewModel::toggleItemsRowMode,
-        viewModel::onChapterClick,
-        viewModel::onPlayClick
-    )
+    Surface {
+        ItemDetails(
+            state,
+            serverUrl,
+            onBack,
+            isRowMode,
+            toastState,
+            onNavigateToItem,
+            actionsViewModel::getEditablePlaylists,
+            actionsViewModel::addToPlaylist,
+            actionsViewModel::onLibraryClick,
+            actionsViewModel::onFavoriteClick,
+            actionsViewModel::onMarkPlayed,
+            actionsViewModel::onMarkUnplayed,
+            { id, pos ->
+                actionsViewModel.removeFromPlaylist(
+                    id,
+                    pos,
+                    viewModel::reload
+                )
+            },
+            { modifier, provider ->
+                actionsViewModel.getProviderIcon(provider)
+                    ?.let { ProviderIcon(modifier, it) }
+            },
+            viewModel::onPlayClick,
+            viewModel::toggleItemsRowMode,
+            viewModel::onChapterClick,
+            viewModel::onPlayClick
+        )
+    }
 }
 
 @Composable


### PR DESCRIPTION
Just some quick tweaks for the compact player/player controls to help in cases where the track name is longer than the available space.

Before:

<img width="351" height="113" alt="Screenshot 2026-03-29 at 11 39 22" src="https://github.com/user-attachments/assets/786bb95a-4b75-4cd1-9093-27d9a1a27873" />

After:

<img width="351" height="113" alt="Screenshot 2026-03-29 at 11 40 40" src="https://github.com/user-attachments/assets/f68ba85a-f17b-425c-a82d-8ef2c4d07ec2" />

EDIT: while testing I also noticed a small problem with predictive back that [I've fixed](https://github.com/music-assistant/mobile-app/pull/171#discussion_r3006023990).