### PR TITLE
chore: bump Android version to 0.4.0 (5)

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "io.music_assistant.client"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 4
-        versionName = "0.3.0"
+        versionCode = 5
+        versionName = "0.4.0"
     }
     packaging {
         resources {


### PR DESCRIPTION
Automated version bump after releasing android-v0.3.0.

versionCode: 4 → 5
versionName: 0.3.0 → 0.4.0