### PR TITLE
Add navigation rail for expanded screens

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -30,6 +31,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationRail
+import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -140,9 +143,11 @@ fun HomeScreen(
         },
         label = "player_transition"
     ) { isPlayersViewShown ->
+        val isExpandedScreen = WindowClass.isAtLeastExpanded()
+
         Scaffold(
             bottomBar = {
-                if (!isPlayersViewShown) {
+                if (!isPlayersViewShown && !isExpandedScreen) {
                     NavigationBar(modifier = Modifier.height(88.dp)) {
                         NavigationBarItem(
                             selected = true,
@@ -166,58 +171,81 @@ fun HomeScreen(
             }
         ) { contentPadding ->
             val bottomPadding = contentPadding.calculateBottomPadding()
-            val isExpandedScreen = WindowClass.isAtLeastExpanded()
             val floatingBarHeight = collapsedPlayerHeight(isExpandedScreen)
 
             if (!isPlayersViewShown) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(bottom = bottomPadding)
-                        .background(MaterialTheme.colorScheme.background)
-                ) {
-                    HomeContent(
-                        homeBackStack = homeBackStack,
-                        connectionState = connectionState,
-                        dataState = dataState,
-                        serverUrl = serverUrl,
-                        onPlayClick = viewModel::onPlayClick,
-                        playlistActions = ActionsViewModel.PlaylistActions(
-                            onLoadPlaylists = actionsViewModel::getEditablePlaylists,
-                            onAddToPlaylist = actionsViewModel::addToPlaylist
-                        ),
-                        libraryActions = ActionsViewModel.LibraryActions(
-                            onLibraryClick = actionsViewModel::onLibraryClick,
-                            onFavoriteClick = actionsViewModel::onFavoriteClick
-                        ),
-                        progressActions = ActionsViewModel.ProgressActions(
-                            onMarkPlayed = actionsViewModel::onMarkPlayed,
-                            onMarkUnplayed = actionsViewModel::onMarkUnplayed
-                        ),
-                        providerIconFetcher = { modifier, provider ->
-                            actionsViewModel.getProviderIcon(provider)
-                                ?.let { ProviderIcon(modifier, it) }
-                        },
-                        contentPadding = PaddingValues(
-                            bottom = floatingBarHeight + FloatingBarDefaults.padding
-                        )
-                    )
+                Row {
+                    if (isExpandedScreen) {
+                        NavigationRail {
+                            NavigationRailItem(
+                                selected = true,
+                                onClick = { },
+                                icon = {
+                                    Icon(Icons.Default.Home, contentDescription = null)
+                                }
+                            )
 
-                    FloatingBar(
+                            NavigationRailItem(
+                                selected = false,
+                                onClick = {
+                                    goToSettings()
+                                },
+                                icon = {
+                                    Icon(Icons.Default.Settings, contentDescription = null)
+                                }
+                            )
+                        }
+                    }
+
+                    Box(
                         modifier = Modifier
-                            .align(Alignment.BottomCenter),
-                        onClick = { showPlayersView = true }
+                            .fillMaxSize()
+                            .padding(bottom = bottomPadding)
+                            .background(MaterialTheme.colorScheme.background)
                     ) {
-                        Players(
-                            playerPagerState = playerPagerState,
-                            state = playersState,
+                        HomeContent(
+                            homeBackStack = homeBackStack,
+                            connectionState = connectionState,
+                            dataState = dataState,
                             serverUrl = serverUrl,
-                            homeScreenViewModel = viewModel,
-                            actionsViewModel = actionsViewModel,
-                            expanded = false,
-                            onClose = { showPlayersView = false },
-                            isExpandedScreen = isExpandedScreen
+                            onPlayClick = viewModel::onPlayClick,
+                            playlistActions = ActionsViewModel.PlaylistActions(
+                                onLoadPlaylists = actionsViewModel::getEditablePlaylists,
+                                onAddToPlaylist = actionsViewModel::addToPlaylist
+                            ),
+                            libraryActions = ActionsViewModel.LibraryActions(
+                                onLibraryClick = actionsViewModel::onLibraryClick,
+                                onFavoriteClick = actionsViewModel::onFavoriteClick
+                            ),
+                            progressActions = ActionsViewModel.ProgressActions(
+                                onMarkPlayed = actionsViewModel::onMarkPlayed,
+                                onMarkUnplayed = actionsViewModel::onMarkUnplayed
+                            ),
+                            providerIconFetcher = { modifier, provider ->
+                                actionsViewModel.getProviderIcon(provider)
+                                    ?.let { ProviderIcon(modifier, it) }
+                            },
+                            contentPadding = PaddingValues(
+                                bottom = floatingBarHeight + FloatingBarDefaults.padding
+                            )
                         )
+
+                        FloatingBar(
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter),
+                            onClick = { showPlayersView = true }
+                        ) {
+                            Players(
+                                playerPagerState = playerPagerState,
+                                state = playersState,
+                                serverUrl = serverUrl,
+                                homeScreenViewModel = viewModel,
+                                actionsViewModel = actionsViewModel,
+                                expanded = false,
+                                onClose = { showPlayersView = false },
+                                isExpandedScreen = isExpandedScreen
+                            )
+                        }
                     }
                 }
             } else {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -29,10 +28,6 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.NavigationRail
-import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -62,7 +57,9 @@ import io.music_assistant.client.ui.compose.home.nav.HomeNavScreen
 import io.music_assistant.client.ui.compose.home.nav.rememberHomeNavBackStack
 import io.music_assistant.client.ui.compose.item.ItemDetailsScreen
 import io.music_assistant.client.ui.compose.library.LibraryScreen
+import io.music_assistant.client.ui.compose.nav.AdaptiveNavigationScaffold
 import io.music_assistant.client.ui.compose.nav.BackHandler
+import io.music_assistant.client.ui.compose.nav.NavigationItem
 import io.music_assistant.client.ui.compose.search.SearchScreen
 import io.music_assistant.client.utils.SessionState
 import io.music_assistant.client.utils.WindowClass
@@ -145,113 +142,12 @@ fun HomeScreen(
     ) { isPlayersViewShown ->
         val isExpandedScreen = WindowClass.isAtLeastExpanded()
 
-        Scaffold(
-            bottomBar = {
-                if (!isPlayersViewShown && !isExpandedScreen) {
-                    NavigationBar(modifier = Modifier.height(88.dp)) {
-                        NavigationBarItem(
-                            selected = true,
-                            onClick = { },
-                            icon = {
-                                Icon(Icons.Default.Home, contentDescription = null)
-                            }
-                        )
-
-                        NavigationBarItem(
-                            selected = false,
-                            onClick = {
-                                goToSettings()
-                            },
-                            icon = {
-                                Icon(Icons.Default.Settings, contentDescription = null)
-                            }
-                        )
-                    }
-                }
-            }
-        ) { contentPadding ->
-            val bottomPadding = contentPadding.calculateBottomPadding()
-            val floatingBarHeight = collapsedPlayerHeight(isExpandedScreen)
-
-            if (!isPlayersViewShown) {
-                Row {
-                    if (isExpandedScreen) {
-                        NavigationRail {
-                            NavigationRailItem(
-                                selected = true,
-                                onClick = { },
-                                icon = {
-                                    Icon(Icons.Default.Home, contentDescription = null)
-                                }
-                            )
-
-                            NavigationRailItem(
-                                selected = false,
-                                onClick = {
-                                    goToSettings()
-                                },
-                                icon = {
-                                    Icon(Icons.Default.Settings, contentDescription = null)
-                                }
-                            )
-                        }
-                    }
-
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(bottom = bottomPadding)
-                            .background(MaterialTheme.colorScheme.background)
-                    ) {
-                        HomeContent(
-                            homeBackStack = homeBackStack,
-                            connectionState = connectionState,
-                            dataState = dataState,
-                            serverUrl = serverUrl,
-                            onPlayClick = viewModel::onPlayClick,
-                            playlistActions = ActionsViewModel.PlaylistActions(
-                                onLoadPlaylists = actionsViewModel::getEditablePlaylists,
-                                onAddToPlaylist = actionsViewModel::addToPlaylist
-                            ),
-                            libraryActions = ActionsViewModel.LibraryActions(
-                                onLibraryClick = actionsViewModel::onLibraryClick,
-                                onFavoriteClick = actionsViewModel::onFavoriteClick
-                            ),
-                            progressActions = ActionsViewModel.ProgressActions(
-                                onMarkPlayed = actionsViewModel::onMarkPlayed,
-                                onMarkUnplayed = actionsViewModel::onMarkUnplayed
-                            ),
-                            providerIconFetcher = { modifier, provider ->
-                                actionsViewModel.getProviderIcon(provider)
-                                    ?.let { ProviderIcon(modifier, it) }
-                            },
-                            contentPadding = PaddingValues(
-                                bottom = floatingBarHeight + FloatingBarDefaults.padding
-                            )
-                        )
-
-                        FloatingBar(
-                            modifier = Modifier
-                                .align(Alignment.BottomCenter),
-                            onClick = { showPlayersView = true }
-                        ) {
-                            Players(
-                                playerPagerState = playerPagerState,
-                                state = playersState,
-                                serverUrl = serverUrl,
-                                homeScreenViewModel = viewModel,
-                                actionsViewModel = actionsViewModel,
-                                expanded = false,
-                                onClose = { showPlayersView = false },
-                                isExpandedScreen = isExpandedScreen
-                            )
-                        }
-                    }
-                }
-            } else {
-                Column(modifier = Modifier
-                    .padding(contentPadding)
-                    .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+        if (isPlayersViewShown) {
+            Scaffold { contentPadding ->
+                Column(
+                    modifier = Modifier
+                        .padding(contentPadding)
+                        .background(MaterialTheme.colorScheme.surfaceContainerHigh)
                 ) {
                     // Close button
                     IconButton(
@@ -276,6 +172,75 @@ fun HomeScreen(
                             homeScreenViewModel = viewModel,
                             actionsViewModel = actionsViewModel,
                             expanded = true,
+                            onClose = { showPlayersView = false },
+                            isExpandedScreen = isExpandedScreen
+                        )
+                    }
+                }
+            }
+        } else {
+            val navigationItems = listOf(
+                NavigationItem(
+                    selected = true,
+                    onClick = { },
+                    Icons.Default.Home
+                ),
+                NavigationItem(
+                    selected = false,
+                    onClick = { goToSettings() },
+                    Icons.Default.Settings
+                )
+            )
+
+            AdaptiveNavigationScaffold(navigationItems = navigationItems) { contentPadding ->
+                val bottomPadding = contentPadding.calculateBottomPadding()
+                val floatingBarHeight = collapsedPlayerHeight(isExpandedScreen)
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(bottom = bottomPadding)
+                        .background(MaterialTheme.colorScheme.background)
+                ) {
+                    HomeContent(
+                        homeBackStack = homeBackStack,
+                        connectionState = connectionState,
+                        dataState = dataState,
+                        serverUrl = serverUrl,
+                        onPlayClick = viewModel::onPlayClick,
+                        playlistActions = ActionsViewModel.PlaylistActions(
+                            onLoadPlaylists = actionsViewModel::getEditablePlaylists,
+                            onAddToPlaylist = actionsViewModel::addToPlaylist
+                        ),
+                        libraryActions = ActionsViewModel.LibraryActions(
+                            onLibraryClick = actionsViewModel::onLibraryClick,
+                            onFavoriteClick = actionsViewModel::onFavoriteClick
+                        ),
+                        progressActions = ActionsViewModel.ProgressActions(
+                            onMarkPlayed = actionsViewModel::onMarkPlayed,
+                            onMarkUnplayed = actionsViewModel::onMarkUnplayed
+                        ),
+                        providerIconFetcher = { modifier, provider ->
+                            actionsViewModel.getProviderIcon(provider)
+                                ?.let { ProviderIcon(modifier, it) }
+                        },
+                        contentPadding = PaddingValues(
+                            bottom = floatingBarHeight + FloatingBarDefaults.padding
+                        )
+                    )
+
+                    FloatingBar(
+                        modifier = Modifier
+                            .align(Alignment.BottomCenter),
+                        onClick = { showPlayersView = true }
+                    ) {
+                        Players(
+                            playerPagerState = playerPagerState,
+                            state = playersState,
+                            serverUrl = serverUrl,
+                            homeScreenViewModel = viewModel,
+                            actionsViewModel = actionsViewModel,
+                            expanded = false,
                             onClose = { showPlayersView = false },
                             isExpandedScreen = isExpandedScreen
                         )

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/AdaptiveNavigationScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/AdaptiveNavigationScaffold.kt
@@ -1,0 +1,109 @@
+package io.music_assistant.client.ui.compose.nav
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationRail
+import androidx.compose.material3.NavigationRailItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.window.core.layout.WindowSizeClass
+import io.music_assistant.client.utils.WindowClass
+
+/**
+ * Shows a [NavigationBar] based on [navigationItems] on smaller screens and a [NavigationRail]
+ * instead on expanded and larger.
+ */
+@Composable
+fun AdaptiveNavigationScaffold(
+    navigationItems: List<NavigationItem>,
+    content: @Composable (contentPadding: PaddingValues) -> Unit
+) {
+    val isExpandedScreen = WindowClass.isAtLeastExpanded()
+
+    Scaffold(
+        bottomBar = {
+            if (!isExpandedScreen) {
+                NavigationBar(modifier = Modifier.height(88.dp)) {
+                    navigationItems.forEach {
+                        NavigationBarItem(
+                            it.selected,
+                            it.onClick,
+                            icon = {
+                                Icon(it.icon, contentDescription = null)
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    ) { contentPadding ->
+        Row {
+            if (isExpandedScreen) {
+                NavigationRail {
+                    navigationItems.forEach {
+                        NavigationRailItem(
+                            it.selected,
+                            it.onClick,
+                            icon = {
+                                Icon(it.icon, contentDescription = null)
+                            }
+                        )
+                    }
+                }
+            }
+
+            Box {
+                content(contentPadding)
+            }
+        }
+    }
+}
+
+data class NavigationItem(
+    val selected: Boolean,
+    val onClick: () -> Unit,
+    val icon: ImageVector
+)
+
+@Preview
+@Composable
+fun PreviewAdaptiveNavigationScaffold() {
+    AdaptiveNavigationScaffold(
+        navigationItems = listOf(
+            NavigationItem(
+                selected = true,
+                onClick = {},
+                Icons.Default.Home
+            ),
+            NavigationItem(
+                selected = false,
+                onClick = {},
+                Icons.Default.Settings
+            )
+        )
+    ) {
+        Text("Content")
+    }
+}
+
+@Preview(
+    widthDp = WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND,
+    heightDp = WindowSizeClass.HEIGHT_DP_EXPANDED_LOWER_BOUND
+)
+@Composable
+fun PreviewAdaptiveNavigationScaffoldExpanded() {
+    PreviewAdaptiveNavigationScaffold()
+}


### PR DESCRIPTION
This replaces the navigation bar with a rail on expanded screens:

<img width="1920" height="1200" alt="Screenshot_20260405_152033" src="https://github.com/user-attachments/assets/f173781e-9a17-4b42-be71-85432e960e32" />

There's a lot more that could be done to optimize/redesign the core layout for expanded screens (fixing the floating bar or embedding it in the rail for example), but this should definitely offer an improvement over a navigation bar on a wider screen.