### PR TITLE
Enable TestFlight distribution

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/music_assistant/client/player/sendspin/audio/Codec.android.kt
+++ b/composeApp/src/androidMain/kotlin/io/music_assistant/client/player/sendspin/audio/Codec.android.kt
@@ -1,0 +1,6 @@
+package io.music_assistant.client.player.sendspin.audio
+
+actual object Codecs {
+    actual val default: Codec = Codec.OPUS
+    actual val list: List<Codec> = listOf(Codec.OPUS, Codec.FLAC, Codec.PCM)
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/audio/Codec.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/audio/Codec.kt
@@ -17,9 +17,9 @@ enum class Codec(
     }
 }
 
-object Codecs {
-    val default = Codec.OPUS
-    val list: List<Codec> = listOf(Codec.OPUS, Codec.FLAC, Codec.PCM)
+expect object Codecs {
+    val default: Codec
+    val list: List<Codec>
 }
 
 fun codecByName(name: String): Codec? =

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/player/sendspin/audio/Codec.ios.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/player/sendspin/audio/Codec.ios.kt
@@ -1,0 +1,9 @@
+package io.music_assistant.client.player.sendspin.audio
+
+// Opus is intentionally omitted: the iOS OpusDecoder is a pass-through stub
+// (no real decoder), so selecting Opus produces broken audio. Restore to the
+// list once a real iOS Opus decoder ships.
+actual object Codecs {
+    actual val default: Codec = Codec.FLAC
+    actual val list: List<Codec> = listOf(Codec.FLAC, Codec.PCM)
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,11 @@
 #Kotlin
 kotlin.code.style=official
-kotlin.daemon.jvmargs=-Xmx2048M
+kotlin.daemon.jvmargs=-Xmx8g
 
 #Gradle
-org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx8g -Dfile.encoding=UTF-8
+org.gradle.parallel=true
+org.gradle.caching=true
 
 #Android
 android.nonTransitiveRClass=true

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -15,11 +15,11 @@
 		C85119282F18C7A900185678 /* Opus in Frameworks */ = {isa = PBXBuildFile; productRef = C85119272F18C7A900185678 /* Opus */; };
 		C851192B2F18C88B00185678 /* FLAC in Frameworks */ = {isa = PBXBuildFile; productRef = C851192A2F18C88B00185678 /* FLAC */; };
 		C851192E2F18C8A200185678 /* ogg in Frameworks */ = {isa = PBXBuildFile; productRef = C851192D2F18C8A200185678 /* ogg */; };
+		C8CP00012F1A000000000001 /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CP00032F1A000000000001 /* CarPlaySceneDelegate.swift */; };
+		C8CP00022F1A000000000002 /* CarPlayContentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CP00042F1A000000000002 /* CarPlayContentManager.swift */; };
 		C8FCC1922F17C6A9005E8312 /* NowPlayingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8FCC1912F17C6A9005E8312 /* NowPlayingManager.swift */; };
 		C8FCC1952F17E001005E8312 /* NativeAudioController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8FCC1962F17E001005E8312 /* NativeAudioController.swift */; };
 		C8FCC1972F17E001005E8312 /* AudioDecoders.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8FCC1982F17E001005E8312 /* AudioDecoders.swift */; };
-		C8CP00012F1A000000000001 /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CP00032F1A000000000001 /* CarPlaySceneDelegate.swift */; };
-		C8CP00022F1A000000000002 /* CarPlayContentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CP00042F1A000000000002 /* CarPlayContentManager.swift */; };
 		C8SI00012F1B000000000001 /* SiriIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8SI00022F1B000000000001 /* SiriIntentHandler.swift */; };
 /* End PBXBuildFile section */
 
@@ -31,11 +31,11 @@
 		7555FF82242A565900829871 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		C8CP00032F1A000000000001 /* CarPlaySceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlaySceneDelegate.swift; sourceTree = "<group>"; };
+		C8CP00042F1A000000000002 /* CarPlayContentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayContentManager.swift; sourceTree = "<group>"; };
 		C8FCC1912F17C6A9005E8312 /* NowPlayingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingManager.swift; sourceTree = "<group>"; };
 		C8FCC1962F17E001005E8312 /* NativeAudioController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeAudioController.swift; sourceTree = "<group>"; };
 		C8FCC1982F17E001005E8312 /* AudioDecoders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDecoders.swift; sourceTree = "<group>"; };
-		C8CP00032F1A000000000001 /* CarPlaySceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlaySceneDelegate.swift; sourceTree = "<group>"; };
-		C8CP00042F1A000000000002 /* CarPlayContentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayContentManager.swift; sourceTree = "<group>"; };
 		C8SI00022F1B000000000001 /* SiriIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiriIntentHandler.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -103,6 +103,14 @@
 			path = iosApp;
 			sourceTree = "<group>";
 		};
+		AB1DB47929225F7C00F7AF9C /* Configuration */ = {
+			isa = PBXGroup;
+			children = (
+				AB3632DC29227652001CCB65 /* Config.xcconfig */,
+			);
+			path = Configuration;
+			sourceTree = "<group>";
+		};
 		C8CP00052F1A000000000003 /* CarPlay */ = {
 			isa = PBXGroup;
 			children = (
@@ -111,14 +119,6 @@
 				C8SI00022F1B000000000001 /* SiriIntentHandler.swift */,
 			);
 			path = CarPlay;
-			sourceTree = "<group>";
-		};
-		AB1DB47929225F7C00F7AF9C /* Configuration */ = {
-			isa = PBXGroup;
-			children = (
-				AB3632DC29227652001CCB65 /* Config.xcconfig */,
-			);
-			path = Configuration;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -156,7 +156,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1130;
-				LastUpgradeCheck = 1540;
+				LastUpgradeCheck = 2640;
 				ORGANIZATIONNAME = orgName;
 				TargetAttributes = {
 					7555FF7A242A565900829871 = {
@@ -202,6 +202,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		F36B1CEB2AD83DDC00CB74D5 /* Compile Kotlin Framework */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -275,6 +276,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -297,6 +299,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -338,6 +341,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -353,6 +357,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				VALIDATE_PRODUCT = YES;
@@ -367,7 +372,6 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
-				DEVELOPMENT_TEAM = "$(TEAM_ID)";
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -395,7 +399,6 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
-				DEVELOPMENT_TEAM = "$(TEAM_ID)";
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
+++ b/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2600"
+   LastUpgradeVersion = "2640"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/iosApp/iosApp/CarPlay/CarPlayContentManager.swift
+++ b/iosApp/iosApp/CarPlay/CarPlayContentManager.swift
@@ -37,45 +37,11 @@ class CarPlayImageLoader {
 class CarPlayContentManager {
     static let shared = CarPlayContentManager()
 
-    private let dataSource = KmpHelper.shared.mainDataSource
-    private let apiClient = KmpHelper.shared.serviceClient
-    
     // MARK: - API Calls
-    
-    /// Fetch Recommendations (Recently Played / Home)
+
     func fetchRecommendations(completion: @escaping ([CPListItem]) -> Void) {
-        // iOS KMP interop: access Flow via suspend function or callbacks wrapper
-        // For simplicity in this plan, accessing request directly
-        
-        let request = Request.Library.shared.recommendations()
-        
-        apiClient.sendRequest(request: request) { result, error in
-            guard let result = result else {
-                print("CP: Error fetching recommendations: \(String(describing: error))")
-                completion([])
-                return
-            }
-            
-            // Parse result to [ServerMediaItem] -> [AppMediaItem] -> [CPListItem]
-            // This requires some manual bridging if not using KMP flow helpers
-            
-            // NOTE: In a full implementation we would use a proper KMP-Swift Flow collector
-            // But for "Build Now", we use the callback approach
-            
-            // Assuming result can be cast/parsed.
-            // Since `sendRequest` returns generic Result, we need to handle parsing.
-            
-            // Strategy: Use a helper on Kotlin side?
-            // Or assume KMP generates ObjC generics properly?
-            
-            // Let's assume we get a list of objects we can map
-            // Realistically, direct mapping from `Any?` in Swift is hard.
-            // Better approach: Use KmpHelper to expose specific methods for Swift
-            
-            KmpHelper.shared.fetchRecommendations { items in
-                let cpItems = items.compactMap { self.mapToCPListItem($0) }
-                completion(cpItems)
-            }
+        KmpHelper.shared.fetchRecommendations { items in
+            completion(items.compactMap { self.mapToCPListItem($0) })
         }
     }
     
@@ -134,13 +100,8 @@ class CarPlayContentManager {
     }
     
     // MARK: - Action Handling
-    
+
     func playItem(_ item: AppMediaItem) {
-        // Trigger play via DataSource
-        // We'll need to know which player is selected
-        // For now, use the first available or last selected
-        
-        // This functionality needs KMP exposure too
         KmpHelper.shared.playMediaItem(item: item)
     }
     

--- a/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
+++ b/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
@@ -182,7 +182,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
             var sections: [CPListSection] = [browseSection]
 
             for folder in folders {
-                let folderItems = ((folder.items as? [AppMediaItem]) ?? []).filter { $0.uri != nil }
+                let folderItems = (folder.items ?? []).filter { $0.uri != nil }
                 guard !folderItems.isEmpty else { continue }
 
                 let displayItems = Array(folderItems.prefix(maxImages))
@@ -218,116 +218,40 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     // MARK: - Navigation Helpers
 
     private func pushBrowseGrid() {
-        // Use 100x100 for grid button images
         let imageSize = CGSize(width: 100, height: 100)
-        let buttons = Self.categoryIcons.enumerated().map { (index, icon) -> CPGridButton in
+        let manager = CarPlayContentManager.shared
+        let categories: [(title: String, fetcher: (@escaping ([CPListItem]) -> Void) -> Void)] = [
+            ("Artists",    manager.fetchArtists),
+            ("Albums",     manager.fetchAlbums),
+            ("Tracks",     manager.fetchTracks),
+            ("Playlists",  manager.fetchPlaylists),
+            ("Audiobooks", manager.fetchAudiobooks),
+            ("Podcasts",   manager.fetchPodcasts),
+            ("Radio",      manager.fetchRadioStations),
+        ]
+        let buttons = zip(Self.categoryIcons, categories).map { icon, category -> CPGridButton in
             let image = Self.dynamicCategoryImage(symbol: icon.symbol, size: imageSize)
             return CPGridButton(titleVariants: [icon.name], image: image) { [weak self] _ in
-                guard let self = self else { return }
-                switch index {
-                case 0: self.pushArtistsTemplate()
-                case 1: self.pushAlbumsTemplate()
-                case 2: self.pushTracksTemplate()
-                case 3: self.pushPlaylistsTemplate()
-                case 4: self.pushAudiobooksTemplate()
-                case 5: self.pushPodcastsTemplate()
-                case 6: self.pushRadioTemplate()
-                default: break
-                }
+                self?.pushCategoryTemplate(title: category.title, fetcher: category.fetcher)
             }
         }
         let gridTemplate = CPGridTemplate(title: "Browse", gridButtons: buttons)
         self.interfaceController?.pushTemplate(gridTemplate, animated: true, completion: nil)
     }
 
-    private func pushPlaylistsTemplate() {
-        let listTemplate = CPListTemplate(title: "Playlists", sections: [])
+    private func pushCategoryTemplate(
+        title: String,
+        fetcher: (@escaping ([CPListItem]) -> Void) -> Void
+    ) {
+        let template = CPListTemplate(title: title, sections: [])
         let loadingItem = CPListItem(text: "Loading...", detailText: nil)
-        listTemplate.updateSections([CPListSection(items: [loadingItem])])
+        template.updateSections([CPListSection(items: [loadingItem])])
 
-        self.interfaceController?.pushTemplate(listTemplate, animated: true, completion: nil)
+        self.interfaceController?.pushTemplate(template, animated: true, completion: nil)
 
-        CarPlayContentManager.shared.fetchPlaylists { items in
-            self.attachHandlers(to: items)
-            listTemplate.updateSections([CPListSection(items: items)])
-        }
-    }
-
-    private func pushAlbumsTemplate() {
-        let listTemplate = CPListTemplate(title: "Albums", sections: [])
-        let loadingItem = CPListItem(text: "Loading...", detailText: nil)
-        listTemplate.updateSections([CPListSection(items: [loadingItem])])
-
-        self.interfaceController?.pushTemplate(listTemplate, animated: true, completion: nil)
-
-        CarPlayContentManager.shared.fetchAlbums { items in
-            self.attachHandlers(to: items)
-            listTemplate.updateSections([CPListSection(items: items)])
-        }
-    }
-
-    private func pushArtistsTemplate() {
-        let listTemplate = CPListTemplate(title: "Artists", sections: [])
-        let loadingItem = CPListItem(text: "Loading...", detailText: nil)
-        listTemplate.updateSections([CPListSection(items: [loadingItem])])
-
-        self.interfaceController?.pushTemplate(listTemplate, animated: true, completion: nil)
-
-        CarPlayContentManager.shared.fetchArtists { items in
-            self.attachHandlers(to: items)
-            listTemplate.updateSections([CPListSection(items: items)])
-        }
-    }
-
-    private func pushTracksTemplate() {
-        let listTemplate = CPListTemplate(title: "Tracks", sections: [])
-        let loadingItem = CPListItem(text: "Loading...", detailText: nil)
-        listTemplate.updateSections([CPListSection(items: [loadingItem])])
-
-        self.interfaceController?.pushTemplate(listTemplate, animated: true, completion: nil)
-
-        CarPlayContentManager.shared.fetchTracks { items in
-            self.attachHandlers(to: items)
-            listTemplate.updateSections([CPListSection(items: items)])
-        }
-    }
-
-    private func pushPodcastsTemplate() {
-        let listTemplate = CPListTemplate(title: "Podcasts", sections: [])
-        let loadingItem = CPListItem(text: "Loading...", detailText: nil)
-        listTemplate.updateSections([CPListSection(items: [loadingItem])])
-
-        self.interfaceController?.pushTemplate(listTemplate, animated: true, completion: nil)
-
-        CarPlayContentManager.shared.fetchPodcasts { items in
-            self.attachHandlers(to: items)
-            listTemplate.updateSections([CPListSection(items: items)])
-        }
-    }
-
-    private func pushAudiobooksTemplate() {
-        let listTemplate = CPListTemplate(title: "Audiobooks", sections: [])
-        let loadingItem = CPListItem(text: "Loading...", detailText: nil)
-        listTemplate.updateSections([CPListSection(items: [loadingItem])])
-
-        self.interfaceController?.pushTemplate(listTemplate, animated: true, completion: nil)
-
-        CarPlayContentManager.shared.fetchAudiobooks { items in
-            self.attachHandlers(to: items)
-            listTemplate.updateSections([CPListSection(items: items)])
-        }
-    }
-
-    private func pushRadioTemplate() {
-        let listTemplate = CPListTemplate(title: "Radio", sections: [])
-        let loadingItem = CPListItem(text: "Loading...", detailText: nil)
-        listTemplate.updateSections([CPListSection(items: [loadingItem])])
-
-        self.interfaceController?.pushTemplate(listTemplate, animated: true, completion: nil)
-
-        CarPlayContentManager.shared.fetchRadioStations { items in
-            self.attachHandlers(to: items)
-            listTemplate.updateSections([CPListSection(items: items)])
+        fetcher { [weak self] items in
+            self?.attachHandlers(to: items)
+            template.updateSections([CPListSection(items: items)])
         }
     }
 

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -6,6 +6,8 @@
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Music Assistant</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -19,9 +21,23 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
+	<key>INIntentsSupported</key>
+	<array>
+		<string>INPlayMediaIntent</string>
+	</array>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>Music Assistant does not access the camera. This description is required because an included framework (WebRTC) references camera APIs that this app does not use.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Music Assistant connects to your Music Assistant server on your local network to browse and play your music library.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Music Assistant does not access the microphone. This description is required because an included framework (WebRTC) references microphone APIs that this app does not use.</string>
+	<key>NSSiriUsageDescription</key>
+	<string>Search and play music using Siri</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -44,12 +60,6 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
-	</array>
-	<key>NSSiriUsageDescription</key>
-	<string>Search and play music using Siri</string>
-	<key>INIntentsSupported</key>
-	<array>
-		<string>INPlayMediaIntent</string>
 	</array>
 	<key>UILaunchScreen</key>
 	<dict/>


### PR DESCRIPTION
Make the iOS app uploadable to App Store Connect and usable via TestFlight. A mix of Info.plist keys, build config bumps, Xcode recommended-settings, and targeted cleanup in adjacent files.

Info.plist:
  - CFBundleDisplayName = "Music Assistant" (prettier home-screen label than the smooshed PRODUCT_NAME fallback)
  - ITSAppUsesNonExemptEncryption = false (skips per-upload dialog; app uses only standard HTTPS, which is exempt)
  - NSLocalNetworkUsageDescription: the default server is the .local hostname 'homeassistant.local' (see Defaults.URI); without this key, mDNS resolution silently fails on iOS 14+
  - NSCameraUsageDescription and NSMicrophoneUsageDescription: Apple's static binary scan sees these APIs referenced by WebRTC.xcframework even though the app itself never invokes them
  - Keys alphabetized
  - CFBundleVersion bumped to 2 (build 1 was consumed by a rejected upload that surfaced the missing purpose strings)

gradle.properties:
  - JVM heap 2GB -> 8GB. Release-mode Kotlin/Native compile for iosArm64 OOMs at 2GB (fine for debug Simulator, not for archive).
  - Enable parallel execution and local build caching.

Xcode project:
  - alwaysOutOfDate = 1 on "Compile Kotlin Framework" script phase (silences the "runs every build" warning; Gradle already does up-to-date checking, so declaring outputs would create stale-build hazards).
  - Accept Xcode's recommended settings: DEVELOPMENT_TEAM inherited from project level (removes per-target duplication), String Catalog symbol generation enabled (no-op today, future-friendly), upgrade check bumped.

CarPlay cleanup (while touching adjacent files):
  - CarPlayContentManager: strip 40+ lines of dead scaffolding from fetchRecommendations (outer apiClient.sendRequest whose result was ignored in favor of a direct KmpHelper call), along with the WIP comments that shipped with it.
  - CarPlaySceneDelegate: collapse 7 nearly-identical pushXTemplate() methods into one pushCategoryTemplate(title:fetcher:), driven by a local category table that pairs icons with fetchers directly (replaces the integer-index switch).
  - Remove redundant as? downcast on folder.items (already typed).

Audio codec defaults split per-platform:
  - Codecs is now expect/actual. Android keeps its current behavior (default OPUS, picker shows OPUS/FLAC/PCM); its Concentus-backed OpusDecoder is real and working.
  - iOS defaults to FLAC and hides OPUS from the picker. OpusDecoder.ios is a no-op pass-through stub that returns raw Opus bytes unchanged, so selecting Opus on iOS produces broken audio. A follow-up will implement a real iOS Opus decoder and restore parity.

Verified end-to-end: uploaded 1.0 (2) to App Store Connect, processed to "Ready to Test".