### PR TITLE
feat(ios): implement OAuth login

### DIFF
--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
@@ -2,6 +2,7 @@ package io.music_assistant.client.di
 
 import io.music_assistant.client.api.Request
 import io.music_assistant.client.api.ServiceClient
+import io.music_assistant.client.auth.AuthenticationManager
 import io.music_assistant.client.data.MainDataSource
 import io.music_assistant.client.data.model.client.AppMediaItem
 import io.music_assistant.client.data.model.client.AppMediaItem.Companion.toAppMediaItemList
@@ -21,6 +22,7 @@ import org.koin.core.component.inject
 object KmpHelper : KoinComponent {
     val mainDataSource: MainDataSource by inject()
     val serviceClient: ServiceClient by inject()
+    val authManager: AuthenticationManager by inject()
     
     // Provide a scope for Swift to launch coroutines if needed
     val mainScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -20,8 +20,19 @@
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>io.music-assistant.client.oauth</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>musicassistant</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>INIntentsSupported</key>
 	<array>
 		<string>INPlayMediaIntent</string>

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -11,6 +11,29 @@ enum KmpState {
     static let readyNotification = Notification.Name("KMPReadyNotification")
 }
 
+/// Buffers an OAuth callback URL when it arrives before Koin is initialized
+/// (cold-launch-from-deep-link). Replayed by ContentView.onAppear once
+/// KmpState.isReady == true. Accessed only from the main thread.
+enum PendingOAuthCallback {
+    static var url: URL?
+}
+
+/// Parses a musicassistant://auth/callback?code=... URL and hands the token
+/// to AuthenticationManager. Matches the shape Android's MainActivity parses
+/// in handleOAuthCallback (MainActivity.kt:64-80). Silently returns for URLs
+/// that don't match — we can't assume this app is the only handler of the
+/// scheme.
+func handleOAuthCallback(_ url: URL) {
+    guard url.scheme == "musicassistant",
+          url.host == "auth",
+          url.path == "/callback",
+          let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+          let code = components.queryItems?.first(where: { $0.name == "code" })?.value
+    else { return }
+
+    KmpHelper.shared.authManager.handleOAuthCallback(token: code)
+}
+
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(
         _ application: UIApplication,
@@ -63,6 +86,24 @@ struct iOSApp: App {
                     // (called when ContentView first renders). Notify CarPlay.
                     KmpState.isReady = true
                     NotificationCenter.default.post(name: KmpState.readyNotification, object: nil)
+
+                    // Wire OAuth: Android does the equivalent in MainActivity.onCreate.
+                    // Must happen after Koin init, which onAppear guarantees.
+                    KmpHelper.shared.authManager.oauthHandler = OAuthHandler()
+
+                    // If a cold-launch OAuth callback arrived before Koin was ready,
+                    // replay it now.
+                    if let pending = PendingOAuthCallback.url {
+                        PendingOAuthCallback.url = nil
+                        handleOAuthCallback(pending)
+                    }
+                }
+                .onOpenURL { url in
+                    if KmpState.isReady {
+                        handleOAuthCallback(url)
+                    } else {
+                        PendingOAuthCallback.url = url
+                    }
                 }
         }
     }


### PR DESCRIPTION
Wire up OAuth support on iOS so users with HA-linked Music Assistant servers can authenticate. The iOS OAuthHandler implementation already existed but was never instantiated, leaving OAuth-based providers inoperable with "OAuth not supported on this platform."

- KmpHelper exposes authManager to Swift.
- Info.plist registers `musicassistant://`, the URL scheme that AuthenticationViewModel hardcodes as the OAuth return URL.
- iOSApp.swift assigns OAuthHandler() in ContentView.onAppear (after Koin init) and parses the callback via .onOpenURL, forwarding the code to authManager.handleOAuthCallback.
- Cold-launch deep links (URL arrives before Koin ready) are buffered and replayed by the same onAppear.

Mirrors Android's MainActivity.onCreate wire-up.