### PR TITLE
chore: bump Android version to 0.5.0 (6)

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "io.music_assistant.client"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 5
-        versionName = "0.4.0"
+        versionCode = 6
+        versionName = "0.5.0"
     }
     packaging {
         resources {


### PR DESCRIPTION
version bump after releasing android-v0.4.0.

versionCode: 5 → 6
versionName: 0.4.0 → 0.5.0