### PR TITLE
chore(build): Build on every PR, cleanup iOS release

### DIFF
--- a/.github/workflows/check-pr-android.yml
+++ b/.github/workflows/check-pr-android.yml
@@ -1,8 +1,12 @@
-name: Check PR
+name: Check PR (Android)
 
 on:
   pull_request:
     branches: [ dev ]
+    # Skip Android PR checks when a PR only touches iOS-exclusive files.
+    # Shared code (composeApp, gradle, etc.) still triggers a build.
+    paths-ignore:
+      - 'iosApp/**'
 
 jobs:
   build:

--- a/.github/workflows/check-pr-ios.yml
+++ b/.github/workflows/check-pr-ios.yml
@@ -1,0 +1,77 @@
+name: Check PR (iOS)
+
+# Sanity-check that iOS still compiles on PRs that could affect it. Pure
+# Android-only PRs are skipped. This is NOT a release — it does no signing,
+# no archive, no upload. Only goal: catch compile-time breakage early.
+
+on:
+  pull_request:
+    branches: [ dev ]
+    paths-ignore:
+      - 'androidApp/**'
+
+jobs:
+  compile:
+    runs-on: macos-26
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.konan
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'gradle/libs.versions.toml') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      # WebRTC.xcframework is gitignored (~99MB). Cache keyed to the pinned
+      # version string so version bumps trigger a redownload automatically.
+      # Keep in sync with ios-release.yml and ios_build_instructions.md.
+      - name: Cache WebRTC.xcframework
+        id: cache-webrtc
+        uses: actions/cache@v4
+        with:
+          path: iosApp/Frameworks/WebRTC.xcframework
+          key: webrtc-xcframework-125.6422.02
+
+      - name: Download WebRTC.xcframework
+        if: steps.cache-webrtc.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          curl -L --fail \
+            "https://github.com/webrtc-sdk/Specs/releases/download/125.6422.02/WebRTC.xcframework.zip" \
+            -o /tmp/WebRTC.xcframework.zip
+          mkdir -p iosApp/Frameworks
+          unzip -q /tmp/WebRTC.xcframework.zip -d iosApp/Frameworks/
+          rm /tmp/WebRTC.xcframework.zip
+          test -d iosApp/Frameworks/WebRTC.xcframework/ios-arm64/WebRTC.framework
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      # Simulator destination + signing disabled gives us a compile-only pass:
+      # Kotlin framework compilation runs via the Xcode build phase script, and
+      # Swift compiles against the real iOS 26 SDK. No provisioning profile or
+      # distribution cert required.
+      - name: Build (no signing, simulator target)
+        run: |
+          xcodebuild \
+            -project iosApp/iosApp.xcodeproj \
+            -scheme iosApp \
+            -configuration Debug \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_IDENTITY='' \
+            build

--- a/.github/workflows/debug-apk-release.yml
+++ b/.github/workflows/debug-apk-release.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - dev
+    # Skip when a push to dev only touches iOS-exclusive files — the Android
+    # APK can't be affected by them. Shared code (composeApp, gradle, etc.)
+    # still triggers a build.
+    paths-ignore:
+      - 'iosApp/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -8,10 +8,6 @@ permissions:
 
 jobs:
   release:
-    # macos-26 ships Xcode 26.2 by default, which builds against the iOS 26 SDK.
-    # Apple requires iOS 26 SDK for all App Store Connect uploads starting
-    # April 28, 2026 (ITMS-90725). macos-15 only has Xcode 16.x / iOS 18.5 SDK
-    # and would get rejected after that date.
     runs-on: macos-26
 
     steps:
@@ -85,7 +81,7 @@ jobs:
         run: |
           git fetch --tags
           if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
-            echo "::error::Tag ${{ steps.version.outputs.tag }} already exists. Bump CFBundleVersion in iosApp/iosApp/Info.plist before releasing."
+            echo "::error title=CFBundleVersion not bumped::Tag ${{ steps.version.outputs.tag }} already exists. Open a PR that bumps CFBundleVersion in iosApp/iosApp/Info.plist, merge it into dev, then dispatch this workflow again."
             exit 1
           fi
 
@@ -207,32 +203,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Compute next build number
-        id: next
-        run: |
-          NEXT_BUILD=$(( ${{ steps.version.outputs.build }} + 1 ))
-          echo "build=$NEXT_BUILD" >> "$GITHUB_OUTPUT"
-          echo "branch=chore/bump-ios-build-${NEXT_BUILD}" >> "$GITHUB_OUTPUT"
-
-      - name: Push version bump branch
-        run: |
-          git fetch origin dev
-          git checkout -b "${{ steps.next.outputs.branch }}" origin/dev
-          plutil -replace CFBundleVersion -string "${{ steps.next.outputs.build }}" iosApp/iosApp/Info.plist
-          git add iosApp/iosApp/Info.plist
-          git commit -m "chore: bump iOS build to ${{ steps.next.outputs.build }}"
-          git push origin "${{ steps.next.outputs.branch }}"
-
       - name: Summary
         if: success()
         run: |
+          NEXT_BUILD=$(( ${{ steps.version.outputs.build }} + 1 ))
           {
             echo "## iOS Release — success"
             echo ""
             echo "- **Version**: ${{ steps.version.outputs.name }} (${{ steps.version.outputs.build }})"
             echo "- **Tag**: [\`${{ steps.version.outputs.tag }}\`](https://github.com/${{ github.repository }}/releases/tag/${{ steps.version.outputs.tag }})"
-            echo "- **Next build bump branch**: [\`${{ steps.next.outputs.branch }}\`](https://github.com/${{ github.repository }}/compare/dev...${{ steps.next.outputs.branch }}?expand=1) — open a PR to prepare the next release"
             echo "- Build should appear in App Store Connect → TestFlight → Builds within a few minutes."
+            echo ""
+            echo "### Before the next release"
+            echo ""
+            echo "Bump \`CFBundleVersion\` in \`iosApp/iosApp/Info.plist\` from \`${{ steps.version.outputs.build }}\` to \`${NEXT_BUILD}\` (or higher) in a PR and merge it into \`dev\`. The duplicate-tag guard will block a re-dispatch until this is done."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Clean up keychain


### PR DESCRIPTION
Build everything in both Android and iOS unless the only changes were for the other platform. Take out the auto-branch function for iOS releases and rely on developers to bump CFBundleVersion themselves.