### PR TITLE
Host compact player in floating toolbar

### DIFF
--- a/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTest.kt
@@ -38,7 +38,8 @@ class ItemDetailsTest {
                     DataState.Data(artist),
                     DataState.Data(albums),
                     DataState.NoData()
-                )
+                ),
+                geEditablePlaylists = suspend { emptyList() },
             )
         }
 
@@ -61,7 +62,8 @@ class ItemDetailsTest {
                     itemState = DataState.Data(album),
                     albumsState = DataState.NoData(),
                     playableItemsState = DataState.Data(tracks)
-                )
+                ),
+                geEditablePlaylists = suspend { emptyList() },
             )
         }
 
@@ -84,7 +86,8 @@ class ItemDetailsTest {
                     itemState = DataState.Data(album),
                     albumsState = DataState.NoData(),
                     playableItemsState = DataState.Data(emptyList())
-                )
+                ),
+                geEditablePlaylists = suspend { emptyList() },
             )
         }
 
@@ -104,7 +107,8 @@ class ItemDetailsTest {
                     itemState = DataState.Data(playlist),
                     albumsState = DataState.NoData(),
                     playableItemsState = DataState.Data(tracks)
-                )
+                ),
+                geEditablePlaylists = suspend { emptyList() },
             )
         }
 
@@ -129,7 +133,8 @@ class ItemDetailsTest {
                     itemState = DataState.Data(podcast),
                     albumsState = DataState.NoData(),
                     playableItemsState = DataState.Data(episodes)
-                )
+                ),
+                geEditablePlaylists = suspend { emptyList() },
             )
         }
 
@@ -150,7 +155,8 @@ class ItemDetailsTest {
                     itemState = DataState.Data(audiobook),
                     albumsState = DataState.NoData(),
                     playableItemsState = DataState.NoData()
-                )
+                ),
+                geEditablePlaylists = suspend { emptyList() },
             )
         }
 
@@ -177,7 +183,8 @@ class ItemDetailsTest {
         composeTestRule.setContent {
             ItemDetails(
                 state = state.value,
-                onPlayClick = onPlayClick
+                geEditablePlaylists = suspend { emptyList() },
+                onPlayClick = onPlayClick,
             )
         }
 
@@ -218,7 +225,8 @@ class ItemDetailsTest {
         composeTestRule.setContent {
             ItemDetails(
                 state = state.value,
-                onBack = onBack
+                onBack = onBack,
+                geEditablePlaylists = suspend { emptyList() },
             )
         }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/FloatingBar.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/FloatingBar.kt
@@ -32,7 +32,7 @@ fun FloatingBar(modifier: Modifier = Modifier, onClick: () -> Unit = {}, content
 }
 
 object FloatingBarDefaults {
-    val padding = 4.dp
+    val padding = 8.dp
 }
 
 @Preview

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/FloatingBar.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/FloatingBar.kt
@@ -22,13 +22,17 @@ fun FloatingBar(modifier: Modifier = Modifier, onClick: () -> Unit = {}, content
     Box(
         modifier
             .fillMaxWidth()
-            .padding(16.dp)
+            .padding(FloatingBarDefaults.padding)
             .clip(RoundedCornerShape(16.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerHigh)
             .clickable { onClick() }
     ) {
         content()
     }
+}
+
+object FloatingBarDefaults {
+    val padding = 8.dp
 }
 
 @Preview

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/FloatingBar.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/FloatingBar.kt
@@ -1,0 +1,57 @@
+package io.music_assistant.client.ui.compose.home
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun FloatingBar(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    Box(
+        modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+    ) {
+        content()
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewFloatingBarRow() {
+    FloatingBar {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text("Left")
+            Text("Right")
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewFloatingBarColumn() {
+    FloatingBar {
+        Column {
+            Text("Top")
+            Text("Bottom")
+        }
+    }
+}
+

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/FloatingBar.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/FloatingBar.kt
@@ -1,6 +1,7 @@
 package io.music_assistant.client.ui.compose.home
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,18 +14,18 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun FloatingBar(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+fun FloatingBar(modifier: Modifier = Modifier, onClick: () -> Unit = {}, content: @Composable () -> Unit) {
     Box(
         modifier
             .fillMaxWidth()
             .padding(16.dp)
             .clip(RoundedCornerShape(16.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .clickable { onClick() }
     ) {
         content()
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/FloatingBar.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/FloatingBar.kt
@@ -32,7 +32,7 @@ fun FloatingBar(modifier: Modifier = Modifier, onClick: () -> Unit = {}, content
 }
 
 object FloatingBarDefaults {
-    val padding = 8.dp
+    val padding = 4.dp
 }
 
 @Preview

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -22,11 +22,16 @@ import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -56,7 +61,6 @@ import io.music_assistant.client.ui.compose.home.nav.rememberHomeNavBackStack
 import io.music_assistant.client.ui.compose.item.ItemDetailsScreen
 import io.music_assistant.client.ui.compose.library.LibraryScreen
 import io.music_assistant.client.ui.compose.nav.BackHandler
-import io.music_assistant.client.ui.compose.nav.NavScreen
 import io.music_assistant.client.ui.compose.search.SearchScreen
 import io.music_assistant.client.utils.SessionState
 import kotlinx.coroutines.flow.collectLatest
@@ -67,8 +71,7 @@ import org.koin.compose.viewmodel.koinViewModel
 fun HomeScreen(
     viewModel: HomeScreenViewModel = koinViewModel(),
     actionsViewModel: ActionsViewModel = koinViewModel(),
-    hostPadding: PaddingValues,
-    navigateTo: (NavScreen) -> Unit,
+    goToSettings: () -> Unit,
 ) {
     val uriHandler = LocalUriHandler.current
     val toastState = rememberToastState()
@@ -137,85 +140,111 @@ fun HomeScreen(
         },
         label = "player_transition"
     ) { isPlayersViewShown ->
-        if (!isPlayersViewShown) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.background)
-            ) {
-                HomeContent(
-                    homeBackStack = homeBackStack,
-                    connectionState = connectionState,
-                    dataState = dataState,
-                    serverUrl = serverUrl,
-                    onPlayClick = viewModel::onPlayClick,
-                    playlistActions = ActionsViewModel.PlaylistActions(
-                        onLoadPlaylists = actionsViewModel::getEditablePlaylists,
-                        onAddToPlaylist = actionsViewModel::addToPlaylist
-                    ),
-                    libraryActions = ActionsViewModel.LibraryActions(
-                        onLibraryClick = actionsViewModel::onLibraryClick,
-                        onFavoriteClick = actionsViewModel::onFavoriteClick
-                    ),
-                    progressActions = ActionsViewModel.ProgressActions(
-                        onMarkPlayed = actionsViewModel::onMarkPlayed,
-                        onMarkUnplayed = actionsViewModel::onMarkUnplayed
-                    ),
-                    navigateTo = navigateTo,
-                    providerIconFetcher = { modifier, provider ->
-                        actionsViewModel.getProviderIcon(provider)
-                            ?.let { ProviderIcon(modifier, it) }
-                    },
-                    hostPadding = hostPadding
-                )
+        Scaffold(
+            bottomBar = {
+                NavigationBar(modifier = Modifier.height(88.dp)) {
+                    NavigationBarItem(
+                        selected = true,
+                        onClick = { },
+                        icon = {
+                            Icon(Icons.Default.Home, contentDescription = null)
+                        }
+                    )
 
-                FloatingBar(
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(hostPadding),
-                    onClick = { showPlayersView = true }
-                ) {
-                    Players(
-                        modifier = Modifier.height(floatingBarHeight),
-                        playerPagerState = playerPagerState,
-                        state = playersState,
-                        serverUrl = serverUrl,
-                        homeScreenViewModel = viewModel,
-                        actionsViewModel = actionsViewModel,
-                        expanded = false
-                    ) { showPlayersView = false }
-                }
-            }
-        } else {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-            ) {
-                // Close button
-                IconButton(
-                    onClick = { showPlayersView = false },
-                    modifier = Modifier.fillMaxWidth().height(36.dp)
-                        .align(Alignment.CenterHorizontally)
-                ) {
-                    Icon(
-                        Icons.Default.ExpandMore,
-                        "Collapse",
-                        modifier = Modifier.size(32.dp)
+                    NavigationBarItem(
+                        selected = false,
+                        onClick = {
+                            goToSettings()
+                        },
+                        icon = {
+                            Icon(Icons.Default.Settings, contentDescription = null)
+                        }
                     )
                 }
+            }
+        ) { contentPadding ->
+            val hostPadding =
+                contentPadding + PaddingValues(bottom = floatingBarHeight + FloatingBarDefaults.padding)
+
+            if (!isPlayersViewShown) {
                 Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.background)
                 ) {
-                    Players(
-                        playerPagerState = playerPagerState,
-                        state = playersState,
+                    HomeContent(
+                        homeBackStack = homeBackStack,
+                        connectionState = connectionState,
+                        dataState = dataState,
                         serverUrl = serverUrl,
-                        homeScreenViewModel = viewModel,
-                        actionsViewModel = actionsViewModel,
-                        expanded = true
-                    ) { showPlayersView = false }
+                        onPlayClick = viewModel::onPlayClick,
+                        playlistActions = ActionsViewModel.PlaylistActions(
+                            onLoadPlaylists = actionsViewModel::getEditablePlaylists,
+                            onAddToPlaylist = actionsViewModel::addToPlaylist
+                        ),
+                        libraryActions = ActionsViewModel.LibraryActions(
+                            onLibraryClick = actionsViewModel::onLibraryClick,
+                            onFavoriteClick = actionsViewModel::onFavoriteClick
+                        ),
+                        progressActions = ActionsViewModel.ProgressActions(
+                            onMarkPlayed = actionsViewModel::onMarkPlayed,
+                            onMarkUnplayed = actionsViewModel::onMarkUnplayed
+                        ),
+                        providerIconFetcher = { modifier, provider ->
+                            actionsViewModel.getProviderIcon(provider)
+                                ?.let { ProviderIcon(modifier, it) }
+                        },
+                        hostPadding = hostPadding
+                    )
+
+                    FloatingBar(
+                        modifier = Modifier
+                            .align(Alignment.BottomCenter)
+                            .padding(contentPadding),
+                        onClick = { showPlayersView = true }
+                    ) {
+                        Players(
+                            modifier = Modifier.height(floatingBarHeight),
+                            playerPagerState = playerPagerState,
+                            state = playersState,
+                            serverUrl = serverUrl,
+                            homeScreenViewModel = viewModel,
+                            actionsViewModel = actionsViewModel,
+                            expanded = false
+                        ) { showPlayersView = false }
+                    }
+                }
+            } else {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                ) {
+                    // Close button
+                    IconButton(
+                        onClick = { showPlayersView = false },
+                        modifier = Modifier.fillMaxWidth().height(36.dp)
+                            .align(Alignment.CenterHorizontally)
+                    ) {
+                        Icon(
+                            Icons.Default.ExpandMore,
+                            "Collapse",
+                            modifier = Modifier.size(32.dp)
+                        )
+                    }
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Players(
+                            playerPagerState = playerPagerState,
+                            state = playersState,
+                            serverUrl = serverUrl,
+                            homeScreenViewModel = viewModel,
+                            actionsViewModel = actionsViewModel,
+                            expanded = true
+                        ) { showPlayersView = false }
+                    }
                 }
             }
         }
@@ -233,7 +262,6 @@ private fun HomeContent(
     playlistActions: ActionsViewModel.PlaylistActions,
     libraryActions: ActionsViewModel.LibraryActions,
     progressActions: ActionsViewModel.ProgressActions,
-    navigateTo: (NavScreen) -> Unit,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
     hostPadding: PaddingValues
 ) {
@@ -249,8 +277,6 @@ private fun HomeContent(
         typedBackStack.removeLastOrNull()
     }
 
-    val hostPadding =
-        hostPadding + PaddingValues(bottom = floatingBarHeight + FloatingBarDefaults.padding)
     NavDisplay(
         modifier = modifier,
         backStack = typedBackStack,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -248,7 +248,8 @@ private fun HomeContent(
         typedBackStack.removeLastOrNull()
     }
 
-    val hostPadding = hostPadding + PaddingValues(bottom = 130.dp + 16.dp)
+    val hostPadding =
+        hostPadding + PaddingValues(bottom = floatingBarHeight + FloatingBarDefaults.padding)
     NavDisplay(
         modifier = modifier,
         backStack = typedBackStack,
@@ -376,7 +377,7 @@ private fun Players(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(130.dp)
+            .height(floatingBarHeight)
     ) {
         if (state is HomeScreenViewModel.PlayersState.Data && state.playerData.isNotEmpty()) {
             PlayersPager(
@@ -437,3 +438,5 @@ private fun Players(
         }
     }
 }
+
+private val floatingBarHeight = 130.dp

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -142,24 +142,26 @@ fun HomeScreen(
     ) { isPlayersViewShown ->
         Scaffold(
             bottomBar = {
-                NavigationBar(modifier = Modifier.height(88.dp)) {
-                    NavigationBarItem(
-                        selected = true,
-                        onClick = { },
-                        icon = {
-                            Icon(Icons.Default.Home, contentDescription = null)
-                        }
-                    )
+                if (!isPlayersViewShown) {
+                    NavigationBar(modifier = Modifier.height(88.dp)) {
+                        NavigationBarItem(
+                            selected = true,
+                            onClick = { },
+                            icon = {
+                                Icon(Icons.Default.Home, contentDescription = null)
+                            }
+                        )
 
-                    NavigationBarItem(
-                        selected = false,
-                        onClick = {
-                            goToSettings()
-                        },
-                        icon = {
-                            Icon(Icons.Default.Settings, contentDescription = null)
-                        }
-                    )
+                        NavigationBarItem(
+                            selected = false,
+                            onClick = {
+                                goToSettings()
+                            },
+                            icon = {
+                                Icon(Icons.Default.Settings, contentDescription = null)
+                            }
+                        )
+                    }
                 }
             }
         ) { contentPadding ->
@@ -215,10 +217,9 @@ fun HomeScreen(
                     }
                 }
             } else {
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                Column(modifier = Modifier
+                    .padding(contentPadding)
+                    .background(MaterialTheme.colorScheme.surfaceContainerHigh)
                 ) {
                     // Close button
                     IconButton(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -174,7 +175,7 @@ fun HomeScreen(
                                 .align(Alignment.BottomCenter),
                             onClick = { showPlayersView = true }
                         ) {
-                            Player(
+                            Players(
                                 playerPagerState = playerPagerState,
                                 state = playersState,
                                 serverUrl = serverUrl,
@@ -206,7 +207,7 @@ fun HomeScreen(
                             modifier = Modifier.fillMaxSize(),
                             contentAlignment = Alignment.Center
                         ) {
-                            Player(
+                            Players(
                                 playerPagerState = playerPagerState,
                                 state = playersState,
                                 serverUrl = serverUrl,
@@ -362,7 +363,7 @@ private fun HomeContent(
 }
 
 @Composable
-private fun Player(
+private fun Players(
     playerPagerState: PagerState,
     state: HomeScreenViewModel.PlayersState,
     serverUrl: String?,
@@ -371,70 +372,66 @@ private fun Player(
     expanded: Boolean,
     onClose: () -> Unit
 ) {
-    when (state) {
-        is HomeScreenViewModel.PlayersState.Loading -> Text(
-            text = "Loading players...",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-
-        is HomeScreenViewModel.PlayersState.Data -> {
-            if (state.playerData.isEmpty()) {
-                Text(
-                    text = "No players available",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            } else {
-                PlayersPager(
-                    playerPagerState = playerPagerState,
-                    playersState = state,
-                    serverUrl = serverUrl,
-                    simplePlayerAction = { playerId, action ->
-                        homeScreenViewModel.playerAction(playerId, action)
-                    },
-                    playerAction = { playerData, action ->
-                        homeScreenViewModel.playerAction(playerData, action)
-                    },
-                    onFavoriteClick = actionsViewModel::onFavoriteClick,
-                    expanded = expanded,
-                    onClose = onClose,
-                    onItemMoved = { indexShift ->
-                        val currentPlayer =
-                            state.playerData[playerPagerState.currentPage].player
-                        val newIndex =
-                            (playerPagerState.currentPage + indexShift).coerceIn(
-                                0,
-                                state.playerData.size - 1
+    if (state is HomeScreenViewModel.PlayersState.Data && state.playerData.isNotEmpty()) {
+        PlayersPager(
+            playerPagerState = playerPagerState,
+            playersState = state,
+            serverUrl = serverUrl,
+            simplePlayerAction = { playerId, action ->
+                homeScreenViewModel.playerAction(playerId, action)
+            },
+            playerAction = { playerData, action ->
+                homeScreenViewModel.playerAction(playerData, action)
+            },
+            onFavoriteClick = actionsViewModel::onFavoriteClick,
+            expanded = expanded,
+            onClose = onClose,
+            onItemMoved = { indexShift ->
+                val currentPlayer =
+                    state.playerData[playerPagerState.currentPage].player
+                val newIndex =
+                    (playerPagerState.currentPage + indexShift).coerceIn(
+                        0,
+                        state.playerData.size - 1
+                    )
+                val newPlayers =
+                    state.playerData.map { it.player.id }
+                        .toMutableList()
+                        .apply {
+                            add(
+                                newIndex,
+                                removeAt(playerPagerState.currentPage)
                             )
-                        val newPlayers =
-                            state.playerData.map { it.player.id }
-                                .toMutableList()
-                                .apply {
-                                    add(
-                                        newIndex,
-                                        removeAt(playerPagerState.currentPage)
-                                    )
-                                }
-                        homeScreenViewModel.selectPlayer(currentPlayer)
-                        homeScreenViewModel.onPlayersSortChanged(newPlayers)
-                    },
-                    queueAction = { action -> homeScreenViewModel.queueAction(action) },
-                    moveToPlayer = { id: String ->
-                        val player =
-                            state.playerData.find { it.player.id == id }
-                        if (player != null) {
-                            homeScreenViewModel.selectPlayer(player.player)
                         }
-                    }
-                )
+                homeScreenViewModel.selectPlayer(currentPlayer)
+                homeScreenViewModel.onPlayersSortChanged(newPlayers)
+            },
+            queueAction = { action -> homeScreenViewModel.queueAction(action) },
+            moveToPlayer = { id: String ->
+                val player =
+                    state.playerData.find { it.player.id == id }
+                if (player != null) {
+                    homeScreenViewModel.selectPlayer(player.player)
+                }
             }
-        }
-
-        else -> Text(
-            text = "No players available",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+    } else {
+        Box(modifier = Modifier
+            .fillMaxWidth()
+            .defaultMinSize(minHeight = 130.dp)
+        ) {
+            val text = when (state) {
+                is HomeScreenViewModel.PlayersState.Loading -> "Loading players..."
+                is HomeScreenViewModel.PlayersState.Data -> "No players available"
+                else ->  "No players available"
+            }
+
+            Text(
+                modifier = Modifier.align(Alignment.Center),
+                text = text,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -176,6 +176,7 @@ fun HomeScreen(
                     onClick = { showPlayersView = true }
                 ) {
                     Players(
+                        modifier = Modifier.height(floatingBarHeight),
                         playerPagerState = playerPagerState,
                         state = playersState,
                         serverUrl = serverUrl,
@@ -366,6 +367,7 @@ private fun HomeContent(
 
 @Composable
 private fun Players(
+    modifier: Modifier = Modifier,
     playerPagerState: PagerState,
     state: HomeScreenViewModel.PlayersState,
     serverUrl: String?,
@@ -374,11 +376,7 @@ private fun Players(
     expanded: Boolean,
     onClose: () -> Unit
 ) {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(floatingBarHeight)
-    ) {
+    Box(modifier = modifier.fillMaxWidth()) {
         if (state is HomeScreenViewModel.PlayersState.Data && state.playerData.isNotEmpty()) {
             PlayersPager(
                 playerPagerState = playerPagerState,
@@ -430,7 +428,7 @@ private fun Players(
             }
 
             Text(
-                modifier = Modifier.align(Alignment.Center),
+                modifier = modifier.align(Alignment.Center),
                 text = text,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -172,6 +172,7 @@ fun HomeScreen(
             if (!isPlayersViewShown) {
                 Box(
                     modifier = Modifier
+                        .fillMaxSize()
                         .padding(bottom = bottomPadding)
                         .background(MaterialTheme.colorScheme.background)
                 ) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -16,7 +16,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ExpandMore
@@ -190,37 +190,16 @@ fun HomeScreen(
                                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                                         )
                                     } else {
-                                        PlayersPager(
-                                            modifier = Modifier
-                                                .fillMaxWidth()
-                                                .wrapContentHeight(),
+                                        Player(
                                             playerPagerState = playerPagerState,
-                                            playersState = state,
+                                            state = state,
                                             serverUrl = serverUrl,
-                                            simplePlayerAction = { playerId, action ->
-                                                viewModel.playerAction(playerId, action)
-                                            },
-                                            playerAction = { playerData, action ->
-                                                viewModel.playerAction(playerData, action)
-                                            },
-                                            onFavoriteClick = actionsViewModel::onFavoriteClick,
-                                            showQueue = false,
+                                            homeScreenViewModel = viewModel,
+                                            actionsViewModel = actionsViewModel,
                                             isQueueExpanded = isQueueExpanded,
-                                            onQueueExpandedSwitch = {
-                                                isQueueExpanded = !isQueueExpanded
-                                            },
-                                            onGoToLibrary = { showPlayersView = false },
-                                            onItemMoved = null,
-                                            queueAction = { action -> viewModel.queueAction(action) },
-                                            settingsAction = viewModel::openPlayerSettings,
-                                            dspSettingsAction = viewModel::openPlayerDspSettings,
-                                            moveToPlayer = { id: String ->
-                                                val player =
-                                                    state.playerData.find { it.player.id == id }
-                                                if (player != null) {
-                                                    viewModel.selectPlayer(player.player)
-                                                }
-                                            }
+                                            onQueueExpanded = { isQueueExpanded = !isQueueExpanded },
+                                            onClose = { showPlayersView = false },
+                                            showQueue = false
                                         )
                                     }
                                 }
@@ -270,54 +249,16 @@ fun HomeScreen(
                                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                                         )
                                     } else {
-                                        PlayersPager(
-                                            modifier = Modifier.fillMaxSize(),
+                                        Player(
                                             playerPagerState = playerPagerState,
-                                            playersState = state,
+                                            state = state,
                                             serverUrl = serverUrl,
-                                            simplePlayerAction = { playerId, action ->
-                                                viewModel.playerAction(playerId, action)
-                                            },
-                                            playerAction = { playerData, action ->
-                                                viewModel.playerAction(playerData, action)
-                                            },
-                                            onFavoriteClick = actionsViewModel::onFavoriteClick,
-                                            showQueue = true,
+                                            homeScreenViewModel = viewModel,
+                                            actionsViewModel = actionsViewModel,
                                             isQueueExpanded = isQueueExpanded,
-                                            onQueueExpandedSwitch = {
-                                                isQueueExpanded = !isQueueExpanded
-                                            },
-                                            onGoToLibrary = { showPlayersView = false },
-                                            onItemMoved = { indexShift ->
-                                                val currentPlayer =
-                                                    state.playerData[playerPagerState.currentPage].player
-                                                val newIndex =
-                                                    (playerPagerState.currentPage + indexShift).coerceIn(
-                                                        0,
-                                                        state.playerData.size - 1
-                                                    )
-                                                val newPlayers =
-                                                    state.playerData.map { it.player.id }
-                                                        .toMutableList()
-                                                        .apply {
-                                                            add(
-                                                                newIndex,
-                                                                removeAt(playerPagerState.currentPage)
-                                                            )
-                                                        }
-                                                viewModel.selectPlayer(currentPlayer)
-                                                viewModel.onPlayersSortChanged(newPlayers)
-                                            },
-                                            queueAction = { action -> viewModel.queueAction(action) },
-                                            settingsAction = viewModel::openPlayerSettings,
-                                            dspSettingsAction = viewModel::openPlayerDspSettings,
-                                            moveToPlayer = { id: String ->
-                                                val player =
-                                                    state.playerData.find { it.player.id == id }
-                                                if (player != null) {
-                                                    viewModel.selectPlayer(player.player)
-                                                }
-                                            }
+                                            onQueueExpanded = { isQueueExpanded = !isQueueExpanded },
+                                            onClose = { showPlayersView = false },
+                                            showQueue = true
                                         )
                                     }
                                 }
@@ -470,6 +411,64 @@ private fun HomeContent(
                         )
                     }
                 )
+            }
+        }
+    )
+}
+
+@Composable
+private fun Player(
+    playerPagerState: PagerState,
+    state: HomeScreenViewModel.PlayersState.Data,
+    serverUrl: String?,
+    homeScreenViewModel: HomeScreenViewModel,
+    actionsViewModel: ActionsViewModel,
+    isQueueExpanded: Boolean,
+    onQueueExpanded: () -> Unit,
+    onClose: () -> Unit,
+    showQueue: Boolean
+) {
+    PlayersPager(
+        playerPagerState = playerPagerState,
+        playersState = state,
+        serverUrl = serverUrl,
+        simplePlayerAction = { playerId, action ->
+            homeScreenViewModel.playerAction(playerId, action)
+        },
+        playerAction = { playerData, action ->
+            homeScreenViewModel.playerAction(playerData, action)
+        },
+        onFavoriteClick = actionsViewModel::onFavoriteClick,
+        showQueue = showQueue,
+        isQueueExpanded = isQueueExpanded,
+        onQueueExpandedSwitch = onQueueExpanded,
+        onGoToLibrary = onClose,
+        onItemMoved = { indexShift ->
+            val currentPlayer =
+                state.playerData[playerPagerState.currentPage].player
+            val newIndex =
+                (playerPagerState.currentPage + indexShift).coerceIn(
+                    0,
+                    state.playerData.size - 1
+                )
+            val newPlayers =
+                state.playerData.map { it.player.id }
+                    .toMutableList()
+                    .apply {
+                        add(
+                            newIndex,
+                            removeAt(playerPagerState.currentPage)
+                        )
+                    }
+            homeScreenViewModel.selectPlayer(currentPlayer)
+            homeScreenViewModel.onPlayersSortChanged(newPlayers)
+        },
+        queueAction = { action -> homeScreenViewModel.queueAction(action) },
+        moveToPlayer = { id: String ->
+            val player =
+                state.playerData.find { it.player.id == id }
+            if (player != null) {
+                homeScreenViewModel.selectPlayer(player.player)
             }
         }
     )

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.NavBackStack
@@ -62,6 +63,7 @@ import io.music_assistant.client.ui.compose.library.LibraryScreen
 import io.music_assistant.client.ui.compose.nav.BackHandler
 import io.music_assistant.client.ui.compose.search.SearchScreen
 import io.music_assistant.client.utils.SessionState
+import io.music_assistant.client.utils.WindowClass
 import kotlinx.coroutines.flow.collectLatest
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -165,6 +167,8 @@ fun HomeScreen(
             }
         ) { contentPadding ->
             val bottomPadding = contentPadding.calculateBottomPadding()
+            val floatingBarHeight = floatingBarHeight()
+
             if (!isPlayersViewShown) {
                 Box(
                     modifier = Modifier
@@ -193,7 +197,9 @@ fun HomeScreen(
                             actionsViewModel.getProviderIcon(provider)
                                 ?.let { ProviderIcon(modifier, it) }
                         },
-                        contentPadding = PaddingValues(bottom = floatingBarHeight + FloatingBarDefaults.padding)
+                        contentPadding = PaddingValues(
+                            bottom = floatingBarHeight + FloatingBarDefaults.padding
+                        )
                     )
 
                     FloatingBar(
@@ -460,4 +466,11 @@ private fun Players(
     }
 }
 
-private val floatingBarHeight = 130.dp
+@Composable
+private fun floatingBarHeight(): Dp {
+    return if (WindowClass.isAtLeastExpanded()) {
+        84.dp
+    } else {
+        130.dp
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
@@ -26,7 +25,6 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -120,102 +118,98 @@ fun HomeScreen(
         }
     }
 
-    Scaffold(
-        containerColor = MaterialTheme.colorScheme.surfaceContainer,
-    ) { paddingValues ->
-        val connectionState = recommendationsState.value.connectionState
-        val dataState = recommendationsState.value.recommendations
-        Box(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
-            // Simple slide transition between main screen and big player
-            AnimatedContent(
-                targetState = showPlayersView,
-                transitionSpec = {
-                    slideInVertically(
-                        initialOffsetY = { if (targetState) it else -it },
-                        animationSpec = tween(300)
-                    ) togetherWith slideOutVertically(
-                        targetOffsetY = { if (targetState) -it else it },
-                        animationSpec = tween(300)
-                    )
-                },
-                label = "player_transition"
-            ) { isPlayersViewShown ->
-                if (!isPlayersViewShown) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(MaterialTheme.colorScheme.background)
-                    ) {
-                        HomeContent(
-                            homeBackStack = homeBackStack,
-                            connectionState = connectionState,
-                            dataState = dataState,
-                            serverUrl = serverUrl,
-                            onPlayClick = viewModel::onPlayClick,
-                            playlistActions = ActionsViewModel.PlaylistActions(
-                                onLoadPlaylists = actionsViewModel::getEditablePlaylists,
-                                onAddToPlaylist = actionsViewModel::addToPlaylist
-                            ),
-                            libraryActions = ActionsViewModel.LibraryActions(
-                                onLibraryClick = actionsViewModel::onLibraryClick,
-                                onFavoriteClick = actionsViewModel::onFavoriteClick
-                            ),
-                            progressActions = ActionsViewModel.ProgressActions(
-                                onMarkPlayed = actionsViewModel::onMarkPlayed,
-                                onMarkUnplayed = actionsViewModel::onMarkUnplayed
-                            ),
-                            navigateTo = navigateTo
-                        ) { modifier, provider ->
-                            actionsViewModel.getProviderIcon(provider)
-                                ?.let { ProviderIcon(modifier, it) }
-                        }
-
-                        FloatingBar(
-                            modifier = Modifier
-                                .align(Alignment.BottomCenter),
-                            onClick = { showPlayersView = true }
-                        ) {
-                            Players(
-                                playerPagerState = playerPagerState,
-                                state = playersState,
-                                serverUrl = serverUrl,
-                                homeScreenViewModel = viewModel,
-                                actionsViewModel = actionsViewModel,
-                                expanded = false
-                            ) { showPlayersView = false }
-                        }
+    val connectionState = recommendationsState.value.connectionState
+    val dataState = recommendationsState.value.recommendations
+    Box(modifier = Modifier.fillMaxSize()) {
+        // Simple slide transition between main screen and big player
+        AnimatedContent(
+            targetState = showPlayersView,
+            transitionSpec = {
+                slideInVertically(
+                    initialOffsetY = { if (targetState) it else -it },
+                    animationSpec = tween(300)
+                ) togetherWith slideOutVertically(
+                    targetOffsetY = { if (targetState) -it else it },
+                    animationSpec = tween(300)
+                )
+            },
+            label = "player_transition"
+        ) { isPlayersViewShown ->
+            if (!isPlayersViewShown) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.background)
+                ) {
+                    HomeContent(
+                        homeBackStack = homeBackStack,
+                        connectionState = connectionState,
+                        dataState = dataState,
+                        serverUrl = serverUrl,
+                        onPlayClick = viewModel::onPlayClick,
+                        playlistActions = ActionsViewModel.PlaylistActions(
+                            onLoadPlaylists = actionsViewModel::getEditablePlaylists,
+                            onAddToPlaylist = actionsViewModel::addToPlaylist
+                        ),
+                        libraryActions = ActionsViewModel.LibraryActions(
+                            onLibraryClick = actionsViewModel::onLibraryClick,
+                            onFavoriteClick = actionsViewModel::onFavoriteClick
+                        ),
+                        progressActions = ActionsViewModel.ProgressActions(
+                            onMarkPlayed = actionsViewModel::onMarkPlayed,
+                            onMarkUnplayed = actionsViewModel::onMarkUnplayed
+                        ),
+                        navigateTo = navigateTo
+                    ) { modifier, provider ->
+                        actionsViewModel.getProviderIcon(provider)
+                            ?.let { ProviderIcon(modifier, it) }
                     }
-                } else {
-                    Column(
+
+                    FloatingBar(
                         modifier = Modifier
-                            .fillMaxSize()
-                            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                            .align(Alignment.BottomCenter),
+                        onClick = { showPlayersView = true }
                     ) {
-                        // Close button
-                        IconButton(
-                            onClick = { showPlayersView = false },
-                            modifier = Modifier.fillMaxWidth().height(36.dp)
-                                .align(Alignment.CenterHorizontally)
-                        ) {
-                            Icon(
-                                Icons.Default.ExpandMore,
-                                "Collapse",
-                                modifier = Modifier.size(32.dp)
-                            )
-                        }
-                        Box(
-                            modifier = Modifier.fillMaxSize(),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Players(
-                                playerPagerState = playerPagerState,
-                                state = playersState,
-                                serverUrl = serverUrl,
-                                homeScreenViewModel = viewModel,
-                                actionsViewModel = actionsViewModel,
-                                expanded = true
-                            ) { showPlayersView = false }
-                        }
+                        Players(
+                            playerPagerState = playerPagerState,
+                            state = playersState,
+                            serverUrl = serverUrl,
+                            homeScreenViewModel = viewModel,
+                            actionsViewModel = actionsViewModel,
+                            expanded = false
+                        ) { showPlayersView = false }
+                    }
+                }
+            } else {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                ) {
+                    // Close button
+                    IconButton(
+                        onClick = { showPlayersView = false },
+                        modifier = Modifier.fillMaxWidth().height(36.dp)
+                            .align(Alignment.CenterHorizontally)
+                    ) {
+                        Icon(
+                            Icons.Default.ExpandMore,
+                            "Collapse",
+                            modifier = Modifier.size(32.dp)
+                        )
+                    }
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Players(
+                            playerPagerState = playerPagerState,
+                            state = playersState,
+                            serverUrl = serverUrl,
+                            homeScreenViewModel = viewModel,
+                            actionsViewModel = actionsViewModel,
+                            expanded = true
+                        ) { showPlayersView = false }
                     }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -405,7 +405,7 @@ private fun Players(
     expanded: Boolean,
     onClose: () -> Unit
 ) {
-    Box(modifier = modifier.fillMaxWidth()) {
+    Box(modifier = modifier.fillMaxSize()) {
         if (state is HomeScreenViewModel.PlayersState.Data && state.playerData.isNotEmpty()) {
             PlayersPager(
                 playerPagerState = playerPagerState,
@@ -457,7 +457,7 @@ private fun Players(
             }
 
             Text(
-                modifier = modifier.align(Alignment.Center),
+                modifier = Modifier.align(Alignment.Center),
                 text = text,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.HorizontalFloatingToolbar
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -62,7 +64,7 @@ import io.music_assistant.client.utils.SessionState
 import kotlinx.coroutines.flow.collectLatest
 import org.koin.compose.viewmodel.koinViewModel
 
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun HomeScreen(
     viewModel: HomeScreenViewModel = koinViewModel(),
@@ -142,13 +144,12 @@ fun HomeScreen(
                 label = "player_transition"
             ) { isPlayersViewShown ->
                 if (!isPlayersViewShown) {
-                    Column(
+                    Box(
                         modifier = Modifier
                             .fillMaxSize()
                             .background(MaterialTheme.colorScheme.background)
                     ) {
                         HomeContent(
-                            modifier = Modifier.weight(1f),
                             homeBackStack = homeBackStack,
                             connectionState = connectionState,
                             dataState = dataState,
@@ -172,14 +173,8 @@ fun HomeScreen(
                                 ?.let { ProviderIcon(modifier, it) }
                         }
 
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .wrapContentHeight()
-                                .defaultMinSize(minHeight = 100.dp)
-                                .clickable { showPlayersView = true }
-                                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
-                            contentAlignment = Alignment.Center
+                        FloatingBar(
+                            modifier = Modifier.align(Alignment.BottomCenter)
                         ) {
                             when (val state = playersState) {
                                 is HomeScreenViewModel.PlayersState.Loading -> Text(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -174,38 +174,14 @@ fun HomeScreen(
                                 .align(Alignment.BottomCenter),
                             onClick = { showPlayersView = true }
                         ) {
-                            when (val state = playersState) {
-                                is HomeScreenViewModel.PlayersState.Loading -> Text(
-                                    text = "Loading players...",
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-
-                                is HomeScreenViewModel.PlayersState.Data -> {
-                                    if (state.playerData.isEmpty()) {
-                                        Text(
-                                            text = "No players available",
-                                            style = MaterialTheme.typography.bodyMedium,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        )
-                                    } else {
-                                        Player(
-                                            playerPagerState = playerPagerState,
-                                            state = state,
-                                            serverUrl = serverUrl,
-                                            homeScreenViewModel = viewModel,
-                                            actionsViewModel = actionsViewModel,
-                                            expanded = false
-                                        ) { showPlayersView = false }
-                                    }
-                                }
-
-                                else -> Text(
-                                    text = "No players available",
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                            }
+                            Player(
+                                playerPagerState = playerPagerState,
+                                state = playersState,
+                                serverUrl = serverUrl,
+                                homeScreenViewModel = viewModel,
+                                actionsViewModel = actionsViewModel,
+                                expanded = false
+                            ) { showPlayersView = false }
                         }
                     }
                 } else {
@@ -230,38 +206,14 @@ fun HomeScreen(
                             modifier = Modifier.fillMaxSize(),
                             contentAlignment = Alignment.Center
                         ) {
-                            when (val state = playersState) {
-                                is HomeScreenViewModel.PlayersState.Loading -> Text(
-                                    text = "Loading players...",
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-
-                                is HomeScreenViewModel.PlayersState.Data -> {
-                                    if (state.playerData.isEmpty()) {
-                                        Text(
-                                            text = "No players available",
-                                            style = MaterialTheme.typography.bodyMedium,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        )
-                                    } else {
-                                        Player(
-                                            playerPagerState = playerPagerState,
-                                            state = state,
-                                            serverUrl = serverUrl,
-                                            homeScreenViewModel = viewModel,
-                                            actionsViewModel = actionsViewModel,
-                                            expanded = true
-                                        ) { showPlayersView = false }
-                                    }
-                                }
-
-                                else -> Text(
-                                    text = "No players available",
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                            }
+                            Player(
+                                playerPagerState = playerPagerState,
+                                state = playersState,
+                                serverUrl = serverUrl,
+                                homeScreenViewModel = viewModel,
+                                actionsViewModel = actionsViewModel,
+                                expanded = true
+                            ) { showPlayersView = false }
                         }
                     }
                 }
@@ -412,53 +364,77 @@ private fun HomeContent(
 @Composable
 private fun Player(
     playerPagerState: PagerState,
-    state: HomeScreenViewModel.PlayersState.Data,
+    state: HomeScreenViewModel.PlayersState,
     serverUrl: String?,
     homeScreenViewModel: HomeScreenViewModel,
     actionsViewModel: ActionsViewModel,
     expanded: Boolean,
     onClose: () -> Unit
 ) {
-    PlayersPager(
-        playerPagerState = playerPagerState,
-        playersState = state,
-        serverUrl = serverUrl,
-        simplePlayerAction = { playerId, action ->
-            homeScreenViewModel.playerAction(playerId, action)
-        },
-        playerAction = { playerData, action ->
-            homeScreenViewModel.playerAction(playerData, action)
-        },
-        onFavoriteClick = actionsViewModel::onFavoriteClick,
-        expanded = expanded,
-        onClose = onClose,
-        onItemMoved = { indexShift ->
-            val currentPlayer =
-                state.playerData[playerPagerState.currentPage].player
-            val newIndex =
-                (playerPagerState.currentPage + indexShift).coerceIn(
-                    0,
-                    state.playerData.size - 1
+    when (state) {
+        is HomeScreenViewModel.PlayersState.Loading -> Text(
+            text = "Loading players...",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        is HomeScreenViewModel.PlayersState.Data -> {
+            if (state.playerData.isEmpty()) {
+                Text(
+                    text = "No players available",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-            val newPlayers =
-                state.playerData.map { it.player.id }
-                    .toMutableList()
-                    .apply {
-                        add(
-                            newIndex,
-                            removeAt(playerPagerState.currentPage)
-                        )
+            } else {
+                PlayersPager(
+                    playerPagerState = playerPagerState,
+                    playersState = state,
+                    serverUrl = serverUrl,
+                    simplePlayerAction = { playerId, action ->
+                        homeScreenViewModel.playerAction(playerId, action)
+                    },
+                    playerAction = { playerData, action ->
+                        homeScreenViewModel.playerAction(playerData, action)
+                    },
+                    onFavoriteClick = actionsViewModel::onFavoriteClick,
+                    expanded = expanded,
+                    onClose = onClose,
+                    onItemMoved = { indexShift ->
+                        val currentPlayer =
+                            state.playerData[playerPagerState.currentPage].player
+                        val newIndex =
+                            (playerPagerState.currentPage + indexShift).coerceIn(
+                                0,
+                                state.playerData.size - 1
+                            )
+                        val newPlayers =
+                            state.playerData.map { it.player.id }
+                                .toMutableList()
+                                .apply {
+                                    add(
+                                        newIndex,
+                                        removeAt(playerPagerState.currentPage)
+                                    )
+                                }
+                        homeScreenViewModel.selectPlayer(currentPlayer)
+                        homeScreenViewModel.onPlayersSortChanged(newPlayers)
+                    },
+                    queueAction = { action -> homeScreenViewModel.queueAction(action) },
+                    moveToPlayer = { id: String ->
+                        val player =
+                            state.playerData.find { it.player.id == id }
+                        if (player != null) {
+                            homeScreenViewModel.selectPlayer(player.player)
+                        }
                     }
-            homeScreenViewModel.selectPlayer(currentPlayer)
-            homeScreenViewModel.onPlayersSortChanged(newPlayers)
-        },
-        queueAction = { action -> homeScreenViewModel.queueAction(action) },
-        moveToPlayer = { id: String ->
-            val player =
-                state.playerData.find { it.player.id == id }
-            if (player != null) {
-                homeScreenViewModel.selectPlayer(player.player)
+                )
             }
         }
-    )
+
+        else -> Text(
+            text = "No players available",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -11,10 +11,12 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.plus
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
@@ -65,6 +67,7 @@ import org.koin.compose.viewmodel.koinViewModel
 fun HomeScreen(
     viewModel: HomeScreenViewModel = koinViewModel(),
     actionsViewModel: ActionsViewModel = koinViewModel(),
+    hostPadding: PaddingValues,
     navigateTo: (NavScreen) -> Unit,
 ) {
     val uriHandler = LocalUriHandler.current
@@ -120,97 +123,98 @@ fun HomeScreen(
 
     val connectionState = recommendationsState.value.connectionState
     val dataState = recommendationsState.value.recommendations
-    Box(modifier = Modifier.fillMaxSize()) {
-        // Simple slide transition between main screen and big player
-        AnimatedContent(
-            targetState = showPlayersView,
-            transitionSpec = {
-                slideInVertically(
-                    initialOffsetY = { if (targetState) it else -it },
-                    animationSpec = tween(300)
-                ) togetherWith slideOutVertically(
-                    targetOffsetY = { if (targetState) -it else it },
-                    animationSpec = tween(300)
-                )
-            },
-            label = "player_transition"
-        ) { isPlayersViewShown ->
-            if (!isPlayersViewShown) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(MaterialTheme.colorScheme.background)
-                ) {
-                    HomeContent(
-                        homeBackStack = homeBackStack,
-                        connectionState = connectionState,
-                        dataState = dataState,
-                        serverUrl = serverUrl,
-                        onPlayClick = viewModel::onPlayClick,
-                        playlistActions = ActionsViewModel.PlaylistActions(
-                            onLoadPlaylists = actionsViewModel::getEditablePlaylists,
-                            onAddToPlaylist = actionsViewModel::addToPlaylist
-                        ),
-                        libraryActions = ActionsViewModel.LibraryActions(
-                            onLibraryClick = actionsViewModel::onLibraryClick,
-                            onFavoriteClick = actionsViewModel::onFavoriteClick
-                        ),
-                        progressActions = ActionsViewModel.ProgressActions(
-                            onMarkPlayed = actionsViewModel::onMarkPlayed,
-                            onMarkUnplayed = actionsViewModel::onMarkUnplayed
-                        ),
-                        navigateTo = navigateTo
-                    ) { modifier, provider ->
+    // Simple slide transition between main screen and big player
+    AnimatedContent(
+        targetState = showPlayersView,
+        transitionSpec = {
+            slideInVertically(
+                initialOffsetY = { if (targetState) it else -it },
+                animationSpec = tween(300)
+            ) togetherWith slideOutVertically(
+                targetOffsetY = { if (targetState) -it else it },
+                animationSpec = tween(300)
+            )
+        },
+        label = "player_transition"
+    ) { isPlayersViewShown ->
+        if (!isPlayersViewShown) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background)
+            ) {
+                HomeContent(
+                    homeBackStack = homeBackStack,
+                    connectionState = connectionState,
+                    dataState = dataState,
+                    serverUrl = serverUrl,
+                    onPlayClick = viewModel::onPlayClick,
+                    playlistActions = ActionsViewModel.PlaylistActions(
+                        onLoadPlaylists = actionsViewModel::getEditablePlaylists,
+                        onAddToPlaylist = actionsViewModel::addToPlaylist
+                    ),
+                    libraryActions = ActionsViewModel.LibraryActions(
+                        onLibraryClick = actionsViewModel::onLibraryClick,
+                        onFavoriteClick = actionsViewModel::onFavoriteClick
+                    ),
+                    progressActions = ActionsViewModel.ProgressActions(
+                        onMarkPlayed = actionsViewModel::onMarkPlayed,
+                        onMarkUnplayed = actionsViewModel::onMarkUnplayed
+                    ),
+                    navigateTo = navigateTo,
+                    providerIconFetcher = { modifier, provider ->
                         actionsViewModel.getProviderIcon(provider)
                             ?.let { ProviderIcon(modifier, it) }
-                    }
+                    },
+                    hostPadding = hostPadding
+                )
 
-                    FloatingBar(
-                        modifier = Modifier
-                            .align(Alignment.BottomCenter),
-                        onClick = { showPlayersView = true }
-                    ) {
-                        Players(
-                            playerPagerState = playerPagerState,
-                            state = playersState,
-                            serverUrl = serverUrl,
-                            homeScreenViewModel = viewModel,
-                            actionsViewModel = actionsViewModel,
-                            expanded = false
-                        ) { showPlayersView = false }
-                    }
-                }
-            } else {
-                Column(
+                FloatingBar(
                     modifier = Modifier
-                        .fillMaxSize()
-                        .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                        .align(Alignment.BottomCenter)
+                        .padding(hostPadding),
+                    onClick = { showPlayersView = true }
                 ) {
-                    // Close button
-                    IconButton(
-                        onClick = { showPlayersView = false },
-                        modifier = Modifier.fillMaxWidth().height(36.dp)
-                            .align(Alignment.CenterHorizontally)
-                    ) {
-                        Icon(
-                            Icons.Default.ExpandMore,
-                            "Collapse",
-                            modifier = Modifier.size(32.dp)
-                        )
-                    }
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Players(
-                            playerPagerState = playerPagerState,
-                            state = playersState,
-                            serverUrl = serverUrl,
-                            homeScreenViewModel = viewModel,
-                            actionsViewModel = actionsViewModel,
-                            expanded = true
-                        ) { showPlayersView = false }
-                    }
+                    Players(
+                        playerPagerState = playerPagerState,
+                        state = playersState,
+                        serverUrl = serverUrl,
+                        homeScreenViewModel = viewModel,
+                        actionsViewModel = actionsViewModel,
+                        expanded = false
+                    ) { showPlayersView = false }
+                }
+            }
+        } else {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            ) {
+                // Close button
+                IconButton(
+                    onClick = { showPlayersView = false },
+                    modifier = Modifier.fillMaxWidth().height(36.dp)
+                        .align(Alignment.CenterHorizontally)
+                ) {
+                    Icon(
+                        Icons.Default.ExpandMore,
+                        "Collapse",
+                        modifier = Modifier.size(32.dp)
+                    )
+                }
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Players(
+                        playerPagerState = playerPagerState,
+                        state = playersState,
+                        serverUrl = serverUrl,
+                        homeScreenViewModel = viewModel,
+                        actionsViewModel = actionsViewModel,
+                        expanded = true
+                    ) { showPlayersView = false }
                 }
             }
         }
@@ -229,7 +233,8 @@ private fun HomeContent(
     libraryActions: ActionsViewModel.LibraryActions,
     progressActions: ActionsViewModel.ProgressActions,
     navigateTo: (NavScreen) -> Unit,
-    providerIconFetcher: (@Composable (Modifier, String) -> Unit)
+    providerIconFetcher: (@Composable (Modifier, String) -> Unit),
+    hostPadding: PaddingValues
 ) {
     @Suppress("UNCHECKED_CAST")
     val typedBackStack = homeBackStack as NavBackStack<HomeNavScreen>
@@ -243,6 +248,7 @@ private fun HomeContent(
         typedBackStack.removeLastOrNull()
     }
 
+    val hostPadding = hostPadding + PaddingValues(bottom = 130.dp + 16.dp)
     NavDisplay(
         modifier = modifier,
         backStack = typedBackStack,
@@ -253,7 +259,7 @@ private fun HomeContent(
         entryProvider = entryProvider {
             entry<HomeNavScreen.Landing> {
                 LandingPage(
-                    modifier = Modifier.fillMaxSize(),
+                    hostPadding = hostPadding,
                     connectionState = connectionState,
                     dataState = dataState,
                     serverUrl = serverUrl,
@@ -288,7 +294,6 @@ private fun HomeContent(
                     playlistActions = playlistActions,
                     libraryActions = libraryActions,
                     progressActions = progressActions,
-                    navigateTo = navigateTo,
                     providerIconFetcher = providerIconFetcher
                 )
             }
@@ -322,6 +327,7 @@ private fun HomeContent(
 
             entry<HomeNavScreen.ItemDetails> {
                 ItemDetailsScreen(
+                    hostPadding = hostPadding,
                     itemId = it.itemId,
                     mediaType = it.mediaType,
                     providerId = it.providerId,
@@ -366,58 +372,59 @@ private fun Players(
     expanded: Boolean,
     onClose: () -> Unit
 ) {
-    if (state is HomeScreenViewModel.PlayersState.Data && state.playerData.isNotEmpty()) {
-        PlayersPager(
-            playerPagerState = playerPagerState,
-            playersState = state,
-            serverUrl = serverUrl,
-            simplePlayerAction = { playerId, action ->
-                homeScreenViewModel.playerAction(playerId, action)
-            },
-            playerAction = { playerData, action ->
-                homeScreenViewModel.playerAction(playerData, action)
-            },
-            onFavoriteClick = actionsViewModel::onFavoriteClick,
-            expanded = expanded,
-            onClose = onClose,
-            onItemMoved = { indexShift ->
-                val currentPlayer =
-                    state.playerData[playerPagerState.currentPage].player
-                val newIndex =
-                    (playerPagerState.currentPage + indexShift).coerceIn(
-                        0,
-                        state.playerData.size - 1
-                    )
-                val newPlayers =
-                    state.playerData.map { it.player.id }
-                        .toMutableList()
-                        .apply {
-                            add(
-                                newIndex,
-                                removeAt(playerPagerState.currentPage)
-                            )
-                        }
-                homeScreenViewModel.selectPlayer(currentPlayer)
-                homeScreenViewModel.onPlayersSortChanged(newPlayers)
-            },
-            queueAction = { action -> homeScreenViewModel.queueAction(action) },
-            moveToPlayer = { id: String ->
-                val player =
-                    state.playerData.find { it.player.id == id }
-                if (player != null) {
-                    homeScreenViewModel.selectPlayer(player.player)
-                }
-            }
-        )
-    } else {
-        Box(modifier = Modifier
+    Box(
+        modifier = Modifier
             .fillMaxWidth()
-            .defaultMinSize(minHeight = 130.dp)
-        ) {
+            .height(130.dp)
+    ) {
+        if (state is HomeScreenViewModel.PlayersState.Data && state.playerData.isNotEmpty()) {
+            PlayersPager(
+                playerPagerState = playerPagerState,
+                playersState = state,
+                serverUrl = serverUrl,
+                simplePlayerAction = { playerId, action ->
+                    homeScreenViewModel.playerAction(playerId, action)
+                },
+                playerAction = { playerData, action ->
+                    homeScreenViewModel.playerAction(playerData, action)
+                },
+                onFavoriteClick = actionsViewModel::onFavoriteClick,
+                expanded = expanded,
+                onClose = onClose,
+                onItemMoved = { indexShift ->
+                    val currentPlayer =
+                        state.playerData[playerPagerState.currentPage].player
+                    val newIndex =
+                        (playerPagerState.currentPage + indexShift).coerceIn(
+                            0,
+                            state.playerData.size - 1
+                        )
+                    val newPlayers =
+                        state.playerData.map { it.player.id }
+                            .toMutableList()
+                            .apply {
+                                add(
+                                    newIndex,
+                                    removeAt(playerPagerState.currentPage)
+                                )
+                            }
+                    homeScreenViewModel.selectPlayer(currentPlayer)
+                    homeScreenViewModel.onPlayersSortChanged(newPlayers)
+                },
+                queueAction = { action -> homeScreenViewModel.queueAction(action) },
+                moveToPlayer = { id: String ->
+                    val player =
+                        state.playerData.find { it.player.id == id }
+                    if (player != null) {
+                        homeScreenViewModel.selectPlayer(player.player)
+                    }
+                }
+            )
+        } else {
             val text = when (state) {
                 is HomeScreenViewModel.PlayersState.Loading -> "Loading players..."
                 is HomeScreenViewModel.PlayersState.Data -> "No players available"
-                else ->  "No players available"
+                else -> "No players available"
             }
 
             Text(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -83,7 +83,6 @@ fun HomeScreen(
     }
 
     var showPlayersView by remember { mutableStateOf(false) }
-    var isQueueExpanded by remember { mutableStateOf(false) }
 
     val recommendationsState = viewModel.recommendationsState.collectAsStateWithLifecycle()
     val serverUrl by viewModel.serverUrl.collectAsStateWithLifecycle()
@@ -196,11 +195,8 @@ fun HomeScreen(
                                             serverUrl = serverUrl,
                                             homeScreenViewModel = viewModel,
                                             actionsViewModel = actionsViewModel,
-                                            isQueueExpanded = isQueueExpanded,
-                                            onQueueExpanded = { isQueueExpanded = !isQueueExpanded },
-                                            onClose = { showPlayersView = false },
-                                            showQueue = false
-                                        )
+                                            expanded = false
+                                        ) { showPlayersView = false }
                                     }
                                 }
 
@@ -255,11 +251,8 @@ fun HomeScreen(
                                             serverUrl = serverUrl,
                                             homeScreenViewModel = viewModel,
                                             actionsViewModel = actionsViewModel,
-                                            isQueueExpanded = isQueueExpanded,
-                                            onQueueExpanded = { isQueueExpanded = !isQueueExpanded },
-                                            onClose = { showPlayersView = false },
-                                            showQueue = true
-                                        )
+                                            expanded = true
+                                        ) { showPlayersView = false }
                                     }
                                 }
 
@@ -423,10 +416,8 @@ private fun Player(
     serverUrl: String?,
     homeScreenViewModel: HomeScreenViewModel,
     actionsViewModel: ActionsViewModel,
-    isQueueExpanded: Boolean,
-    onQueueExpanded: () -> Unit,
-    onClose: () -> Unit,
-    showQueue: Boolean
+    expanded: Boolean,
+    onClose: () -> Unit
 ) {
     PlayersPager(
         playerPagerState = playerPagerState,
@@ -439,10 +430,8 @@ private fun Player(
             homeScreenViewModel.playerAction(playerData, action)
         },
         onFavoriteClick = actionsViewModel::onFavoriteClick,
-        showQueue = showQueue,
-        isQueueExpanded = isQueueExpanded,
-        onQueueExpandedSwitch = onQueueExpanded,
-        onGoToLibrary = onClose,
+        expanded = expanded,
+        onClose = onClose,
         onItemMoved = { indexShift ->
             val currentPlayer =
                 state.playerData[playerPagerState.currentPage].player

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.plus
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
@@ -165,13 +164,11 @@ fun HomeScreen(
                 }
             }
         ) { contentPadding ->
-            val hostPadding =
-                contentPadding + PaddingValues(bottom = floatingBarHeight + FloatingBarDefaults.padding)
-
+            val bottomPadding = contentPadding.calculateBottomPadding()
             if (!isPlayersViewShown) {
                 Box(
                     modifier = Modifier
-                        .fillMaxSize()
+                        .padding(bottom = bottomPadding)
                         .background(MaterialTheme.colorScheme.background)
                 ) {
                     HomeContent(
@@ -196,13 +193,12 @@ fun HomeScreen(
                             actionsViewModel.getProviderIcon(provider)
                                 ?.let { ProviderIcon(modifier, it) }
                         },
-                        hostPadding = hostPadding
+                        contentPadding = PaddingValues(bottom = floatingBarHeight + FloatingBarDefaults.padding)
                     )
 
                     FloatingBar(
                         modifier = Modifier
-                            .align(Alignment.BottomCenter)
-                            .padding(contentPadding),
+                            .align(Alignment.BottomCenter),
                         onClick = { showPlayersView = true }
                     ) {
                         Players(
@@ -264,7 +260,7 @@ private fun HomeContent(
     libraryActions: ActionsViewModel.LibraryActions,
     progressActions: ActionsViewModel.ProgressActions,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
-    hostPadding: PaddingValues
+    contentPadding: PaddingValues
 ) {
     @Suppress("UNCHECKED_CAST")
     val typedBackStack = homeBackStack as NavBackStack<HomeNavScreen>
@@ -288,7 +284,7 @@ private fun HomeContent(
         entryProvider = entryProvider {
             entry<HomeNavScreen.Landing> {
                 LandingPage(
-                    hostPadding = hostPadding,
+                    contentPadding = contentPadding,
                     connectionState = connectionState,
                     dataState = dataState,
                     serverUrl = serverUrl,
@@ -329,7 +325,7 @@ private fun HomeContent(
 
             entry<HomeNavScreen.Library> {
                 LibraryScreen(
-                    hostPadding = hostPadding,
+                    contentPadding = contentPadding,
                     initialTabType = it.type,
                     onBack = { typedBackStack.removeLastOrNull() },
                     onNavigateClick = { item ->
@@ -357,7 +353,7 @@ private fun HomeContent(
 
             entry<HomeNavScreen.ItemDetails> {
                 ItemDetailsScreen(
-                    hostPadding = hostPadding,
+                    contentPadding = contentPadding,
                     itemId = it.itemId,
                     mediaType = it.mediaType,
                     providerId = it.providerId,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -43,7 +43,6 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.NavBackStack
@@ -167,7 +166,8 @@ fun HomeScreen(
             }
         ) { contentPadding ->
             val bottomPadding = contentPadding.calculateBottomPadding()
-            val floatingBarHeight = floatingBarHeight()
+            val isExpandedScreen = WindowClass.isAtLeastExpanded()
+            val floatingBarHeight = collapsedPlayerHeight(isExpandedScreen)
 
             if (!isPlayersViewShown) {
                 Box(
@@ -208,14 +208,15 @@ fun HomeScreen(
                         onClick = { showPlayersView = true }
                     ) {
                         Players(
-                            modifier = Modifier.height(floatingBarHeight),
                             playerPagerState = playerPagerState,
                             state = playersState,
                             serverUrl = serverUrl,
                             homeScreenViewModel = viewModel,
                             actionsViewModel = actionsViewModel,
-                            expanded = false
-                        ) { showPlayersView = false }
+                            expanded = false,
+                            onClose = { showPlayersView = false },
+                            isExpandedScreen = isExpandedScreen
+                        )
                     }
                 }
             } else {
@@ -245,8 +246,10 @@ fun HomeScreen(
                             serverUrl = serverUrl,
                             homeScreenViewModel = viewModel,
                             actionsViewModel = actionsViewModel,
-                            expanded = true
-                        ) { showPlayersView = false }
+                            expanded = true,
+                            onClose = { showPlayersView = false },
+                            isExpandedScreen = isExpandedScreen
+                        )
                     }
                 }
             }
@@ -396,60 +399,61 @@ private fun HomeContent(
 
 @Composable
 private fun Players(
-    modifier: Modifier = Modifier,
     playerPagerState: PagerState,
     state: HomeScreenViewModel.PlayersState,
     serverUrl: String?,
     homeScreenViewModel: HomeScreenViewModel,
     actionsViewModel: ActionsViewModel,
     expanded: Boolean,
-    onClose: () -> Unit
+    onClose: () -> Unit,
+    isExpandedScreen: Boolean
 ) {
-    Box(modifier = modifier.fillMaxSize()) {
-        if (state is HomeScreenViewModel.PlayersState.Data && state.playerData.isNotEmpty()) {
-            PlayersPager(
-                playerPagerState = playerPagerState,
-                playersState = state,
-                serverUrl = serverUrl,
-                simplePlayerAction = { playerId, action ->
-                    homeScreenViewModel.playerAction(playerId, action)
-                },
-                playerAction = { playerData, action ->
-                    homeScreenViewModel.playerAction(playerData, action)
-                },
-                onFavoriteClick = actionsViewModel::onFavoriteClick,
-                expanded = expanded,
-                onClose = onClose,
-                onItemMoved = { indexShift ->
-                    val currentPlayer =
-                        state.playerData[playerPagerState.currentPage].player
-                    val newIndex =
-                        (playerPagerState.currentPage + indexShift).coerceIn(
-                            0,
-                            state.playerData.size - 1
-                        )
-                    val newPlayers =
-                        state.playerData.map { it.player.id }
-                            .toMutableList()
-                            .apply {
-                                add(
-                                    newIndex,
-                                    removeAt(playerPagerState.currentPage)
-                                )
-                            }
-                    homeScreenViewModel.selectPlayer(currentPlayer)
-                    homeScreenViewModel.onPlayersSortChanged(newPlayers)
-                },
-                queueAction = { action -> homeScreenViewModel.queueAction(action) },
-                moveToPlayer = { id: String ->
-                    val player =
-                        state.playerData.find { it.player.id == id }
-                    if (player != null) {
-                        homeScreenViewModel.selectPlayer(player.player)
-                    }
+    if (state is HomeScreenViewModel.PlayersState.Data && state.playerData.isNotEmpty()) {
+        PlayersPager(
+            playerPagerState = playerPagerState,
+            playersState = state,
+            serverUrl = serverUrl,
+            simplePlayerAction = { playerId, action ->
+                homeScreenViewModel.playerAction(playerId, action)
+            },
+            playerAction = { playerData, action ->
+                homeScreenViewModel.playerAction(playerData, action)
+            },
+            onFavoriteClick = actionsViewModel::onFavoriteClick,
+            expanded = expanded,
+            onClose = onClose,
+            onItemMoved = { indexShift ->
+                val currentPlayer =
+                    state.playerData[playerPagerState.currentPage].player
+                val newIndex =
+                    (playerPagerState.currentPage + indexShift).coerceIn(
+                        0,
+                        state.playerData.size - 1
+                    )
+                val newPlayers =
+                    state.playerData.map { it.player.id }
+                        .toMutableList()
+                        .apply {
+                            add(
+                                newIndex,
+                                removeAt(playerPagerState.currentPage)
+                            )
+                        }
+                homeScreenViewModel.selectPlayer(currentPlayer)
+                homeScreenViewModel.onPlayersSortChanged(newPlayers)
+            },
+            queueAction = { action -> homeScreenViewModel.queueAction(action) },
+            moveToPlayer = { id: String ->
+                val player =
+                    state.playerData.find { it.player.id == id }
+                if (player != null) {
+                    homeScreenViewModel.selectPlayer(player.player)
                 }
-            )
-        } else {
+            },
+            isExpandedScreen = isExpandedScreen
+        )
+    } else {
+        Box(Modifier.fillMaxWidth().height(collapsedPlayerHeight(isExpandedScreen))) {
             val text = when (state) {
                 is HomeScreenViewModel.PlayersState.Loading -> "Loading players..."
                 is HomeScreenViewModel.PlayersState.Data -> "No players available"
@@ -463,14 +467,5 @@ private fun Players(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
-    }
-}
-
-@Composable
-private fun floatingBarHeight(): Dp {
-    return if (WindowClass.isAtLeastExpanded()) {
-        84.dp
-    } else {
-        130.dp
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -9,10 +9,8 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -24,7 +22,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.HorizontalFloatingToolbar
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -174,7 +171,9 @@ fun HomeScreen(
                         }
 
                         FloatingBar(
-                            modifier = Modifier.align(Alignment.BottomCenter)
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter),
+                            onClick = { showPlayersView = true }
                         ) {
                             when (val state = playersState) {
                                 is HomeScreenViewModel.PlayersState.Loading -> Text(
@@ -192,7 +191,9 @@ fun HomeScreen(
                                         )
                                     } else {
                                         PlayersPager(
-                                            modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .wrapContentHeight(),
                                             playerPagerState = playerPagerState,
                                             playersState = state,
                                             serverUrl = serverUrl,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -300,6 +300,7 @@ private fun HomeContent(
 
             entry<HomeNavScreen.Library> {
                 LibraryScreen(
+                    hostPadding = hostPadding,
                     initialTabType = it.type,
                     onBack = { typedBackStack.removeLastOrNull() },
                     onNavigateClick = { item ->

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/LandingPage.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/LandingPage.kt
@@ -70,7 +70,7 @@ import io.music_assistant.client.utils.SessionState
 @Composable
 fun LandingPage(
     modifier: Modifier = Modifier,
-    hostPadding: PaddingValues,
+    contentPadding: PaddingValues,
     connectionState: SessionState,
     dataState: DataState<List<AppMediaItem.RecommendationFolder>>,
     serverUrl: String?,
@@ -112,7 +112,7 @@ fun LandingPage(
 
         LazyColumn(
             state = listState,
-            contentPadding = hostPadding
+            contentPadding = contentPadding
         ) {
             // Your library row
             item {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/LandingPage.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/LandingPage.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.plus
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
@@ -35,7 +34,6 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -107,13 +105,14 @@ fun LandingPage(
     val listState = rememberLazyListState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
 
-    Scaffold(
+    Column(
         modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-        topBar = { LandingPageTopBar(scrollBehavior) }
-    ) { contentPadding ->
+    ) {
+        LandingPageTopBar(scrollBehavior)
+
         LazyColumn(
             state = listState,
-            contentPadding = contentPadding + hostPadding
+            contentPadding = hostPadding
         ) {
             // Your library row
             item {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/LandingPage.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/LandingPage.kt
@@ -32,11 +32,8 @@ import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.Podcasts
 import androidx.compose.material.icons.filled.Radio
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -156,14 +153,6 @@ private fun LandingPageTopBar(
 ) {
     TopAppBar(
         title = { Text("Home") },
-        actions = {
-            IconButton(onClick = { navigateTo(NavScreen.Settings) }) {
-                Icon(
-                    imageVector = Icons.Default.Settings,
-                    contentDescription = "Settings",
-                )
-            }
-        },
         windowInsets = WindowInsets(0, 0, 0, 0)
     )
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/LandingPage.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/LandingPage.kt
@@ -37,7 +37,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -45,7 +44,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -65,6 +63,7 @@ import io.music_assistant.client.ui.compose.common.items.RadioWithMenu
 import io.music_assistant.client.ui.compose.common.items.TrackWithMenu
 import io.music_assistant.client.ui.compose.common.painters.rememberPlaceholderPainter
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
+import io.music_assistant.client.ui.compose.nav.Screen
 import io.music_assistant.client.utils.SessionState
 
 @Composable
@@ -103,13 +102,12 @@ fun LandingPage(
     }
 
     val listState = rememberLazyListState()
-    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
 
-    Column(
-        modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+    Screen(
+        topBar = { scrollBehavior ->
+            LandingPageTopBar(scrollBehavior)
+        }
     ) {
-        LandingPageTopBar(scrollBehavior)
-
         LazyColumn(
             state = listState,
             contentPadding = contentPadding

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/LandingPage.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/LandingPage.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -37,25 +38,23 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
-import io.music_assistant.client.ui.compose.common.icons.GenreIcon
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import io.music_assistant.client.data.model.client.AppMediaItem
 import io.music_assistant.client.data.model.server.MediaType
 import io.music_assistant.client.data.model.server.QueueOption
 import io.music_assistant.client.ui.compose.common.DataState
+import io.music_assistant.client.ui.compose.common.icons.GenreIcon
 import io.music_assistant.client.ui.compose.common.items.AlbumWithMenu
 import io.music_assistant.client.ui.compose.common.items.ArtistWithMenu
 import io.music_assistant.client.ui.compose.common.items.AudiobookWithMenu
@@ -69,9 +68,6 @@ import io.music_assistant.client.ui.compose.common.painters.rememberPlaceholderP
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.nav.NavScreen
 import io.music_assistant.client.utils.SessionState
-import musicassistantclient.composeapp.generated.resources.Res
-import musicassistantclient.composeapp.generated.resources.mass
-import org.jetbrains.compose.resources.painterResource
 
 @Composable
 fun LandingPage(
@@ -158,39 +154,18 @@ fun LandingPage(
 private fun LandingPageTopBar(
     navigateTo: (NavScreen) -> Unit
 ) {
-    Surface(
-        modifier = Modifier
-            .fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surfaceContainer,
-        tonalElevation = 2.dp
-    ) {
-        Row(
-            modifier = Modifier.height(64.dp).fillMaxWidth().padding(8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.Start)
-        ) {
-            Image(
-                painter = painterResource(Res.drawable.mass),
-                contentDescription = "Music Assistant Logo",
-                modifier = Modifier.size(48.dp)
-            )
-            Text(
-                text = "MASS",
-                style = MaterialTheme.typography.headlineMedium,
-                fontWeight = FontWeight.Bold,
-                letterSpacing = 2.sp,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-            Spacer(modifier = Modifier.weight(1f))
+    TopAppBar(
+        title = { Text("Home") },
+        actions = {
             IconButton(onClick = { navigateTo(NavScreen.Settings) }) {
                 Icon(
                     imageVector = Icons.Default.Settings,
                     contentDescription = "Settings",
                 )
             }
-        }
-    }
+        },
+        windowInsets = WindowInsets(0, 0, 0, 0)
+    )
 }
 
 // --- Common UI Components ---

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/LandingPage.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/LandingPage.kt
@@ -11,11 +11,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.plus
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
@@ -35,15 +35,19 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -63,12 +67,12 @@ import io.music_assistant.client.ui.compose.common.items.RadioWithMenu
 import io.music_assistant.client.ui.compose.common.items.TrackWithMenu
 import io.music_assistant.client.ui.compose.common.painters.rememberPlaceholderPainter
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
-import io.music_assistant.client.ui.compose.nav.NavScreen
 import io.music_assistant.client.utils.SessionState
 
 @Composable
 fun LandingPage(
     modifier: Modifier = Modifier,
+    hostPadding: PaddingValues,
     connectionState: SessionState,
     dataState: DataState<List<AppMediaItem.RecommendationFolder>>,
     serverUrl: String?,
@@ -78,7 +82,6 @@ fun LandingPage(
     playlistActions: ActionsViewModel.PlaylistActions,
     libraryActions: ActionsViewModel.LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
-    navigateTo: (NavScreen) -> Unit,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)
 ) {
     val filteredData = remember(dataState) {
@@ -102,14 +105,15 @@ fun LandingPage(
     }
 
     val listState = rememberLazyListState()
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
 
-    Column(modifier = modifier.fillMaxSize()) {
-
-        LandingPageTopBar(navigateTo)
+    Scaffold(
+        modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        topBar = { LandingPageTopBar(scrollBehavior) }
+    ) { contentPadding ->
         LazyColumn(
-            modifier = Modifier.fillMaxSize(),
             state = listState,
-            contentPadding = PaddingValues(bottom = 16.dp)
+            contentPadding = contentPadding + hostPadding
         ) {
             // Your library row
             item {
@@ -148,12 +152,10 @@ fun LandingPage(
 }
 
 @Composable
-private fun LandingPageTopBar(
-    navigateTo: (NavScreen) -> Unit
-) {
+private fun LandingPageTopBar(scrollBehavior: TopAppBarScrollBehavior) {
     TopAppBar(
         title = { Text("Home") },
-        windowInsets = WindowInsets(0, 0, 0, 0)
+        scrollBehavior = scrollBehavior
     )
 }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/PagerIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/PagerIndicator.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.launch
 fun HorizontalPagerIndicator(
     modifier: Modifier = Modifier,
     pagerState: PagerState,
+    allowMoving: Boolean = true,
     onItemMoved: ((Int) -> Unit)?,
 ) {
     val pageCount = pagerState.pageCount
@@ -92,7 +93,7 @@ fun HorizontalPagerIndicator(
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        onItemMoved?.let {
+        if (allowMoving) {
             IconButton(
                 modifier = Modifier.size(32.dp),
                 enabled = pagerState.currentPage > 0,
@@ -155,7 +156,8 @@ fun HorizontalPagerIndicator(
                 textAlign = TextAlign.Center,
             )
         }
-        onItemMoved?.let {
+
+        if (allowMoving) {
             IconButton(
                 modifier = Modifier.size(32.dp),
                 enabled = pagerState.currentPage < pageCount - 1,
@@ -204,7 +206,8 @@ fun HorizontalPagerIndicatorDotsPreviewNoMove() {
         HorizontalPagerIndicator(
             modifier = Modifier.fillMaxWidth().wrapContentHeight(),
             pagerState = rememberPagerState(pageCount = { 9 }, initialPage = 2),
-            onItemMoved = null,
+            allowMoving = false,
+            onItemMoved = { },
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/PlayersPager.kt
@@ -73,8 +73,6 @@ internal fun PlayersPager(
     onGoToLibrary: () -> Unit,
     onItemMoved: ((Int) -> Unit)?,
     queueAction: (QueueAction) -> Unit,
-    settingsAction: (String) -> Unit,
-    dspSettingsAction: (String) -> Unit,
     moveToPlayer: (String) -> Unit
 ) {
     // Extract playerData list to ensure proper recomposition
@@ -84,7 +82,8 @@ internal fun PlayersPager(
         if (playerDataList.size > 1) {
             HorizontalPagerIndicator(
                 pagerState = playerPagerState,
-                onItemMoved = onItemMoved,
+                allowMoving = showQueue,
+                onItemMoved = onItemMoved
             )
         }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/PlayersPager.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -54,7 +55,6 @@ import io.music_assistant.client.ui.compose.common.action.QueueAction
 import io.music_assistant.client.ui.compose.home.players.GroupSettingsDialog
 import io.music_assistant.client.ui.compose.home.players.PlayerSelectionLayout
 import io.music_assistant.client.ui.compose.home.players.SelectPlayerDialog
-import io.music_assistant.client.utils.WindowClass
 import io.music_assistant.client.utils.conditional
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -71,8 +71,15 @@ internal fun PlayersPager(
     onClose: () -> Unit,
     onItemMoved: ((Int) -> Unit)?,
     queueAction: (QueueAction) -> Unit,
-    moveToPlayer: (String) -> Unit
+    moveToPlayer: (String) -> Unit,
+    isExpandedScreen: Boolean
 ) {
+    val modifier = if (expanded) {
+        modifier
+    } else {
+        modifier.height(collapsedPlayerHeight(isExpandedScreen))
+    }
+
     // Extract playerData list to ensure proper recomposition
     val playerDataList = playersState.playerData
 
@@ -135,8 +142,7 @@ internal fun PlayersPager(
                     }
                 )
             ) {
-                val isAtLeastExpanded = WindowClass.isAtLeastExpanded()
-                if (!isAtLeastExpanded || expanded) {
+                if (!isExpandedScreen || expanded) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.Center
@@ -170,9 +176,9 @@ internal fun PlayersPager(
                             playersState = playersState,
                             serverUrl = serverUrl,
                             playerAction = playerAction,
-                            onSelectPlayer = if (isAtLeastExpanded && !isQueueExpanded) onSelectPlayer else null,
-                            onGroupButton = if (isAtLeastExpanded && !isQueueExpanded) onGroupButton else null,
-                            showAdditionalControls = isAtLeastExpanded,
+                            onSelectPlayer = if (isExpandedScreen && !isQueueExpanded) onSelectPlayer else null,
+                            onGroupButton = if (isExpandedScreen && !isQueueExpanded) onGroupButton else null,
+                            showAdditionalControls = isExpandedScreen,
                         )
                     }
                 }
@@ -306,5 +312,13 @@ internal fun PlayersPager(
                 }
             }
         }
+    }
+}
+
+fun collapsedPlayerHeight(isExpandedScreen: Boolean): Dp {
+    return if (isExpandedScreen) {
+        84.dp
+    } else {
+        130.dp
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/PlayersPager.kt
@@ -67,10 +67,8 @@ internal fun PlayersPager(
     simplePlayerAction: (String, PlayerAction) -> Unit,
     playerAction: (PlayerData, PlayerAction) -> Unit,
     onFavoriteClick: (AppMediaItem) -> Unit,
-    showQueue: Boolean,
-    isQueueExpanded: Boolean,
-    onQueueExpandedSwitch: () -> Unit,
-    onGoToLibrary: () -> Unit,
+    expanded: Boolean,
+    onClose: () -> Unit,
     onItemMoved: ((Int) -> Unit)?,
     queueAction: (QueueAction) -> Unit,
     moveToPlayer: (String) -> Unit
@@ -82,7 +80,7 @@ internal fun PlayersPager(
         if (playerDataList.size > 1) {
             HorizontalPagerIndicator(
                 pagerState = playerPagerState,
-                allowMoving = showQueue,
+                allowMoving = expanded,
                 onItemMoved = onItemMoved
             )
         }
@@ -116,6 +114,8 @@ internal fun PlayersPager(
                 )
             }
 
+            var isQueueExpanded by remember { mutableStateOf(false) }
+
             Column(
                 Modifier.background(
                     brush = if (isLocalPlayer) {
@@ -136,7 +136,7 @@ internal fun PlayersPager(
                 )
             ) {
                 val isAtLeastExpanded = WindowClass.isAtLeastExpanded()
-                if (!isAtLeastExpanded || showQueue) {
+                if (!isAtLeastExpanded || expanded) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.Center
@@ -151,19 +151,18 @@ internal fun PlayersPager(
                 }
 
                 AnimatedVisibility(
-                    visible = isQueueExpanded.takeIf { showQueue } != false,
+                    visible = isQueueExpanded.takeIf { expanded } != false,
                     enter = fadeIn(tween(300)) + expandVertically(tween(300)),
                     exit = fadeOut(tween(200)) + shrinkVertically(tween(300))
                 ) {
-
                     Box(
                         modifier = Modifier
                             .padding(top = 2.dp)
                             .fillMaxWidth()
                             .wrapContentSize()
                             .conditional(
-                                showQueue,
-                                { clickable { onQueueExpandedSwitch() } }
+                                expanded,
+                                { clickable { isQueueExpanded = false } }
                             )
                     ) {
                         CompactPlayerItem(
@@ -181,13 +180,13 @@ internal fun PlayersPager(
                 Column(
                     modifier = Modifier
                         .conditional(
-                            condition = isQueueExpanded.takeIf { showQueue } == false,
+                            condition = isQueueExpanded.takeIf { expanded } == false,
                             ifTrue = { weight(1f) },
                             ifFalse = { wrapContentHeight() }
                         )
                 ) {
                     AnimatedVisibility(
-                        visible = isQueueExpanded.takeIf { showQueue } == false,
+                        visible = isQueueExpanded.takeIf { expanded } == false,
                         enter = fadeIn(tween(300)) + expandVertically(tween(300)),
                         exit = fadeOut(tween(200)) + shrinkVertically(tween(300))
                     ) {
@@ -204,7 +203,7 @@ internal fun PlayersPager(
                 }
 
                 if (
-                    showQueue
+                    expanded
                     && player.player.isVolumeSliderAccessible
                     && player.player.currentVolume != null
                 ) {
@@ -284,7 +283,7 @@ internal fun PlayersPager(
 
                 Spacer(modifier = Modifier.fillMaxWidth().height(8.dp))
 
-                player.queue.takeIf { showQueue }?.let { queue ->
+                player.queue.takeIf { expanded }?.let { queue ->
                     CollapsibleQueue(
                         modifier = Modifier
                             .conditional(
@@ -294,8 +293,8 @@ internal fun PlayersPager(
                             ),
                         queue = queue,
                         isQueueExpanded = isQueueExpanded,
-                        onQueueExpandedSwitch = { onQueueExpandedSwitch() },
-                        onGoToLibrary = onGoToLibrary,
+                        onQueueExpandedSwitch = { isQueueExpanded = !isQueueExpanded },
+                        onGoToLibrary = onClose,
                         serverUrl = serverUrl,
                         queueAction = queueAction,
                         players = playerDataList,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -5,7 +5,6 @@ package io.music_assistant.client.ui.compose.item
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -21,13 +20,11 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -48,6 +45,7 @@ import io.music_assistant.client.ui.compose.common.items.TrackWithMenu
 import io.music_assistant.client.ui.compose.common.providers.ProviderIcon
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
+import io.music_assistant.client.ui.compose.nav.Screen
 import io.music_assistant.client.ui.theme.AppTheme
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -231,10 +229,7 @@ private fun ItemChildren(
                     else -> return@Box
                 }
 
-                val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
-                Column(
-                    modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-                ) {
+                Screen(topBar = { scrollBehaviour ->
                     ItemTopBar(
                         item = item,
                         isRowMode = isRowMode,
@@ -242,9 +237,9 @@ private fun ItemChildren(
                         onToggleViewMode = onToggleViewMode,
                         libraryActions = libraryActions,
                         playlistActions = playlistActions.takeIf { item !is AppMediaItem.Genre },
-                        scrollBehavior = scrollBehavior
+                        scrollBehavior = scrollBehaviour
                     )
-
+                }) {
                     LazyVerticalGrid(
                         modifier = Modifier.fillMaxWidth()
                             .testTag("LazyVerticalGrid"),

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -5,12 +5,12 @@ package io.music_assistant.client.ui.compose.item
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.plus
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -19,17 +19,17 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.music_assistant.client.data.model.client.AppMediaItem
@@ -48,7 +48,6 @@ import io.music_assistant.client.ui.compose.common.providers.ProviderIcon
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.theme.AppTheme
-import androidx.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -58,6 +57,7 @@ fun ItemDetailsScreen(
     providerId: String,
     onBack: () -> Unit,
     onNavigateToItem: (String, MediaType, String) -> Unit,
+    hostPadding: PaddingValues,
 ) {
     val viewModel: ItemDetailsViewModel = koinViewModel()
     val actionsViewModel: ActionsViewModel = koinViewModel()
@@ -77,41 +77,41 @@ fun ItemDetailsScreen(
         }
     }
 
-    Surface {
-        ItemDetails(
-            state,
-            serverUrl,
-            onBack,
-            isRowMode,
-            toastState,
-            onNavigateToItem,
-            actionsViewModel::getEditablePlaylists,
-            actionsViewModel::addToPlaylist,
-            actionsViewModel::onLibraryClick,
-            actionsViewModel::onFavoriteClick,
-            actionsViewModel::onMarkPlayed,
-            actionsViewModel::onMarkUnplayed,
-            { id, pos ->
-                actionsViewModel.removeFromPlaylist(
-                    id,
-                    pos,
-                    viewModel::reload
-                )
-            },
-            { modifier, provider ->
-                actionsViewModel.getProviderIcon(provider)
-                    ?.let { ProviderIcon(modifier, it) }
-            },
-            viewModel::onPlayClick,
-            viewModel::toggleItemsRowMode,
-            viewModel::onChapterClick,
-            viewModel::onPlayClick
-        )
-    }
+    ItemDetails(
+        hostPadding,
+        state,
+        serverUrl,
+        onBack,
+        isRowMode,
+        toastState,
+        onNavigateToItem,
+        actionsViewModel::getEditablePlaylists,
+        actionsViewModel::addToPlaylist,
+        actionsViewModel::onLibraryClick,
+        actionsViewModel::onFavoriteClick,
+        actionsViewModel::onMarkPlayed,
+        actionsViewModel::onMarkUnplayed,
+        { id, pos ->
+            actionsViewModel.removeFromPlaylist(
+                id,
+                pos,
+                viewModel::reload
+            )
+        },
+        { modifier, provider ->
+            actionsViewModel.getProviderIcon(provider)
+                ?.let { ProviderIcon(modifier, it) }
+        },
+        viewModel::onPlayClick,
+        viewModel::toggleItemsRowMode,
+        viewModel::onChapterClick,
+        viewModel::onPlayClick
+    )
 }
 
 @Composable
 fun ItemDetails(
+    hostPadding: PaddingValues = PaddingValues(),
     state: ItemDetailsViewModel.State,
     serverUrl: String? = null,
     onBack: () -> Unit = {},
@@ -131,53 +131,52 @@ fun ItemDetails(
     onChapterClick: (Int) -> Unit = {},
     onChildPlayClick: (AppMediaItem, QueueOption, Boolean) -> Unit = { _, _, _ -> }
 ) {
-    Column {
-        val playlistActions = ActionsViewModel.PlaylistActions(
-            onLoadPlaylists = geEditablePlaylists,
-            onAddToPlaylist = addToPlaylist
-        )
+    val playlistActions = ActionsViewModel.PlaylistActions(
+        onLoadPlaylists = geEditablePlaylists,
+        onAddToPlaylist = addToPlaylist
+    )
 
-        val libraryActions = ActionsViewModel.LibraryActions(
-            onLibraryClick = onLibraryClick,
-            onFavoriteClick = onFavoriteClick
-        )
+    val libraryActions = ActionsViewModel.LibraryActions(
+        onLibraryClick = onLibraryClick,
+        onFavoriteClick = onFavoriteClick
+    )
 
-        val progressActions = ActionsViewModel.ProgressActions(
-            onMarkPlayed = onMarkPlayed,
-            onMarkUnplayed = onMarkUnplayed
-        )
+    val progressActions = ActionsViewModel.ProgressActions(
+        onMarkPlayed = onMarkPlayed,
+        onMarkUnplayed = onMarkUnplayed
+    )
 
-        ItemChildren(
-            state = state,
-            serverUrl = serverUrl,
-            toastState = toastState,
-            isRowMode = isRowMode,
-            onNavigateClick = { item ->
-                when (item) {
-                    is AppMediaItem.Artist,
-                    is AppMediaItem.Album,
-                    is AppMediaItem.Playlist,
-                    is AppMediaItem.Podcast,
-                    is AppMediaItem.Audiobook,
-                    is AppMediaItem.Genre -> {
-                        onNavigateToItem(item.itemId, item.mediaType, item.provider)
-                    }
-
-                    else -> Unit
+    ItemChildren(
+        state = state,
+        serverUrl = serverUrl,
+        toastState = toastState,
+        isRowMode = isRowMode,
+        onNavigateClick = { item ->
+            when (item) {
+                is AppMediaItem.Artist,
+                is AppMediaItem.Album,
+                is AppMediaItem.Playlist,
+                is AppMediaItem.Podcast,
+                is AppMediaItem.Audiobook,
+                is AppMediaItem.Genre -> {
+                    onNavigateToItem(item.itemId, item.mediaType, item.provider)
                 }
-            },
-            onPlayItemClick = onPlayClick,
-            onPlayChildClick = onChildPlayClick,
-            onChapterClick = onChapterClick,
-            playlistActions = playlistActions,
-            progressActions = progressActions,
-            onRemoveFromPlaylist = onRemoveFromPlaylist,
-            libraryActions = libraryActions,
-            providerIconFetcher = providerIconFetcher,
-            onBack = onBack,
-            onToggleViewMode = onToggleViewMode
-        )
-    }
+
+                else -> Unit
+            }
+        },
+        onPlayItemClick = onPlayClick,
+        onPlayChildClick = onChildPlayClick,
+        onChapterClick = onChapterClick,
+        playlistActions = playlistActions,
+        progressActions = progressActions,
+        onRemoveFromPlaylist = onRemoveFromPlaylist,
+        libraryActions = libraryActions,
+        providerIconFetcher = providerIconFetcher,
+        onBack = onBack,
+        onToggleViewMode = onToggleViewMode,
+        hostPadding,
+    )
 }
 
 @Composable
@@ -197,6 +196,7 @@ private fun ItemChildren(
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
     onBack: () -> Unit,
     onToggleViewMode: () -> Unit,
+    hostPadding: PaddingValues,
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         when (val itemState = state.itemState) {
@@ -231,24 +231,25 @@ private fun ItemChildren(
                 }
 
                 val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .nestedScroll(scrollBehavior.nestedScrollConnection)
-                ) {
-                    ItemTopBar(
-                        item = item,
-                        isRowMode = isRowMode,
-                        onBack = onBack,
-                        onToggleViewMode = onToggleViewMode,
-                        libraryActions = libraryActions,
-                        playlistActions = playlistActions.takeIf { item !is AppMediaItem.Genre },
-                        scrollBehavior = scrollBehavior
-                    )
+                Scaffold(
+                    modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+                    topBar = {
+                        ItemTopBar(
+                            item = item,
+                            isRowMode = isRowMode,
+                            onBack = onBack,
+                            onToggleViewMode = onToggleViewMode,
+                            libraryActions = libraryActions,
+                            playlistActions = playlistActions.takeIf { item !is AppMediaItem.Genre },
+                            scrollBehavior = scrollBehavior
+                        )
+                    }
+                ) { contentPadding ->
                     LazyVerticalGrid(
-                        modifier = Modifier.weight(1f).fillMaxWidth().testTag("LazyVerticalGrid"),
+                        modifier = Modifier.fillMaxWidth()
+                            .testTag("LazyVerticalGrid"),
                         columns = GridCells.Adaptive(minSize = 96.dp),
-                        contentPadding = PaddingValues(8.dp),
+                        contentPadding = contentPadding + hostPadding,
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
@@ -261,30 +262,162 @@ private fun ItemChildren(
                             )
                         }
 
-                    // For Genre: Artists section
-                    if (item is AppMediaItem.Genre) {
-                        when (val artistsState = state.artistsState) {
-                            is DataState.Data -> {
-                                if (artistsState.data.isNotEmpty()) {
-                                    item(span = { GridItemSpan(maxLineSpan) }) {
-                                        SectionHeader("Artists")
-                                    }
-                                    items(
-                                        artistsState.data,
-                                        span = if (isRowMode) {
-                                            { GridItemSpan(maxLineSpan) }
-                                        } else null
-                                    ) { artist ->
-                                        ArtistWithMenu(
-                                            item = artist,
-                                            rowMode = isRowMode,
+                        // For Genre: Artists section
+                        if (item is AppMediaItem.Genre) {
+                            when (val artistsState = state.artistsState) {
+                                is DataState.Data -> {
+                                    if (artistsState.data.isNotEmpty()) {
+                                        item(span = { GridItemSpan(maxLineSpan) }) {
+                                            SectionHeader("Artists")
+                                        }
+                                        items(
+                                            artistsState.data,
+                                            span = if (isRowMode) {
+                                                { GridItemSpan(maxLineSpan) }
+                                            } else null
+                                        ) { artist ->
+                                            ArtistWithMenu(
+                                                item = artist,
+                                                rowMode = isRowMode,
 
-                                            serverUrl = serverUrl,
-                                            onNavigateClick = onNavigateClick,
-                                            onPlayOption = onPlayChildClick,
-                                            libraryActions = libraryActions,
-                                            providerIconFetcher = providerIconFetcher
+                                                serverUrl = serverUrl,
+                                                onNavigateClick = onNavigateClick,
+                                                onPlayOption = onPlayChildClick,
+                                                libraryActions = libraryActions,
+                                                providerIconFetcher = providerIconFetcher
+                                            )
+                                        }
+                                    }
+                                }
+
+                                is DataState.Loading -> {
+                                    item(span = { GridItemSpan(maxLineSpan) }) {
+                                        Box(
+                                            modifier = Modifier.fillMaxWidth().padding(16.dp),
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            CircularProgressIndicator()
+                                        }
+                                    }
+                                }
+
+                                else -> Unit
+                            }
+                        }
+
+                        // For Artist or Genre: Albums section
+                        if (item is AppMediaItem.Artist || item is AppMediaItem.Genre) {
+                            when (val albumsState = state.albumsState) {
+                                is DataState.Data -> {
+                                    if (albumsState.data.isNotEmpty()) {
+                                        item(span = { GridItemSpan(maxLineSpan) }) {
+                                            SectionHeader("Albums")
+                                        }
+                                        items(
+                                            albumsState.data,
+                                            span = if (isRowMode) {
+                                                { GridItemSpan(maxLineSpan) }
+                                            } else null
+                                        ) { album ->
+                                            AlbumWithMenu(
+                                                item = album,
+                                                rowMode = isRowMode,
+
+                                                serverUrl = serverUrl,
+                                                onNavigateClick = onNavigateClick,
+                                                onPlayOption = onPlayChildClick,
+                                                libraryActions = libraryActions,
+                                                providerIconFetcher = providerIconFetcher
+                                            )
+                                        }
+                                    }
+                                }
+
+                                is DataState.Loading -> {
+                                    item(span = { GridItemSpan(maxLineSpan) }) {
+                                        Box(
+                                            modifier = Modifier.fillMaxWidth().padding(16.dp),
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            CircularProgressIndicator()
+                                        }
+                                    }
+                                }
+
+                                else -> Unit
+                            }
+                        }
+
+                        // For Audiobook: Chapters section (from metadata, not a separate API)
+                        if (item is AppMediaItem.Audiobook) {
+                            val chapters = item.chapters
+                            if (!chapters.isNullOrEmpty()) {
+                                item(span = { GridItemSpan(maxLineSpan) }) {
+                                    SectionHeader("Chapters")
+                                }
+                                chapters.forEach { chapter ->
+                                    item(span = { GridItemSpan(maxLineSpan) }) {
+                                        ChapterRow(
+                                            chapter = chapter,
+                                            onClick = {
+                                                onChapterClick(chapter.position)
+                                            }
                                         )
+                                    }
+                                }
+                            }
+                        }
+
+                        // Tracks section (all types)
+                        when (val tracksState = state.playableItemsState) {
+                            is DataState.Data -> {
+                                if (tracksState.data.isNotEmpty()) {
+                                    item(span = { GridItemSpan(maxLineSpan) }) {
+                                        SectionHeader(
+                                            when (item) {
+                                                is AppMediaItem.Podcast -> "Episodes"
+                                                else -> "Tracks"
+                                            }
+                                        )
+                                    }
+                                    tracksState.data.forEachIndexed { index, track ->
+                                        item(
+                                            span = if (isRowMode) {
+                                                { GridItemSpan(maxLineSpan) }
+                                            } else null
+                                        ) {
+                                            when (track) {
+                                                is AppMediaItem.Track -> TrackWithMenu(
+                                                    item = track,
+                                                    serverUrl = serverUrl,
+                                                    rowMode = isRowMode,
+                                                    onPlayOption = onPlayChildClick,
+                                                    playlistActions = playlistActions,
+                                                    // Show "remove from playlist" only for playlist items
+                                                    onRemoveFromPlaylist = if (item is AppMediaItem.Playlist && item.isEditable == true) {
+                                                        {
+                                                            onRemoveFromPlaylist(
+                                                                item.itemId,
+                                                                index
+                                                            )
+                                                        }
+                                                    } else null,
+                                                    libraryActions = libraryActions,
+                                                    providerIconFetcher = providerIconFetcher,
+                                                )
+
+                                                is AppMediaItem.PodcastEpisode -> PodcastEpisodeWithMenu(
+                                                    item = track,
+                                                    serverUrl = serverUrl,
+                                                    rowMode = isRowMode,
+                                                    onPlayOption = onPlayChildClick,
+                                                    playlistActions = null, // No playlist actions for podcast episodes
+                                                    libraryActions = libraryActions,
+                                                    progressActions = progressActions,
+                                                    providerIconFetcher = providerIconFetcher,
+                                                )
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -302,133 +435,6 @@ private fun ItemChildren(
 
                             else -> Unit
                         }
-                    }
-
-                    // For Artist or Genre: Albums section
-                    if (item is AppMediaItem.Artist || item is AppMediaItem.Genre) {
-                        when (val albumsState = state.albumsState) {
-                            is DataState.Data -> {
-                                if (albumsState.data.isNotEmpty()) {
-                                    item(span = { GridItemSpan(maxLineSpan) }) {
-                                        SectionHeader("Albums")
-                                    }
-                                    items(
-                                        albumsState.data,
-                                        span = if (isRowMode) {
-                                            { GridItemSpan(maxLineSpan) }
-                                        } else null
-                                    ) { album ->
-                                        AlbumWithMenu(
-                                            item = album,
-                                            rowMode = isRowMode,
-
-                                            serverUrl = serverUrl,
-                                            onNavigateClick = onNavigateClick,
-                                            onPlayOption = onPlayChildClick,
-                                            libraryActions = libraryActions,
-                                            providerIconFetcher = providerIconFetcher
-                                        )
-                                    }
-                                }
-                            }
-
-                            is DataState.Loading -> {
-                                item(span = { GridItemSpan(maxLineSpan) }) {
-                                    Box(
-                                        modifier = Modifier.fillMaxWidth().padding(16.dp),
-                                        contentAlignment = Alignment.Center
-                                    ) {
-                                        CircularProgressIndicator()
-                                    }
-                                }
-                            }
-
-                            else -> Unit
-                        }
-                    }
-
-                    // For Audiobook: Chapters section (from metadata, not a separate API)
-                    if (item is AppMediaItem.Audiobook) {
-                        val chapters = item.chapters
-                        if (!chapters.isNullOrEmpty()) {
-                            item(span = { GridItemSpan(maxLineSpan) }) {
-                                SectionHeader("Chapters")
-                            }
-                            chapters.forEach { chapter ->
-                                item(span = { GridItemSpan(maxLineSpan) }) {
-                                    ChapterRow(
-                                        chapter = chapter,
-                                        onClick = {
-                                            onChapterClick(chapter.position)
-                                        }
-                                    )
-                                }
-                            }
-                        }
-                    }
-
-                    // Tracks section (all types)
-                    when (val tracksState = state.playableItemsState) {
-                        is DataState.Data -> {
-                            if (tracksState.data.isNotEmpty()) {
-                                item(span = { GridItemSpan(maxLineSpan) }) {
-                                    SectionHeader(
-                                        when (item) {
-                                            is AppMediaItem.Podcast -> "Episodes"
-                                            else -> "Tracks"
-                                        }
-                                    )
-                                }
-                                tracksState.data.forEachIndexed { index, track ->
-                                    item(
-                                        span = if (isRowMode) {
-                                            { GridItemSpan(maxLineSpan) }
-                                        } else null
-                                    ) {
-                                        when (track) {
-                                            is AppMediaItem.Track -> TrackWithMenu(
-                                                item = track,
-                                                serverUrl = serverUrl,
-                                                rowMode = isRowMode,
-                                                onPlayOption = onPlayChildClick,
-                                                playlistActions = playlistActions,
-                                                // Show "remove from playlist" only for playlist items
-                                                onRemoveFromPlaylist = if (item is AppMediaItem.Playlist && item.isEditable == true) {
-                                                    { onRemoveFromPlaylist(item.itemId, index) }
-                                                } else null,
-                                                libraryActions = libraryActions,
-                                                providerIconFetcher = providerIconFetcher,
-                                            )
-
-                                            is AppMediaItem.PodcastEpisode -> PodcastEpisodeWithMenu(
-                                                item = track,
-                                                serverUrl = serverUrl,
-                                                rowMode = isRowMode,
-                                                onPlayOption = onPlayChildClick,
-                                                playlistActions = null, // No playlist actions for podcast episodes
-                                                libraryActions = libraryActions,
-                                                progressActions = progressActions,
-                                                providerIconFetcher = providerIconFetcher,
-                                            )
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        is DataState.Loading -> {
-                            item(span = { GridItemSpan(maxLineSpan) }) {
-                                Box(
-                                    modifier = Modifier.fillMaxWidth().padding(16.dp),
-                                    contentAlignment = Alignment.Center
-                                ) {
-                                    CircularProgressIndicator()
-                                }
-                            }
-                        }
-
-                        else -> Unit
-                    }
                     }
                 }
             }
@@ -509,7 +515,8 @@ private fun PreviewLoading() {
                     DataState.Loading(),
                     DataState.Loading(),
                     DataState.Loading()
-                )
+                ),
+                geEditablePlaylists = suspend { emptyList() },
             )
         }
     }
@@ -533,7 +540,8 @@ private fun PreviewArtist(isRowMode: Boolean = true) {
                     ),
                     DataState.NoData()
                 ),
-                isRowMode = isRowMode
+                isRowMode = isRowMode,
+                geEditablePlaylists = suspend { emptyList() },
             )
         }
     }
@@ -552,21 +560,20 @@ private fun PreviewAlbum(isRowMode: Boolean = true) {
     val album = AppMediaItemFixtures.album("Title", artist)
 
     AppTheme(darkTheme = false) {
-        Scaffold {
-            ItemDetails(
-                state = ItemDetailsViewModel.State(
-                    DataState.Data(album),
-                    DataState.NoData(),
-                    DataState.Data(
-                        AppMediaItemFixtures.tracks(
-                            listOf("Track 1", "Track 2"),
-                            album = album
-                        )
+        ItemDetails(
+            state = ItemDetailsViewModel.State(
+                DataState.Data(album),
+                DataState.NoData(),
+                DataState.Data(
+                    AppMediaItemFixtures.tracks(
+                        listOf("Track 1", "Track 2"),
+                        album = album
                     )
-                ),
-                isRowMode = isRowMode
-            )
-        }
+                )
+            ),
+            isRowMode = isRowMode,
+            geEditablePlaylists = suspend { emptyList() },
+        )
     }
 }
 
@@ -580,16 +587,15 @@ private fun PreviewAlbumGrid() {
 @Composable
 private fun PreviewPlaylist(isRowMode: Boolean = true) {
     AppTheme(darkTheme = false) {
-        Scaffold {
-            ItemDetails(
-                state = ItemDetailsViewModel.State(
-                    DataState.Data(AppMediaItemFixtures.playlist("Title")),
-                    DataState.NoData(),
-                    DataState.Data(AppMediaItemFixtures.tracks(listOf("Track 1", "Track 2")))
-                ),
-                isRowMode = isRowMode
-            )
-        }
+        ItemDetails(
+            state = ItemDetailsViewModel.State(
+                DataState.Data(AppMediaItemFixtures.playlist("Title")),
+                DataState.NoData(),
+                DataState.Data(AppMediaItemFixtures.tracks(listOf("Track 1", "Track 2")))
+            ),
+            isRowMode = isRowMode,
+            geEditablePlaylists = suspend { emptyList() },
+        )
     }
 }
 
@@ -604,21 +610,20 @@ private fun PreviewPlaylistGrid() {
 private fun PreviewPodcast(isRowMode: Boolean = true) {
     val podcast = AppMediaItemFixtures.podcast()
     AppTheme(darkTheme = false) {
-        Scaffold {
-            ItemDetails(
-                state = ItemDetailsViewModel.State(
-                    DataState.Data(podcast),
-                    DataState.NoData(),
-                    DataState.Data(
-                        AppMediaItemFixtures.episodes(
-                            listOf("Episode 1", "Episode 2"),
-                            podcast = podcast
-                        )
+        ItemDetails(
+            state = ItemDetailsViewModel.State(
+                DataState.Data(podcast),
+                DataState.NoData(),
+                DataState.Data(
+                    AppMediaItemFixtures.episodes(
+                        listOf("Episode 1", "Episode 2"),
+                        podcast = podcast
                     )
-                ),
-                isRowMode = isRowMode
-            )
-        }
+                )
+            ),
+            isRowMode = isRowMode,
+            geEditablePlaylists = suspend { emptyList() },
+        )
     }
 }
 
@@ -632,21 +637,20 @@ private fun PreviewPodcastGrid() {
 @Composable
 private fun PreviewAudiobook(isRowMode: Boolean = true) {
     AppTheme(darkTheme = false) {
-        Scaffold {
-            ItemDetails(
-                state = ItemDetailsViewModel.State(
-                    DataState.Data(
-                        AppMediaItemFixtures.audiobook(
-                            "Title",
-                            listOf("Chapter 1", "Chapter 2")
-                        )
-                    ),
-                    DataState.NoData(),
-                    DataState.NoData()
+        ItemDetails(
+            state = ItemDetailsViewModel.State(
+                DataState.Data(
+                    AppMediaItemFixtures.audiobook(
+                        "Title",
+                        listOf("Chapter 1", "Chapter 2")
+                    )
                 ),
-                isRowMode = isRowMode
-            )
-        }
+                DataState.NoData(),
+                DataState.NoData()
+            ),
+            isRowMode = isRowMode,
+            geEditablePlaylists = suspend { emptyList() },
+        )
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -58,7 +58,7 @@ fun ItemDetailsScreen(
     providerId: String,
     onBack: () -> Unit,
     onNavigateToItem: (String, MediaType, String) -> Unit,
-    hostPadding: PaddingValues,
+    contentPadding: PaddingValues,
 ) {
     val viewModel: ItemDetailsViewModel = koinViewModel()
     val actionsViewModel: ActionsViewModel = koinViewModel()
@@ -79,7 +79,7 @@ fun ItemDetailsScreen(
     }
 
     ItemDetails(
-        hostPadding,
+        contentPadding,
         state,
         serverUrl,
         onBack,
@@ -112,7 +112,7 @@ fun ItemDetailsScreen(
 
 @Composable
 fun ItemDetails(
-    hostPadding: PaddingValues = PaddingValues(),
+    contentPadding: PaddingValues = PaddingValues(),
     state: ItemDetailsViewModel.State,
     serverUrl: String? = null,
     onBack: () -> Unit = {},
@@ -176,7 +176,7 @@ fun ItemDetails(
         providerIconFetcher = providerIconFetcher,
         onBack = onBack,
         onToggleViewMode = onToggleViewMode,
-        hostPadding,
+        contentPadding,
     )
 }
 
@@ -197,7 +197,7 @@ private fun ItemChildren(
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
     onBack: () -> Unit,
     onToggleViewMode: () -> Unit,
-    hostPadding: PaddingValues,
+    contentPadding: PaddingValues,
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         when (val itemState = state.itemState) {
@@ -249,7 +249,7 @@ private fun ItemChildren(
                         modifier = Modifier.fillMaxWidth()
                             .testTag("LazyVerticalGrid"),
                         columns = GridCells.Adaptive(minSize = 96.dp),
-                        contentPadding = hostPadding + PaddingValues(8.dp),
+                        contentPadding = contentPadding + PaddingValues(8.dp),
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -249,7 +249,7 @@ private fun ItemChildren(
                         modifier = Modifier.fillMaxWidth()
                             .testTag("LazyVerticalGrid"),
                         columns = GridCells.Adaptive(minSize = 96.dp),
-                        contentPadding = contentPadding + hostPadding,
+                        contentPadding = contentPadding + hostPadding + PaddingValues(8.dp),
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -5,6 +5,7 @@ package io.music_assistant.client.ui.compose.item
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -231,25 +232,24 @@ private fun ItemChildren(
                 }
 
                 val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
-                Scaffold(
+                Column(
                     modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-                    topBar = {
-                        ItemTopBar(
-                            item = item,
-                            isRowMode = isRowMode,
-                            onBack = onBack,
-                            onToggleViewMode = onToggleViewMode,
-                            libraryActions = libraryActions,
-                            playlistActions = playlistActions.takeIf { item !is AppMediaItem.Genre },
-                            scrollBehavior = scrollBehavior
-                        )
-                    }
-                ) { contentPadding ->
+                ) {
+                    ItemTopBar(
+                        item = item,
+                        isRowMode = isRowMode,
+                        onBack = onBack,
+                        onToggleViewMode = onToggleViewMode,
+                        libraryActions = libraryActions,
+                        playlistActions = playlistActions.takeIf { item !is AppMediaItem.Genre },
+                        scrollBehavior = scrollBehavior
+                    )
+
                     LazyVerticalGrid(
                         modifier = Modifier.fillMaxWidth()
                             .testTag("LazyVerticalGrid"),
                         columns = GridCells.Adaptive(minSize = 96.dp),
-                        contentPadding = contentPadding + hostPadding + PaddingValues(8.dp),
+                        contentPadding = hostPadding + PaddingValues(8.dp),
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
@@ -2,10 +2,10 @@
 
 package io.music_assistant.client.ui.compose.item
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -21,19 +21,17 @@ import androidx.compose.material.icons.automirrored.filled.ViewList
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.MusicNote
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -141,9 +139,6 @@ internal fun ItemTopBar(
             )
         },
         windowInsets = WindowInsets(0, 0, 0, 0),
-        colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainer
-        ),
         scrollBehavior = scrollBehavior
     )
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
@@ -5,7 +5,6 @@ package io.music_assistant.client.ui.compose.item
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -138,7 +137,6 @@ internal fun ItemTopBar(
                 playlistActions = playlistActions
             )
         },
-        windowInsets = WindowInsets(0, 0, 0, 0),
         scrollBehavior = scrollBehavior
     )
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/AdaptiveMediaGrid.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/AdaptiveMediaGrid.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.plus
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridState
@@ -48,6 +49,7 @@ fun AdaptiveMediaGrid(
     playlistActions: ActionsViewModel.PlaylistActions,
     libraryActions: ActionsViewModel.LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
+    hostPadding: PaddingValues,
 ) {
     // Detect when we're near the end and trigger load more
     val shouldLoadMore by remember {
@@ -71,7 +73,7 @@ fun AdaptiveMediaGrid(
         modifier = modifier,
         state = gridState,
         columns = GridCells.Adaptive(minSize = 96.dp),
-        contentPadding = PaddingValues(8.dp),
+        contentPadding = hostPadding + PaddingValues(8.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/AdaptiveMediaGrid.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/AdaptiveMediaGrid.kt
@@ -49,7 +49,7 @@ fun AdaptiveMediaGrid(
     playlistActions: ActionsViewModel.PlaylistActions,
     libraryActions: ActionsViewModel.LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
-    hostPadding: PaddingValues,
+    contentPadding: PaddingValues,
 ) {
     // Detect when we're near the end and trigger load more
     val shouldLoadMore by remember {
@@ -73,7 +73,7 @@ fun AdaptiveMediaGrid(
         modifier = modifier,
         state = gridState,
         columns = GridCells.Adaptive(minSize = 96.dp),
-        contentPadding = hostPadding + PaddingValues(8.dp),
+        contentPadding = contentPadding + PaddingValues(8.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryScreen.kt
@@ -2,10 +2,9 @@
 
 package io.music_assistant.client.ui.compose.library
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -27,6 +26,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.PrimaryScrollableTabRow
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -42,10 +42,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import compose.icons.TablerIcons
@@ -55,12 +55,14 @@ import io.music_assistant.client.data.model.server.MediaType
 import io.music_assistant.client.data.model.server.QueueOption
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.ToastHost
+import io.music_assistant.client.ui.compose.common.ToastState
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import org.koin.compose.koinInject
 
 @Composable
 fun LibraryScreen(
+    hostPadding: PaddingValues,
     initialTabType: MediaType?,
     onBack: () -> Unit,
     onNavigateClick: (AppMediaItem) -> Unit,
@@ -99,20 +101,22 @@ fun LibraryScreen(
     }
 
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .nestedScroll(scrollBehavior.nestedScrollConnection)
-    ) {
-        LibraryTopBar(
-            onBack = onBack,
-            tabs = state.tabs,
-            onTabSelected = viewModel::onTabSelected,
-            isRowMode = isRowMode,
-            onToggleViewMode = viewModel::toggleItemsRowMode,
-            scrollBehavior = scrollBehavior,
-        )
+    Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        topBar = {
+            LibraryTopBar(
+                onBack = onBack,
+                tabs = state.tabs,
+                onTabSelected = viewModel::onTabSelected,
+                isRowMode = isRowMode,
+                onToggleViewMode = viewModel::toggleItemsRowMode,
+                scrollBehavior = scrollBehavior,
+            )
+        }
+    ) { contentPadding ->
         Library(
+            modifier = Modifier.padding(contentPadding),
+            hostPadding = hostPadding,
             state = state,
             serverUrl = serverUrl,
             isRowMode = isRowMode,
@@ -192,7 +196,6 @@ private fun LibraryTopBar(
                 )
             }
         },
-        windowInsets = WindowInsets(0, 0, 0, 0),
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainer
         ),
@@ -202,10 +205,11 @@ private fun LibraryTopBar(
 
 @Composable
 private fun Library(
+    modifier: Modifier,
     state: LibraryViewModel.State,
     serverUrl: String?,
     isRowMode: Boolean,
-    toastState: io.music_assistant.client.ui.compose.common.ToastState,
+    toastState: ToastState,
     onNavigateClick: (AppMediaItem) -> Unit,
     onPlayClick: (AppMediaItem, QueueOption, Boolean) -> Unit,
     onCreatePlaylistClick: () -> Unit,
@@ -217,10 +221,11 @@ private fun Library(
     playlistActions: ActionsViewModel.PlaylistActions,
     libraryActions: ActionsViewModel.LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
+    hostPadding: PaddingValues,
 ) {
     val selectedTab = state.tabs.find { it.isSelected } ?: state.tabs.first()
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = modifier) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -269,6 +274,7 @@ private fun Library(
                     playlistActions = playlistActions,
                     libraryActions = libraryActions,
                     progressActions = progressActions,
+                    hostPadding
                 )
             }
         }
@@ -347,6 +353,7 @@ private fun TabContent(
     playlistActions: ActionsViewModel.PlaylistActions,
     libraryActions: ActionsViewModel.LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
+    hostPadding: PaddingValues,
 ) {
     // Create separate grid states for each tab to preserve scroll position
     val artistsGridState = rememberLazyGridState()
@@ -425,6 +432,7 @@ private fun TabContent(
                                 playlistActions = playlistActions,
                                 libraryActions = libraryActions,
                                 progressActions = progressActions,
+                                hostPadding
                             )
                         }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryScreen.kt
@@ -61,7 +61,7 @@ import org.koin.compose.koinInject
 
 @Composable
 fun LibraryScreen(
-    hostPadding: PaddingValues,
+    contentPadding: PaddingValues,
     initialTabType: MediaType?,
     onBack: () -> Unit,
     onNavigateClick: (AppMediaItem) -> Unit,
@@ -113,7 +113,7 @@ fun LibraryScreen(
         )
 
         Library(
-            hostPadding = hostPadding,
+            contentPadding = contentPadding,
             state = state,
             serverUrl = serverUrl,
             isRowMode = isRowMode,
@@ -218,7 +218,7 @@ private fun Library(
     playlistActions: ActionsViewModel.PlaylistActions,
     libraryActions: ActionsViewModel.LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
-    hostPadding: PaddingValues,
+    contentPadding: PaddingValues,
 ) {
     val selectedTab = state.tabs.find { it.isSelected } ?: state.tabs.first()
 
@@ -271,7 +271,7 @@ private fun Library(
                     playlistActions = playlistActions,
                     libraryActions = libraryActions,
                     progressActions = progressActions,
-                    hostPadding
+                    contentPadding
                 )
             }
         }
@@ -350,7 +350,7 @@ private fun TabContent(
     playlistActions: ActionsViewModel.PlaylistActions,
     libraryActions: ActionsViewModel.LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
-    hostPadding: PaddingValues,
+    contentPadding: PaddingValues,
 ) {
     // Create separate grid states for each tab to preserve scroll position
     val artistsGridState = rememberLazyGridState()
@@ -429,7 +429,7 @@ private fun TabContent(
                                 playlistActions = playlistActions,
                                 libraryActions = libraryActions,
                                 progressActions = progressActions,
-                                hostPadding
+                                contentPadding = contentPadding
                             )
                         }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryScreen.kt
@@ -44,7 +44,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import compose.icons.TablerIcons
@@ -57,6 +56,7 @@ import io.music_assistant.client.ui.compose.common.ToastHost
 import io.music_assistant.client.ui.compose.common.ToastState
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
+import io.music_assistant.client.ui.compose.nav.Screen
 import org.koin.compose.koinInject
 
 @Composable
@@ -99,19 +99,18 @@ fun LibraryScreen(
         }
     }
 
-    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
-    Column(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
+    Screen(
+        topBar = { scrollBehavior ->
+            LibraryTopBar(
+                onBack = onBack,
+                tabs = state.tabs,
+                onTabSelected = viewModel::onTabSelected,
+                isRowMode = isRowMode,
+                onToggleViewMode = viewModel::toggleItemsRowMode,
+                scrollBehavior = scrollBehavior,
+            )
+        }
     ) {
-        LibraryTopBar(
-            onBack = onBack,
-            tabs = state.tabs,
-            onTabSelected = viewModel::onTabSelected,
-            isRowMode = isRowMode,
-            onToggleViewMode = viewModel::toggleItemsRowMode,
-            scrollBehavior = scrollBehavior,
-        )
-
         Library(
             contentPadding = contentPadding,
             state = state,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.PrimaryScrollableTabRow
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -101,21 +100,19 @@ fun LibraryScreen(
     }
 
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
-    Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-        topBar = {
-            LibraryTopBar(
-                onBack = onBack,
-                tabs = state.tabs,
-                onTabSelected = viewModel::onTabSelected,
-                isRowMode = isRowMode,
-                onToggleViewMode = viewModel::toggleItemsRowMode,
-                scrollBehavior = scrollBehavior,
-            )
-        }
-    ) { contentPadding ->
+    Column(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
+    ) {
+        LibraryTopBar(
+            onBack = onBack,
+            tabs = state.tabs,
+            onTabSelected = viewModel::onTabSelected,
+            isRowMode = isRowMode,
+            onToggleViewMode = viewModel::toggleItemsRowMode,
+            scrollBehavior = scrollBehavior,
+        )
+
         Library(
-            modifier = Modifier.padding(contentPadding),
             hostPadding = hostPadding,
             state = state,
             serverUrl = serverUrl,
@@ -205,7 +202,7 @@ private fun LibraryTopBar(
 
 @Composable
 private fun Library(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     state: LibraryViewModel.State,
     serverUrl: String?,
     isRowMode: Boolean,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/AppNavigation.kt
@@ -1,8 +1,8 @@
 package io.music_assistant.client.ui.compose.nav
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Settings
@@ -149,7 +149,7 @@ fun NavigationRoot(modifier: Modifier = Modifier) {
             }
         }
     ) { contentPadding ->
-        Box(modifier = Modifier.padding(contentPadding)) {
+        Box {
             // Main navigation content
             NavDisplay(
                 modifier = Modifier.fillMaxSize(),
@@ -163,10 +163,14 @@ fun NavigationRoot(modifier: Modifier = Modifier) {
                 ),
                 entryProvider = entryProvider {
                     entry<NavScreen.Home> {
-                        HomeScreen(navigateTo = { screen -> backStack.add(screen) })
+                        HomeScreen(
+                            hostPadding = PaddingValues(bottom = contentPadding.calculateBottomPadding()),
+                            navigateTo = { screen -> backStack.add(screen) })
                     }
+
                     entry<NavScreen.Settings> {
                         SettingsScreen(
+                            hostPadding = PaddingValues(bottom = contentPadding.calculateBottomPadding()),
                             goHome = goHome,
                             exitApp = { exitApp() }
                         )

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/AppNavigation.kt
@@ -1,17 +1,8 @@
 package io.music_assistant.client.ui.compose.nav
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -19,7 +10,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
@@ -123,67 +113,41 @@ fun NavigationRoot(modifier: Modifier = Modifier) {
     val bottomSheetStrategy = remember { BottomSheetSceneStrategy<NavKey>() }
     val dialogStrategy = remember { DialogSceneStrategy<NavKey>() }
 
-    val goHome: () -> Unit = {
-        backStack.clear()
-        backStack.add(NavScreen.Home)
-    }
-
-    Scaffold(
-        bottomBar = {
-            NavigationBar(modifier = Modifier.height(88.dp)) {
-                NavigationBarItem(
-                    selected = backStack.last() == NavScreen.Home,
-                    onClick = goHome,
-                    icon = {
-                        Icon(Icons.Default.Home, contentDescription = null)
-                    }
+    Box {
+        // Main navigation content
+        NavDisplay(
+            modifier = Modifier.fillMaxSize(),
+            backStack = backStack,
+            onBack = { backStack.removeLastOrNull() },
+            sceneStrategy = bottomSheetStrategy.then(dialogStrategy),
+            entryDecorators = listOf(
+                rememberSaveableStateHolderNavEntryDecorator(
+                    rememberSaveableStateHolder()
                 )
-
-                NavigationBarItem(
-                    selected = backStack.last() == NavScreen.Settings,
-                    onClick = {
-                        backStack.add(NavScreen.Settings)
-                    },
-                    icon = {
-                        Icon(Icons.Default.Settings, contentDescription = null)
-                    }
-                )
-            }
-        }
-    ) { contentPadding ->
-        Box {
-            // Main navigation content
-            NavDisplay(
-                modifier = Modifier.fillMaxSize(),
-                backStack = backStack,
-                onBack = { backStack.removeLastOrNull() },
-                sceneStrategy = bottomSheetStrategy.then(dialogStrategy),
-                entryDecorators = listOf(
-                    rememberSaveableStateHolderNavEntryDecorator(
-                        rememberSaveableStateHolder()
+            ),
+            entryProvider = entryProvider {
+                entry<NavScreen.Home> {
+                    HomeScreen(
+                        goToSettings = { backStack.add(NavScreen.Settings) }
                     )
-                ),
-                entryProvider = entryProvider {
-                    entry<NavScreen.Home> {
-                        HomeScreen(
-                            hostPadding = PaddingValues(bottom = contentPadding.calculateBottomPadding()),
-                            navigateTo = { screen -> backStack.add(screen) })
-                    }
-
-                    entry<NavScreen.Settings> {
-                        SettingsScreen(
-                            hostPadding = PaddingValues(bottom = contentPadding.calculateBottomPadding()),
-                            goHome = goHome,
-                            exitApp = { exitApp() }
-                        )
-                    }
                 }
-            )
 
-            // Connection status banner - overlays at top, doesn't shrink content
-            ConnectionStatusBanner(
-                modifier = Modifier.align(Alignment.TopCenter)
-            )
-        }
+                entry<NavScreen.Settings> {
+                    SettingsScreen(
+                        goHome = {
+                            ->
+                            backStack.clear()
+                            backStack.add(NavScreen.Home)
+                        },
+                        exitApp = { exitApp() }
+                    )
+                }
+            }
+        )
+
+        // Connection status banner - overlays at top, doesn't shrink content
+        ConnectionStatusBanner(
+            modifier = Modifier.align(Alignment.TopCenter)
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/AppNavigation.kt
@@ -3,6 +3,7 @@ package io.music_assistant.client.ui.compose.nav
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Settings
@@ -18,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
@@ -128,7 +130,7 @@ fun NavigationRoot(modifier: Modifier = Modifier) {
 
     Scaffold(
         bottomBar = {
-            NavigationBar {
+            NavigationBar(modifier = Modifier.height(88.dp)) {
                 NavigationBarItem(
                     selected = backStack.last() == NavScreen.Home,
                     onClick = goHome,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/AppNavigation.kt
@@ -2,7 +2,9 @@ package io.music_assistant.client.ui.compose.nav
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -113,37 +115,39 @@ fun NavigationRoot(modifier: Modifier = Modifier) {
     val bottomSheetStrategy = remember { BottomSheetSceneStrategy<NavKey>() }
     val dialogStrategy = remember { DialogSceneStrategy<NavKey>() }
 
-    Box(modifier = modifier.fillMaxSize()) {
-        // Main navigation content
-        NavDisplay(
-            modifier = Modifier.fillMaxSize(),
-            backStack = backStack,
-            onBack = { backStack.removeLastOrNull() },
-            sceneStrategy = bottomSheetStrategy.then(dialogStrategy),
-            entryDecorators = listOf(
-                rememberSaveableStateHolderNavEntryDecorator(
-                    rememberSaveableStateHolder()
-                )
-            ),
-            entryProvider = entryProvider {
-                entry<NavScreen.Home> {
-                    HomeScreen(navigateTo = { screen -> backStack.add(screen) })
-                }
-                entry<NavScreen.Settings> {
-                    SettingsScreen(
-                        goHome = {
-                            backStack.clear()
-                            backStack.add(NavScreen.Home)
-                        },
-                        exitApp = { exitApp() }
+    Scaffold { contentPadding ->
+        Box(modifier = Modifier.padding(contentPadding)) {
+            // Main navigation content
+            NavDisplay(
+                modifier = Modifier.fillMaxSize(),
+                backStack = backStack,
+                onBack = { backStack.removeLastOrNull() },
+                sceneStrategy = bottomSheetStrategy.then(dialogStrategy),
+                entryDecorators = listOf(
+                    rememberSaveableStateHolderNavEntryDecorator(
+                        rememberSaveableStateHolder()
                     )
+                ),
+                entryProvider = entryProvider {
+                    entry<NavScreen.Home> {
+                        HomeScreen(navigateTo = { screen -> backStack.add(screen) })
+                    }
+                    entry<NavScreen.Settings> {
+                        SettingsScreen(
+                            goHome = {
+                                backStack.clear()
+                                backStack.add(NavScreen.Home)
+                            },
+                            exitApp = { exitApp() }
+                        )
+                    }
                 }
-            }
-        )
+            )
 
-        // Connection status banner - overlays at top, doesn't shrink content
-        ConnectionStatusBanner(
-            modifier = Modifier.align(Alignment.TopCenter)
-        )
+            // Connection status banner - overlays at top, doesn't shrink content
+            ConnectionStatusBanner(
+                modifier = Modifier.align(Alignment.TopCenter)
+            )
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/AppNavigation.kt
@@ -3,7 +3,13 @@ package io.music_assistant.client.ui.compose.nav
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -115,7 +121,34 @@ fun NavigationRoot(modifier: Modifier = Modifier) {
     val bottomSheetStrategy = remember { BottomSheetSceneStrategy<NavKey>() }
     val dialogStrategy = remember { DialogSceneStrategy<NavKey>() }
 
-    Scaffold { contentPadding ->
+    val goHome: () -> Unit = {
+        backStack.clear()
+        backStack.add(NavScreen.Home)
+    }
+
+    Scaffold(
+        bottomBar = {
+            NavigationBar {
+                NavigationBarItem(
+                    selected = backStack.last() == NavScreen.Home,
+                    onClick = goHome,
+                    icon = {
+                        Icon(Icons.Default.Home, contentDescription = null)
+                    }
+                )
+
+                NavigationBarItem(
+                    selected = backStack.last() == NavScreen.Settings,
+                    onClick = {
+                        backStack.add(NavScreen.Settings)
+                    },
+                    icon = {
+                        Icon(Icons.Default.Settings, contentDescription = null)
+                    }
+                )
+            }
+        }
+    ) { contentPadding ->
         Box(modifier = Modifier.padding(contentPadding)) {
             // Main navigation content
             NavDisplay(
@@ -134,10 +167,7 @@ fun NavigationRoot(modifier: Modifier = Modifier) {
                     }
                     entry<NavScreen.Settings> {
                         SettingsScreen(
-                            goHome = {
-                                backStack.clear()
-                                backStack.add(NavScreen.Home)
-                            },
+                            goHome = goHome,
                             exitApp = { exitApp() }
                         )
                     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/Screen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/Screen.kt
@@ -1,0 +1,29 @@
+package io.music_assistant.client.ui.compose.nav
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Surface
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+
+/**
+ * Simplified version of [androidx.compose.material3.Scaffold] that just supports a top bar. Can be
+ * nested in a [androidx.compose.material3.Scaffold] with a bottom bar without introducing the
+ * extra recomposition of a nesting set [androidx.compose.material3.Scaffold] composables.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun Screen(topBar: @Composable (TopAppBarScrollBehavior) -> Unit, content: @Composable () -> Unit) {
+    Surface {
+        val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+        Column(
+            modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        ) {
+            topBar(scrollBehavior)
+            content()
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
@@ -25,14 +25,12 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.capitalize
 import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.unit.dp
@@ -54,6 +52,7 @@ import io.music_assistant.client.ui.compose.common.items.TrackWithMenu
 import io.music_assistant.client.ui.compose.common.providers.ProviderIcon
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
+import io.music_assistant.client.ui.compose.nav.Screen
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -73,20 +72,18 @@ fun SearchScreen(
         }
     }
 
-    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
-    LaunchedEffect(state.searchState.query) {
-        scrollBehavior.state.heightOffset = 0f
-    }
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .nestedScroll(scrollBehavior.nestedScrollConnection)
-    ) {
-        SearchTopBar(
-            onBack = onBack,
-            scrollBehavior = scrollBehavior,
-        )
+    Screen(
+        topBar = { scrollBehaviour ->
+            LaunchedEffect(state.searchState.query) {
+                scrollBehaviour.state.heightOffset = 0f
+            }
 
+            SearchTopBar(
+                onBack = onBack,
+                scrollBehavior = scrollBehaviour,
+            )
+        }
+    ) {
         SearchContent(
             state = state,
             serverUrl = serverUrl,
@@ -136,19 +133,13 @@ private fun SearchTopBar(
 ) {
     TopAppBar(
         title = {
-            Text(
-                text = "Global search",
-                style = MaterialTheme.typography.titleLarge
-            )
+            Text(text = "Global search")
         },
         navigationIcon = {
             IconButton(onClick = onBack) {
                 Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
             }
         },
-        colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainer
-        ),
         scrollBehavior = scrollBehavior
     )
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
@@ -5,7 +5,6 @@ package io.music_assistant.client.ui.compose.search
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
@@ -147,7 +146,6 @@ private fun SearchTopBar(
                 Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
             }
         },
-        windowInsets = WindowInsets(0, 0, 0, 0),
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainer
         ),

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
@@ -4,13 +4,14 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.plus
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
@@ -34,11 +35,13 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -47,6 +50,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -77,7 +81,7 @@ import org.publicvalue.multiplatform.qrcode.ScannerWithPermissions
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SettingsScreen(goHome: () -> Unit, exitApp: () -> Unit) {
+fun SettingsScreen(hostPadding: PaddingValues, goHome: () -> Unit, exitApp: () -> Unit) {
     val themeViewModel = koinViewModel<ThemeViewModel>()
     val theme = themeViewModel.theme.collectAsStateWithLifecycle(ThemeSetting.FollowSystem)
     val viewModel = koinViewModel<SettingsViewModel>()
@@ -97,172 +101,178 @@ fun SettingsScreen(goHome: () -> Unit, exitApp: () -> Unit) {
         }
     }
 
-    Column(
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+
+    Scaffold(
         modifier = Modifier
-            .background(color = MaterialTheme.colorScheme.background)
-            .fillMaxSize()
-    ) {
-        TopAppBar(
-            title = { Text("Settings") },
-            actions = {
-                ThemeChooser(
-                    modifier = Modifier.padding(end = 16.dp),
-                    currentTheme = theme.value
-                ) { changedTheme ->
-                    themeViewModel.switchTheme(changedTheme)
-                }
-            },
-            windowInsets = WindowInsets(0, 0, 0, 0)
-        )
-
-        // Content
-        val scrollState = rememberScrollState()
-
+            .nestedScroll(scrollBehavior.nestedScrollConnection),
+        topBar = {
+            TopAppBar(
+                title = { Text("Settings") },
+                actions = {
+                    ThemeChooser(
+                        modifier = Modifier.padding(end = 16.dp),
+                        currentTheme = theme.value
+                    ) { changedTheme ->
+                        themeViewModel.switchTheme(changedTheme)
+                    }
+                },
+                scrollBehavior = scrollBehavior
+            )
+        }
+    ) { contentPadding ->
         Column(
             modifier = Modifier
+                .padding(contentPadding + hostPadding)
+                .background(color = MaterialTheme.colorScheme.background)
                 .fillMaxSize()
-                .verticalScroll(scrollState)
-                .padding(horizontal = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            var ipAddress by remember { mutableStateOf(Defaults.URI) }
-            var port by remember { mutableStateOf(Defaults.PORT.toString()) }
-            var isTls by remember { mutableStateOf(false) }
-
-            LaunchedEffect(savedConnectionInfo) {
-                savedConnectionInfo?.let {
-                    ipAddress = it.host
-                    port = it.port.toString()
-                    isTls = it.isTls
-                }
-            }
-
-            // Track if we've already attempted auto-reconnect
-            var autoReconnectAttempted by remember { mutableStateOf(false) }
-
-            // Auto-reconnect on error ONLY if user hasn't changed the connection info
-            // This prevents auto-reconnect to old server when user is trying to connect to new server
-            // Does NOT auto-reconnect when user is using WebRTC (different failure mode)
-            val preferredMethod by viewModel.preferredConnectionMethod.collectAsStateWithLifecycle()
-            LaunchedEffect(sessionState) {
-                val connInfo = savedConnectionInfo
-                if (sessionState is SessionState.Disconnected.Error &&
-                    connInfo != null &&
-                    !autoReconnectAttempted &&
-                    preferredMethod != "webrtc"
-                ) {
-                    // Only auto-reconnect if text fields match saved connection info
-                    // (i.e., user hasn't changed anything)
-                    val userChangedConnectionInfo =
-                        ipAddress != connInfo.host ||
-                                port != connInfo.port.toString() ||
-                                isTls != connInfo.isTls
-
-                    if (!userChangedConnectionInfo) {
-                        // User is trying to reconnect to same server - auto-retry
-                        autoReconnectAttempted = true
-                        viewModel.attemptConnection(
-                            connInfo.host,
-                            connInfo.port.toString(),
-                            connInfo.isTls
-                        )
-                    }
-                    // If user changed connection info, don't auto-retry - let them manually retry
-                } else if (sessionState is SessionState.Connected) {
-                    // Reset flag on successful connection
-                    autoReconnectAttempted = false
-                }
-            }
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp)
+                    .verticalScroll(rememberScrollState())                ,
+                verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                if (!isAuthenticated) {
-                    OutlinedButton(onClick = exitApp) { Text("EXIT APP") }
-                }
-            }
+                var ipAddress by remember { mutableStateOf(Defaults.URI) }
+                var port by remember { mutableStateOf(Defaults.PORT.toString()) }
+                var isTls by remember { mutableStateOf(false) }
 
-            when (sessionState) {
-                is SessionState.Disconnected -> {
-                    // State 1 & 2: Disconnected (with or without token)
-                    // Show connection method tabs
-                    ConnectionMethodTabs(
-                        viewModel = viewModel,
-                        ipAddress = ipAddress,
-                        port = port,
-                        isTls = isTls,
-                        onIpAddressChange = { ipAddress = it },
-                        onPortChange = { port = it },
-                        onTlsChange = { isTls = it },
-                        onDirectConnect = {
+                LaunchedEffect(savedConnectionInfo) {
+                    savedConnectionInfo?.let {
+                        ipAddress = it.host
+                        port = it.port.toString()
+                        isTls = it.isTls
+                    }
+                }
+
+                // Track if we've already attempted auto-reconnect
+                var autoReconnectAttempted by remember { mutableStateOf(false) }
+
+                // Auto-reconnect on error ONLY if user hasn't changed the connection info
+                // This prevents auto-reconnect to old server when user is trying to connect to new server
+                // Does NOT auto-reconnect when user is using WebRTC (different failure mode)
+                val preferredMethod by viewModel.preferredConnectionMethod.collectAsStateWithLifecycle()
+                LaunchedEffect(sessionState) {
+                    val connInfo = savedConnectionInfo
+                    if (sessionState is SessionState.Disconnected.Error &&
+                        connInfo != null &&
+                        !autoReconnectAttempted &&
+                        preferredMethod != "webrtc"
+                    ) {
+                        // Only auto-reconnect if text fields match saved connection info
+                        // (i.e., user hasn't changed anything)
+                        val userChangedConnectionInfo =
+                            ipAddress != connInfo.host ||
+                                    port != connInfo.port.toString() ||
+                                    isTls != connInfo.isTls
+
+                        if (!userChangedConnectionInfo) {
+                            // User is trying to reconnect to same server - auto-retry
+                            autoReconnectAttempted = true
                             viewModel.attemptConnection(
-                                ipAddress,
-                                port,
-                                isTls
-                            )
-                        },
-                        directConnectEnabled = ipAddress.isValidHost() && port.isIpPort(),
-                        sessionState = sessionState,
-                        connectionHistory = connectionHistory,
-                    )
-                }
-
-                SessionState.Connecting -> {
-                    ConnectingSection(
-                        ipAddress = ipAddress,
-                        port = port,
-                        preferredMethod = preferredMethod,
-                        onCancel = { viewModel.disconnect() }
-                    )
-                }
-
-                is SessionState.Reconnecting -> {
-                    ConnectingSection(
-                        ipAddress = ipAddress,
-                        port = port,
-                        preferredMethod = preferredMethod,
-                        onCancel = { viewModel.disconnect() }
-                    )
-                }
-
-                is SessionState.Connected -> {
-                    val connectedState = sessionState as SessionState.Connected
-
-                    // Server Info Section (always shown when connected)
-                    ServerInfoSection(
-                        connectionInfo = savedConnectionInfo,
-                        serverInfo = connectedState.serverInfo,
-                        isWebRTC = connectedState is SessionState.Connected.WebRTC,
-                        onDisconnect = { viewModel.disconnect() }
-                    )
-
-                    LoginSection(connectedState.user)
-
-                    when (dataConnection) {
-                        DataConnectionState.Authenticated -> {
-                            // State 4: Connected and authenticated
-
-                            // Local Player Section
-                            SendspinSection(
-                                viewModel = viewModel,
+                                connInfo.host,
+                                connInfo.port.toString(),
+                                connInfo.isTls
                             )
                         }
-
-                        else -> Unit
+                        // If user changed connection info, don't auto-retry - let them manually retry
+                    } else if (sessionState is SessionState.Connected) {
+                        // Reset flag on successful connection
+                        autoReconnectAttempted = false
                     }
                 }
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    if (!isAuthenticated) {
+                        OutlinedButton(onClick = exitApp) { Text("EXIT APP") }
+                    }
+                }
+
+                when (sessionState) {
+                    is SessionState.Disconnected -> {
+                        // State 1 & 2: Disconnected (with or without token)
+                        // Show connection method tabs
+                        ConnectionMethodTabs(
+                            viewModel = viewModel,
+                            ipAddress = ipAddress,
+                            port = port,
+                            isTls = isTls,
+                            onIpAddressChange = { ipAddress = it },
+                            onPortChange = { port = it },
+                            onTlsChange = { isTls = it },
+                            onDirectConnect = {
+                                viewModel.attemptConnection(
+                                    ipAddress,
+                                    port,
+                                    isTls
+                                )
+                            },
+                            directConnectEnabled = ipAddress.isValidHost() && port.isIpPort(),
+                            sessionState = sessionState,
+                            connectionHistory = connectionHistory,
+                        )
+                    }
+
+                    SessionState.Connecting -> {
+                        ConnectingSection(
+                            ipAddress = ipAddress,
+                            port = port,
+                            preferredMethod = preferredMethod,
+                            onCancel = { viewModel.disconnect() }
+                        )
+                    }
+
+                    is SessionState.Reconnecting -> {
+                        ConnectingSection(
+                            ipAddress = ipAddress,
+                            port = port,
+                            preferredMethod = preferredMethod,
+                            onCancel = { viewModel.disconnect() }
+                        )
+                    }
+
+                    is SessionState.Connected -> {
+                        val connectedState = sessionState as SessionState.Connected
+
+                        // Server Info Section (always shown when connected)
+                        ServerInfoSection(
+                            connectionInfo = savedConnectionInfo,
+                            serverInfo = connectedState.serverInfo,
+                            isWebRTC = connectedState is SessionState.Connected.WebRTC,
+                            onDisconnect = { viewModel.disconnect() }
+                        )
+
+                        LoginSection(connectedState.user)
+
+                        when (dataConnection) {
+                            DataConnectionState.Authenticated -> {
+                                // State 4: Connected and authenticated
+
+                                // Local Player Section
+                                SendspinSection(
+                                    viewModel = viewModel,
+                                )
+                            }
+
+                            else -> Unit
+                        }
+                    }
+                }
+
+                // Misc settings - always visible
+                MiscSection(
+                    onShareLogs = { viewModel.shareLogs() },
+                    hasCrashLog = hasCrashLog,
+                    onShareCrashLog = { viewModel.shareCrashLog() },
+                    onDeleteCrashLog = { viewModel.deleteCrashLog() }
+                )
+
+                Spacer(modifier = Modifier.size(16.dp))
             }
-
-            // Misc settings - always visible
-            MiscSection(
-                onShareLogs = { viewModel.shareLogs() },
-                hasCrashLog = hasCrashLog,
-                onShareCrashLog = { viewModel.shareCrashLog() },
-                onDeleteCrashLog = { viewModel.deleteCrashLog() }
-            )
-
-            Spacer(modifier = Modifier.size(16.dp))
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -79,7 +78,7 @@ import org.publicvalue.multiplatform.qrcode.ScannerWithPermissions
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SettingsScreen(hostPadding: PaddingValues, goHome: () -> Unit, exitApp: () -> Unit) {
+fun SettingsScreen(goHome: () -> Unit, exitApp: () -> Unit) {
     val themeViewModel = koinViewModel<ThemeViewModel>()
     val theme = themeViewModel.theme.collectAsStateWithLifecycle(ThemeSetting.FollowSystem)
     val viewModel = koinViewModel<SettingsViewModel>()
@@ -119,7 +118,6 @@ fun SettingsScreen(hostPadding: PaddingValues, goHome: () -> Unit, exitApp: () -
 
         Column(
             modifier = Modifier
-                .padding(hostPadding)
                 .background(color = MaterialTheme.colorScheme.background)
                 .fillMaxSize()
         ) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.plus
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
@@ -35,7 +34,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.PrimaryTabRow
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -103,27 +101,25 @@ fun SettingsScreen(hostPadding: PaddingValues, goHome: () -> Unit, exitApp: () -
 
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
 
-    Scaffold(
-        modifier = Modifier
-            .nestedScroll(scrollBehavior.nestedScrollConnection),
-        topBar = {
-            TopAppBar(
-                title = { Text("Settings") },
-                actions = {
-                    ThemeChooser(
-                        modifier = Modifier.padding(end = 16.dp),
-                        currentTheme = theme.value
-                    ) { changedTheme ->
-                        themeViewModel.switchTheme(changedTheme)
-                    }
-                },
-                scrollBehavior = scrollBehavior
-            )
-        }
-    ) { contentPadding ->
+    Column(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
+    ) {
+        TopAppBar(
+            title = { Text("Settings") },
+            actions = {
+                ThemeChooser(
+                    modifier = Modifier.padding(end = 16.dp),
+                    currentTheme = theme.value
+                ) { changedTheme ->
+                    themeViewModel.switchTheme(changedTheme)
+                }
+            },
+            scrollBehavior = scrollBehavior
+        )
+
         Column(
             modifier = Modifier
-                .padding(contentPadding + hostPadding)
+                .padding(hostPadding)
                 .background(color = MaterialTheme.colorScheme.background)
                 .fillMaxSize()
         ) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.ExpandMore
@@ -111,6 +112,13 @@ fun SettingsScreen(goHome: () -> Unit, exitApp: () -> Unit) {
                     currentTheme = theme.value
                 ) { changedTheme ->
                     themeViewModel.switchTheme(changedTheme)
+                }
+            },
+            navigationIcon = {
+                if (isAuthenticated) {
+                    IconButton(onClick = goHome) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
+                    }
                 }
             },
             scrollBehavior = scrollBehavior

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
@@ -37,6 +38,7 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -73,6 +75,7 @@ import org.publicvalue.multiplatform.qrcode.CameraPosition
 import org.publicvalue.multiplatform.qrcode.CodeType
 import org.publicvalue.multiplatform.qrcode.ScannerWithPermissions
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(goHome: () -> Unit, exitApp: () -> Unit) {
     val themeViewModel = koinViewModel<ThemeViewModel>()
@@ -99,22 +102,18 @@ fun SettingsScreen(goHome: () -> Unit, exitApp: () -> Unit) {
             .background(color = MaterialTheme.colorScheme.background)
             .fillMaxSize()
     ) {
-        // Header
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(all = 16.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = "Settings",
-                style = MaterialTheme.typography.titleLarge,
-            )
-            ThemeChooser(currentTheme = theme.value) { changedTheme ->
-                themeViewModel.switchTheme(changedTheme)
-            }
-        }
+        TopAppBar(
+            title = { Text("Settings") },
+            actions = {
+                ThemeChooser(
+                    modifier = Modifier.padding(end = 16.dp),
+                    currentTheme = theme.value
+                ) { changedTheme ->
+                    themeViewModel.switchTheme(changedTheme)
+                }
+            },
+            windowInsets = WindowInsets(0, 0, 0, 0)
+        )
 
         // Content
         val scrollState = rememberScrollState()

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
@@ -178,9 +178,7 @@ fun SettingsScreen(goHome: () -> Unit, exitApp: () -> Unit) {
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.Center
             ) {
-                if (isAuthenticated) {
-                    Button(onClick = goHome) { Text("GO HOME") }
-                } else {
+                if (!isAuthenticated) {
                     OutlinedButton(onClick = exitApp) { Text("EXIT APP") }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -48,7 +47,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -65,6 +63,7 @@ import io.music_assistant.client.ui.compose.auth.AuthenticationPanel
 import io.music_assistant.client.ui.compose.common.OverflowMenu
 import io.music_assistant.client.ui.compose.common.OverflowMenuOption
 import io.music_assistant.client.ui.compose.nav.BackHandler
+import io.music_assistant.client.ui.compose.nav.Screen
 import io.music_assistant.client.ui.theme.ThemeSetting
 import io.music_assistant.client.ui.theme.ThemeViewModel
 import io.music_assistant.client.utils.DataConnectionState
@@ -99,31 +98,29 @@ fun SettingsScreen(goHome: () -> Unit, exitApp: () -> Unit) {
         }
     }
 
-    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
-
-    Column(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
-    ) {
-        TopAppBar(
-            title = { Text("Settings") },
-            actions = {
-                ThemeChooser(
-                    modifier = Modifier.padding(end = 16.dp),
-                    currentTheme = theme.value
-                ) { changedTheme ->
-                    themeViewModel.switchTheme(changedTheme)
-                }
-            },
-            navigationIcon = {
-                if (isAuthenticated) {
-                    IconButton(onClick = goHome) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
+    Screen(
+        topBar = { scrollBehavior ->
+            TopAppBar(
+                title = { Text("Settings") },
+                actions = {
+                    ThemeChooser(
+                        modifier = Modifier.padding(end = 16.dp),
+                        currentTheme = theme.value
+                    ) { changedTheme ->
+                        themeViewModel.switchTheme(changedTheme)
                     }
-                }
-            },
-            scrollBehavior = scrollBehavior
-        )
-
+                },
+                navigationIcon = {
+                    if (isAuthenticated) {
+                        IconButton(onClick = goHome) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
+                        }
+                    }
+                },
+                scrollBehavior = scrollBehavior
+            )
+        }
+    ) {
         Column(
             modifier = Modifier
                 .background(color = MaterialTheme.colorScheme.background)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
@@ -6,14 +6,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CornerSize
@@ -36,7 +33,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.PrimaryTabRow
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -56,11 +52,11 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.music_assistant.client.api.ConnectionInfo
 import io.music_assistant.client.api.Defaults
-import io.music_assistant.client.settings.ConnectionHistoryEntry
-import io.music_assistant.client.settings.ConnectionType
 import io.music_assistant.client.data.model.server.ServerInfo
 import io.music_assistant.client.data.model.server.User
 import io.music_assistant.client.player.sendspin.audio.Codecs
+import io.music_assistant.client.settings.ConnectionHistoryEntry
+import io.music_assistant.client.settings.ConnectionType
 import io.music_assistant.client.ui.compose.auth.AuthenticationPanel
 import io.music_assistant.client.ui.compose.common.OverflowMenu
 import io.music_assistant.client.ui.compose.common.OverflowMenuOption
@@ -98,186 +94,178 @@ fun SettingsScreen(goHome: () -> Unit, exitApp: () -> Unit) {
         }
     }
 
-    Scaffold(
-        containerColor = MaterialTheme.colorScheme.background,
-        contentWindowInsets = WindowInsets(0, 0, 0, 0),
-    ) { scaffoldPadding ->
+    Column(
+        modifier = Modifier
+            .background(color = MaterialTheme.colorScheme.background)
+            .fillMaxSize()
+    ) {
+        // Header
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(all = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Settings",
+                style = MaterialTheme.typography.titleLarge,
+            )
+            ThemeChooser(currentTheme = theme.value) { changedTheme ->
+                themeViewModel.switchTheme(changedTheme)
+            }
+        }
+
+        // Content
+        val scrollState = rememberScrollState()
+
         Column(
             modifier = Modifier
-                .background(color = MaterialTheme.colorScheme.background)
                 .fillMaxSize()
-                .padding(scaffoldPadding)
-                .consumeWindowInsets(scaffoldPadding)
-                .systemBarsPadding(),
+                .verticalScroll(scrollState)
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            // Header
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(all = 16.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = "Settings",
-                    style = MaterialTheme.typography.titleLarge,
-                )
-                ThemeChooser(currentTheme = theme.value) { changedTheme ->
-                    themeViewModel.switchTheme(changedTheme)
+            var ipAddress by remember { mutableStateOf(Defaults.URI) }
+            var port by remember { mutableStateOf(Defaults.PORT.toString()) }
+            var isTls by remember { mutableStateOf(false) }
+
+            LaunchedEffect(savedConnectionInfo) {
+                savedConnectionInfo?.let {
+                    ipAddress = it.host
+                    port = it.port.toString()
+                    isTls = it.isTls
                 }
             }
 
-            // Content
-            val scrollState = rememberScrollState()
+            // Track if we've already attempted auto-reconnect
+            var autoReconnectAttempted by remember { mutableStateOf(false) }
 
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .verticalScroll(scrollState)
-                    .padding(horizontal = 16.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                var ipAddress by remember { mutableStateOf(Defaults.URI) }
-                var port by remember { mutableStateOf(Defaults.PORT.toString()) }
-                var isTls by remember { mutableStateOf(false) }
+            // Auto-reconnect on error ONLY if user hasn't changed the connection info
+            // This prevents auto-reconnect to old server when user is trying to connect to new server
+            // Does NOT auto-reconnect when user is using WebRTC (different failure mode)
+            val preferredMethod by viewModel.preferredConnectionMethod.collectAsStateWithLifecycle()
+            LaunchedEffect(sessionState) {
+                val connInfo = savedConnectionInfo
+                if (sessionState is SessionState.Disconnected.Error &&
+                    connInfo != null &&
+                    !autoReconnectAttempted &&
+                    preferredMethod != "webrtc"
+                ) {
+                    // Only auto-reconnect if text fields match saved connection info
+                    // (i.e., user hasn't changed anything)
+                    val userChangedConnectionInfo =
+                        ipAddress != connInfo.host ||
+                                port != connInfo.port.toString() ||
+                                isTls != connInfo.isTls
 
-                LaunchedEffect(savedConnectionInfo) {
-                    savedConnectionInfo?.let {
-                        ipAddress = it.host
-                        port = it.port.toString()
-                        isTls = it.isTls
+                    if (!userChangedConnectionInfo) {
+                        // User is trying to reconnect to same server - auto-retry
+                        autoReconnectAttempted = true
+                        viewModel.attemptConnection(
+                            connInfo.host,
+                            connInfo.port.toString(),
+                            connInfo.isTls
+                        )
                     }
+                    // If user changed connection info, don't auto-retry - let them manually retry
+                } else if (sessionState is SessionState.Connected) {
+                    // Reset flag on successful connection
+                    autoReconnectAttempted = false
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center
+            ) {
+                if (isAuthenticated) {
+                    Button(onClick = goHome) { Text("GO HOME") }
+                } else {
+                    OutlinedButton(onClick = exitApp) { Text("EXIT APP") }
+                }
+            }
+
+            when (sessionState) {
+                is SessionState.Disconnected -> {
+                    // State 1 & 2: Disconnected (with or without token)
+                    // Show connection method tabs
+                    ConnectionMethodTabs(
+                        viewModel = viewModel,
+                        ipAddress = ipAddress,
+                        port = port,
+                        isTls = isTls,
+                        onIpAddressChange = { ipAddress = it },
+                        onPortChange = { port = it },
+                        onTlsChange = { isTls = it },
+                        onDirectConnect = {
+                            viewModel.attemptConnection(
+                                ipAddress,
+                                port,
+                                isTls
+                            )
+                        },
+                        directConnectEnabled = ipAddress.isValidHost() && port.isIpPort(),
+                        sessionState = sessionState,
+                        connectionHistory = connectionHistory,
+                    )
                 }
 
-                // Track if we've already attempted auto-reconnect
-                var autoReconnectAttempted by remember { mutableStateOf(false) }
+                SessionState.Connecting -> {
+                    ConnectingSection(
+                        ipAddress = ipAddress,
+                        port = port,
+                        preferredMethod = preferredMethod,
+                        onCancel = { viewModel.disconnect() }
+                    )
+                }
 
-                // Auto-reconnect on error ONLY if user hasn't changed the connection info
-                // This prevents auto-reconnect to old server when user is trying to connect to new server
-                // Does NOT auto-reconnect when user is using WebRTC (different failure mode)
-                val preferredMethod by viewModel.preferredConnectionMethod.collectAsStateWithLifecycle()
-                LaunchedEffect(sessionState) {
-                    val connInfo = savedConnectionInfo
-                    if (sessionState is SessionState.Disconnected.Error &&
-                        connInfo != null &&
-                        !autoReconnectAttempted &&
-                        preferredMethod != "webrtc"
-                    ) {
-                        // Only auto-reconnect if text fields match saved connection info
-                        // (i.e., user hasn't changed anything)
-                        val userChangedConnectionInfo =
-                            ipAddress != connInfo.host ||
-                                    port != connInfo.port.toString() ||
-                                    isTls != connInfo.isTls
+                is SessionState.Reconnecting -> {
+                    ConnectingSection(
+                        ipAddress = ipAddress,
+                        port = port,
+                        preferredMethod = preferredMethod,
+                        onCancel = { viewModel.disconnect() }
+                    )
+                }
 
-                        if (!userChangedConnectionInfo) {
-                            // User is trying to reconnect to same server - auto-retry
-                            autoReconnectAttempted = true
-                            viewModel.attemptConnection(
-                                connInfo.host,
-                                connInfo.port.toString(),
-                                connInfo.isTls
+                is SessionState.Connected -> {
+                    val connectedState = sessionState as SessionState.Connected
+
+                    // Server Info Section (always shown when connected)
+                    ServerInfoSection(
+                        connectionInfo = savedConnectionInfo,
+                        serverInfo = connectedState.serverInfo,
+                        isWebRTC = connectedState is SessionState.Connected.WebRTC,
+                        onDisconnect = { viewModel.disconnect() }
+                    )
+
+                    LoginSection(connectedState.user)
+
+                    when (dataConnection) {
+                        DataConnectionState.Authenticated -> {
+                            // State 4: Connected and authenticated
+
+                            // Local Player Section
+                            SendspinSection(
+                                viewModel = viewModel,
                             )
                         }
-                        // If user changed connection info, don't auto-retry - let them manually retry
-                    } else if (sessionState is SessionState.Connected) {
-                        // Reset flag on successful connection
-                        autoReconnectAttempted = false
+
+                        else -> Unit
                     }
                 }
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.Center
-                ) {
-                    if (isAuthenticated) {
-                        Button(onClick = goHome) { Text("GO HOME") }
-                    } else {
-                        OutlinedButton(onClick = exitApp) { Text("EXIT APP") }
-                    }
-                }
-
-                when (sessionState) {
-                    is SessionState.Disconnected -> {
-                        // State 1 & 2: Disconnected (with or without token)
-                        // Show connection method tabs
-                        ConnectionMethodTabs(
-                            viewModel = viewModel,
-                            ipAddress = ipAddress,
-                            port = port,
-                            isTls = isTls,
-                            onIpAddressChange = { ipAddress = it },
-                            onPortChange = { port = it },
-                            onTlsChange = { isTls = it },
-                            onDirectConnect = {
-                                viewModel.attemptConnection(
-                                    ipAddress,
-                                    port,
-                                    isTls
-                                )
-                            },
-                            directConnectEnabled = ipAddress.isValidHost() && port.isIpPort(),
-                            sessionState = sessionState,
-                            connectionHistory = connectionHistory,
-                        )
-                    }
-
-                    SessionState.Connecting -> {
-                        ConnectingSection(
-                            ipAddress = ipAddress,
-                            port = port,
-                            preferredMethod = preferredMethod,
-                            onCancel = { viewModel.disconnect() }
-                        )
-                    }
-
-                    is SessionState.Reconnecting -> {
-                        ConnectingSection(
-                            ipAddress = ipAddress,
-                            port = port,
-                            preferredMethod = preferredMethod,
-                            onCancel = { viewModel.disconnect() }
-                        )
-                    }
-
-                    is SessionState.Connected -> {
-                        val connectedState = sessionState as SessionState.Connected
-
-                        // Server Info Section (always shown when connected)
-                        ServerInfoSection(
-                            connectionInfo = savedConnectionInfo,
-                            serverInfo = connectedState.serverInfo,
-                            isWebRTC = connectedState is SessionState.Connected.WebRTC,
-                            onDisconnect = { viewModel.disconnect() }
-                        )
-
-                        LoginSection(connectedState.user)
-
-                        when (dataConnection) {
-                            DataConnectionState.Authenticated -> {
-                                // State 4: Connected and authenticated
-
-                                // Local Player Section
-                                SendspinSection(
-                                    viewModel = viewModel,
-                                )
-                            }
-
-                            else -> Unit
-                        }
-                    }
-                }
-
-                // Misc settings - always visible
-                MiscSection(
-                    onShareLogs = { viewModel.shareLogs() },
-                    hasCrashLog = hasCrashLog,
-                    onShareCrashLog = { viewModel.shareCrashLog() },
-                    onDeleteCrashLog = { viewModel.deleteCrashLog() }
-                )
-
-                Spacer(modifier = Modifier.size(16.dp))
             }
+
+            // Misc settings - always visible
+            MiscSection(
+                onShareLogs = { viewModel.shareLogs() },
+                hasCrashLog = hasCrashLog,
+                onShareCrashLog = { viewModel.shareCrashLog() },
+                onDeleteCrashLog = { viewModel.deleteCrashLog() }
+            )
+
+            Spacer(modifier = Modifier.size(16.dp))
         }
     }
 }
@@ -371,7 +359,7 @@ private fun ConnectionMethodTabs(
     val directHasToken = port.toIntOrNull()
         ?.let { viewModel.hasCredentialsForDirect(ipAddress, it, isTls) } ?: false
     val webrtcHasToken = webrtcRemoteId.isNotBlank() &&
-        viewModel.hasCredentialsForWebRTC(webrtcRemoteId)
+            viewModel.hasCredentialsForWebRTC(webrtcRemoteId)
 
     SectionCard {
         SectionTitle("Connection Method")
@@ -441,6 +429,7 @@ private fun ConnectionMethodTabs(
                         }
                         viewModel.setPreferredConnectionMethod("direct")
                     }
+
                     ConnectionType.WEBRTC -> {
                         entry.remoteId?.let { viewModel.setWebrtcRemoteId(it) }
                         viewModel.setPreferredConnectionMethod("webrtc")


### PR DESCRIPTION
Work towards #113

As discussed in the issue, this moves the "compact" player to a floating toolbar. This allows it to be distinct when a bottom nav bar is added.