### PR TITLE
feat: add about section to Settings screen when disconnected

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -193,8 +194,7 @@ fun SettingsScreen(goHome: () -> Unit, exitApp: () -> Unit) {
 
                 when (sessionState) {
                     is SessionState.Disconnected -> {
-                        // State 1 & 2: Disconnected (with or without token)
-                        // Show connection method tabs
+                        AboutSection()
                         ConnectionMethodTabs(
                             viewModel = viewModel,
                             ipAddress = ipAddress,
@@ -341,6 +341,27 @@ private fun SectionTitle(text: String) {
         color = MaterialTheme.colorScheme.onBackground,
         modifier = Modifier.padding(bottom = 12.dp)
     )
+}
+
+@Composable
+private fun AboutSection() {
+    val uriHandler = LocalUriHandler.current
+    SectionCard {
+        Text(
+            text = "Music Assistant is a free, open-source, self-hosted music server. " +
+                    "Connect to your server below to browse your library and control " +
+                    "playback throughout your home.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Spacer(modifier = Modifier.size(4.dp))
+        Text(
+            text = "Learn more at music-assistant.io →",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.clickable { uriHandler.openUri("https://music-assistant.io") },
+        )
+    }
 }
 
 @Composable


### PR DESCRIPTION
I'm going through trying to prep for an 'external' Test Flight build, which means we'll need to pass the App Store review at least once. It's a lower-level review than for a full App Store publish, but still a small hurdle. Adding this link will hopefully help with that (and in the future when we *are* on the App Store it'll help actual users who may have downloaded the app without fully understanding what it is, learn what it is).


Adds a brief description of Music Assistant and a tappable link to music-assistant.io on the connect/settings screen shown to new users.

This is the first screen a reviewer or new tester sees — giving them context about what the app connects to without having to leave the app.