### PR TITLE
Add release mode build variant

### DIFF
--- a/.github/workflows/debug-apk-release.yml
+++ b/.github/workflows/debug-apk-release.yml
@@ -44,7 +44,7 @@ jobs:
           EOF
 
       - name: Build debug APK
-        run: ./gradlew :androidApp:assembleSelfSignedRelease
+        run: ./gradlew :androidApp:assembleSelfSignedDebug
 
       - name: Get vars
         id: vars
@@ -80,7 +80,7 @@ jobs:
             
             ### Installation
             Download the APK below and install on your Android device.
-          files: androidApp/build/outputs/apk/selfSignedRelease/androidApp-selfSignedRelease.apk
+          files: androidApp/build/outputs/apk/selfSignedDebug/androidApp-selfSignedDebug.apk
           draft: false
           prerelease: true
         env:

--- a/README.md
+++ b/README.md
@@ -52,8 +52,16 @@ See [ios_build_instructions.md](ios_build_instructions.md) for a full step-by-st
 
 #### Android
 
+To build the app:
+
 ```bash
 ./gradlew :androidApp:assembleDebug
+```
+
+To build a non-debuggable "release mode" APK for testing performance using your local debug keystore:
+
+```bash
+./gradlew :androidApp:assembleSelfSignedRelease
 ```
 
 ### Writing/running tests

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -23,7 +23,7 @@ android {
         }
     }
     signingConfigs {
-        create("selfSignedRelease") {
+        create("selfSigned") {
             storeFile = file(System.getProperty("user.home") + "/.android/debug.keystore")
             storePassword = "android"
             keyAlias = "androiddebugkey"
@@ -52,10 +52,16 @@ android {
             )
         }
 
-        create("selfSignedRelease") {
+        create("selfSignedDebug") {
             isDebuggable = true
             isMinifyEnabled = false
-            signingConfig = signingConfigs.getByName("selfSignedRelease")
+            signingConfig = signingConfigs.getByName("selfSigned")
+        }
+
+        create("selfSignedRelease") {
+            isDebuggable = false
+            isMinifyEnabled = false
+            signingConfig = signingConfigs.getByName("selfSigned")
         }
     }
     compileOptions {


### PR DESCRIPTION
Compose can perform significantly worse in debug builds. This makes the `selfSignedRelease` build variant non-debuggable and introduces a new `selfSignedDebug` variant that is debuggable. Both use the local debug keystore that Android dev tooling manages.