### PR TITLE
fix(ios): enable device signing via xcconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ gha-creds-*.json
 
 # Local Claude Code settings
 .claude/settings.local.json
+.mcp.json
 
 # Downloaded binary frameworks (too large for git, see ios_build_instructions.md step 5)
 iosApp/Frameworks/

--- a/iosApp/Configuration/Config.xcconfig
+++ b/iosApp/Configuration/Config.xcconfig
@@ -1,4 +1,4 @@
 TEAM_ID=5J5R9QK64D
-PRODUCT_BUNDLE_IDENTIFIER=io.music_assistant.client.MusicAssistantClient
+PRODUCT_BUNDLE_IDENTIFIER=io.music-assistant.client
 APP_NAME=MusicAssistantClient
 IPHONEOS_DEPLOYMENT_TARGET = 15.0

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -367,7 +367,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
-				DEVELOPMENT_TEAM = RH4TEEE3RP;
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -380,7 +380,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.ma.kmp;
 				PRODUCT_NAME = "${APP_NAME}";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -396,7 +395,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
-				DEVELOPMENT_TEAM = RH4TEEE3RP;
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -409,7 +408,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.ma.kmp;
 				PRODUCT_NAME = "${APP_NAME}";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/ios_build_instructions.md
+++ b/ios_build_instructions.md
@@ -57,7 +57,7 @@ Edit `iosApp/Configuration/Config.xcconfig`:
 
 ```
 TEAM_ID=YOUR_APPLE_TEAM_ID
-BUNDLE_ID=io.music_assistant.client.MusicAssistantClient
+PRODUCT_BUNDLE_IDENTIFIER=io.music-assistant.client
 APP_NAME=MusicAssistantClient
 IPHONEOS_DEPLOYMENT_TARGET = 15.0
 ```
@@ -136,7 +136,7 @@ Xcode will invoke the Gradle build phase automatically.
 
 Physical device builds require valid provisioning:
 - Set `TEAM_ID` in `Config.xcconfig`
-- Ensure your Apple Developer account can sign for `BUNDLE_ID`
+- Ensure your Apple Developer account can sign for `PRODUCT_BUNDLE_IDENTIFIER`
 - Remove `CODE_SIGNING_ALLOWED=NO` from the xcodebuild command
 - The device must be registered in your Apple Developer portal
 
@@ -156,7 +156,7 @@ xcrun simctl install <SIMULATOR_UUID> \
   ~/Library/Developer/Xcode/DerivedData/iosApp-*/Build/Products/Debug-iphonesimulator/MusicAssistantClient.app
 
 # Launch the app
-xcrun simctl launch <SIMULATOR_UUID> io.music_assistant.client.MusicAssistantClient
+xcrun simctl launch <SIMULATOR_UUID> io.music-assistant.client
 ```
 
 ---
@@ -174,7 +174,7 @@ mobile-app/
 │   ├── NativeAudioController.swift # AudioQueue-based PCM player
 │   ├── NowPlayingManager.swift    # Lock screen / Control Center
 │   ├── Configuration/
-│   │   └── Config.xcconfig        # TEAM_ID, BUNDLE_ID, APP_NAME
+│   │   └── Config.xcconfig        # TEAM_ID, PRODUCT_BUNDLE_IDENTIFIER, APP_NAME
 │   └── Frameworks/
 │       └── WebRTC.xcframework     # WebRTC M125 binary (125.6422.02)
 ├── composeApp/
@@ -255,7 +255,7 @@ The following issues were found and fixed to enable iOS/Kotlin-Native compilatio
 
 **File:** `iosApp/iosApp.xcodeproj/project.pbxproj`
 **Problem:** Bundle ID was hardcoded to `com.yourname.musicassistant` (placeholder).
-**Fix:** Changed to `"$(BUNDLE_ID)"` to use the value from `Config.xcconfig`.
+**Fix:** Changed to `"$(PRODUCT_BUNDLE_IDENTIFIER)"` to use the value from `Config.xcconfig`.
 
 ### 4. `TEAM_ID` empty in Config.xcconfig
 
@@ -312,7 +312,7 @@ WebRTC.xcframework is missing from `iosApp/Frameworks/`. Follow step 5 above to 
 
 ### `The project is damaged and cannot be opened due to a parse error`
 
-Variable references in `project.pbxproj` must be quoted. e.g., use `"$(BUNDLE_ID)"` not `$(BUNDLE_ID)`.
+Variable references in `project.pbxproj` must be quoted. e.g., use `"$(PRODUCT_BUNDLE_IDENTIFIER)"` not `$(PRODUCT_BUNDLE_IDENTIFIER)`.
 
 ### App crashes immediately on launch — `dyld4::halt()` / `dyld4::prepare()` in backtrace
 


### PR DESCRIPTION
Wire DEVELOPMENT_TEAM and PRODUCT_BUNDLE_IDENTIFIER through Config.xcconfig instead of hardcoded values in project.pbxproj.

Bundle ID renamed from io.music_assistant.client.MusicAssistantClient to io.music-assistant.client. Apple rejects underscores in auto-generated App ID names, and the hyphen form matches the music-assistant.io domain and the Android's applicationId.

Also gitignore .mcp.json so the Xcode MCP server config (xcrun mcpbridge) stays personal.