### PR TITLE
fix(api): harden decode boundaries and RpcEngine concurrency

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Answer.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Answer.kt
@@ -1,6 +1,8 @@
 package io.music_assistant.client.api
 
+import co.touchlab.kermit.Logger
 import io.music_assistant.client.utils.myJson
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
@@ -11,5 +13,26 @@ data class Answer(
 ) {
     val messageId: String? = json["message_id"]?.jsonPrimitive?.content
     val result: JsonElement? = json["result"]
-    inline fun <reified T : Any> resultAs(): T? = result?.let { myJson.decodeFromJsonElement(it) }
+
+    /**
+     * Decode the RPC result payload as [T], returning `null` if there's no
+     * result or if the payload doesn't match the Kotlin model. Decode
+     * failures are logged with a truncated JSON preview (so the reason is
+     * recoverable from logs) rather than thrown — an uncaught
+     * [SerializationException] on a background coroutine dispatcher aborts
+     * the whole Kotlin/Native process, so schema drift must stay local to the
+     * affected RPC rather than crash the app.
+     */
+    inline fun <reified T : Any> resultAs(): T? {
+        val payload = result ?: return null
+        return try {
+            myJson.decodeFromJsonElement<T>(payload)
+        } catch (e: SerializationException) {
+            Logger.withTag("Answer").w(e) {
+                val preview = payload.toString().take(500)
+                "Failed to decode RPC result as ${T::class.simpleName}: $preview"
+            }
+            null
+        }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Event.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Event.kt
@@ -15,43 +15,65 @@ import io.music_assistant.client.data.model.server.events.QueueItemsUpdatedEvent
 import io.music_assistant.client.data.model.server.events.QueueTimeUpdatedEvent
 import io.music_assistant.client.data.model.server.events.QueueUpdatedEvent
 import io.music_assistant.client.utils.myJson
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
+
+private val logger = Logger.withTag("Event")
 
 data class Event(
     val json: JsonObject
 ) {
-    private val type: EventType? = parseEventType(
-        myJson.decodeFromJsonElement<GenericEvent>(json).eventType
-    )
+    private val type: EventType? = runCatching {
+        parseEventType(myJson.decodeFromJsonElement<GenericEvent>(json).eventType)
+    }.getOrElse { e ->
+        logger.w(e) { "Failed to decode event envelope: ${json.toString().take(500)}" }
+        null
+    }
 
-    fun event(): Event<out Any>? = when (type) {
-        EventType.PLAYER_ADDED -> myJson.decodeFromJsonElement<PlayerAddedEvent>(json)
-        EventType.PLAYER_REMOVED -> myJson.decodeFromJsonElement<PlayerRemovedEvent>(json)
-        EventType.PLAYER_UPDATED -> myJson.decodeFromJsonElement<PlayerUpdatedEvent>(json)
-        EventType.MEDIA_ITEM_UPDATED -> myJson.decodeFromJsonElement<MediaItemUpdatedEvent>(json)
-        EventType.MEDIA_ITEM_ADDED -> myJson.decodeFromJsonElement<MediaItemAddedEvent>(json)
-        EventType.MEDIA_ITEM_DELETED -> myJson.decodeFromJsonElement<MediaItemDeletedEvent>(json)
-        EventType.MEDIA_ITEM_PLAYED -> myJson.decodeFromJsonElement<MediaItemPlayedEvent>(json)
-        EventType.QUEUE_UPDATED -> myJson.decodeFromJsonElement<QueueUpdatedEvent>(json)
-        EventType.QUEUE_TIME_UPDATED -> myJson.decodeFromJsonElement<QueueTimeUpdatedEvent>(json)
-        EventType.QUEUE_ITEMS_UPDATED -> myJson.decodeFromJsonElement<QueueItemsUpdatedEvent>(json)
-        EventType.PLAYER_SETTINGS_UPDATED,
-        EventType.QUEUE_ADDED,
-        EventType.QUEUE_SETTINGS_UPDATED,
-        EventType.SHUTDOWN,
-        EventType.PROVIDERS_UPDATED,
-        EventType.PLAYER_CONFIG_UPDATED,
-        EventType.SYNC_TASKS_UPDATED,
-        EventType.TASKS_UPDATED,
-        EventType.AUTH_SESSION,
-        EventType.CONNECTED,
-        EventType.DISCONNECTED,
-        EventType.ALL,
-        null -> {
-            Logger.withTag("Event").w { "Unparsed event: $json" }
-            null
+    /**
+     * Decode the server event into its concrete shape. Returns `null` for
+     * event types we don't currently model and — critically — also when the
+     * payload fails to deserialize. An uncaught [SerializationException]
+     * here would bubble to the websocket message collector and abort the
+     * Kotlin/Native process, so one malformed event must not take the app
+     * down with it.
+     */
+    fun event(): Event<out Any>? = try {
+        when (type) {
+            EventType.PLAYER_ADDED -> myJson.decodeFromJsonElement<PlayerAddedEvent>(json)
+            EventType.PLAYER_REMOVED -> myJson.decodeFromJsonElement<PlayerRemovedEvent>(json)
+            EventType.PLAYER_UPDATED -> myJson.decodeFromJsonElement<PlayerUpdatedEvent>(json)
+            EventType.MEDIA_ITEM_UPDATED -> myJson.decodeFromJsonElement<MediaItemUpdatedEvent>(json)
+            EventType.MEDIA_ITEM_ADDED -> myJson.decodeFromJsonElement<MediaItemAddedEvent>(json)
+            EventType.MEDIA_ITEM_DELETED -> myJson.decodeFromJsonElement<MediaItemDeletedEvent>(json)
+            EventType.MEDIA_ITEM_PLAYED -> myJson.decodeFromJsonElement<MediaItemPlayedEvent>(json)
+            EventType.QUEUE_UPDATED -> myJson.decodeFromJsonElement<QueueUpdatedEvent>(json)
+            EventType.QUEUE_TIME_UPDATED -> myJson.decodeFromJsonElement<QueueTimeUpdatedEvent>(json)
+            EventType.QUEUE_ITEMS_UPDATED -> myJson.decodeFromJsonElement<QueueItemsUpdatedEvent>(json)
+            EventType.PLAYER_SETTINGS_UPDATED,
+            EventType.QUEUE_ADDED,
+            EventType.QUEUE_SETTINGS_UPDATED,
+            EventType.SHUTDOWN,
+            EventType.PROVIDERS_UPDATED,
+            EventType.PLAYER_CONFIG_UPDATED,
+            EventType.SYNC_TASKS_UPDATED,
+            EventType.TASKS_UPDATED,
+            EventType.AUTH_SESSION,
+            EventType.CONNECTED,
+            EventType.DISCONNECTED,
+            EventType.ALL,
+            null -> {
+                logger.w { "Unparsed event: $json" }
+                null
+            }
         }
+    } catch (e: SerializationException) {
+        logger.w(e) {
+            "Failed to decode $type event (payload shape drift?): " +
+                    json.toString().take(500)
+        }
+        null
     }
 
     private fun parseEventType(value: String): EventType? =

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -7,6 +7,7 @@ import io.ktor.client.plugins.websocket.pingInterval
 import io.ktor.serialization.kotlinx.KotlinxWebsocketSerializationConverter
 import io.music_assistant.client.data.model.server.AuthorizationResponse
 import io.music_assistant.client.data.model.server.LoginResponse
+import io.music_assistant.client.data.model.server.ServerInfo
 import io.music_assistant.client.data.model.server.events.Event
 import io.music_assistant.client.settings.ConnectionHistoryEntry
 import io.music_assistant.client.settings.ConnectionType
@@ -41,6 +42,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonPrimitive
@@ -645,10 +647,18 @@ class KtorServiceClient(private val settings: SettingsRepository) : ServiceClien
             rpcEngine.handleResponse(message) -> return
 
             message.containsKey("server_id") -> {
-                _sessionState.update {
-                    (it as? SessionState.Connected)?.update(
-                        serverInfo = myJson.decodeFromJsonElement(message)
-                    ) ?: it
+                val serverInfo = try {
+                    myJson.decodeFromJsonElement<ServerInfo>(message)
+                } catch (e: SerializationException) {
+                    logger.w(e) {
+                        "Failed to decode ServerInfo handshake: ${message.toString().take(500)}"
+                    }
+                    null
+                }
+                if (serverInfo != null) {
+                    _sessionState.update {
+                        (it as? SessionState.Connected)?.update(serverInfo = serverInfo) ?: it
+                    }
                 }
             }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/RpcEngine.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/RpcEngine.kt
@@ -1,6 +1,8 @@
 package io.music_assistant.client.api
 
 import co.touchlab.kermit.Logger
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -12,46 +14,67 @@ import kotlinx.serialization.json.jsonPrimitive
 /**
  * Handles RPC request/response correlation for the Music Assistant API.
  *
- * Manages pending request callbacks and partial result accumulation.
- * The MA server sends large result sets in 500-item batches with "partial": true;
+ * Manages pending request callbacks and partial result accumulation. The
+ * server sends large result sets in 500-item batches with `"partial": true`;
  * this class accumulates them and delivers the merged result to the caller.
  *
- * @param onAuthError Called when the server returns error_code 20 (token expired/invalid).
+ * Thread-safety: [registerCallback] and [removeCallback] are called from
+ * request-issuing coroutines on `Dispatchers.IO`, while [handleResponse]
+ * runs on the websocket message-collector coroutine. On Kotlin/Native those
+ * can run on different threads, and [kotlin.collections.HashMap] is not
+ * concurrency-safe — concurrent mutations corrupt its internal buckets and
+ * surface as `ArrayIndexOutOfBoundsException` out of `HashMap#addKey`. We
+ * use [AtomicReference] with copy-on-write immutable maps instead; every
+ * mutation is a CAS loop, and the races that matter (is this messageId
+ * still pending? what partials did we accumulate?) resolve at the CAS
+ * rather than at a later "check then act" step.
+ *
+ * @param onAuthError Called when the server returns `error_code 20`
+ *   (token expired/invalid).
  */
+@OptIn(ExperimentalAtomicApi::class)
 class RpcEngine(private val onAuthError: () -> Unit) {
 
     private val logger = Logger.withTag("RpcEngine")
-    private val pendingResponses = mutableMapOf<String, (Answer) -> Unit>()
+
+    private val pendingResponses =
+        AtomicReference<Map<String, (Answer) -> Unit>>(emptyMap())
 
     // Accumulated partial results: message_id -> list of result items received so far.
-    private val partialResults = mutableMapOf<String, MutableList<JsonElement>>()
+    private val partialResults =
+        AtomicReference<Map<String, List<JsonElement>>>(emptyMap())
 
     /**
-     * Handle an incoming message. Returns true if the message was an RPC response
-     * (has "message_id"), false if the caller should process it as an event or other message.
+     * Handle an incoming message. Returns true if the message was an RPC
+     * response (has `message_id`), false if the caller should process it as
+     * an event or other message.
      */
     fun handleResponse(message: JsonObject): Boolean {
         val messageId = message["message_id"]?.jsonPrimitive?.content ?: return false
         val isPartial = message["partial"]?.jsonPrimitive?.boolean == true
 
         if (isPartial) {
-            // Accumulate partial batch — don't resolve the callback yet.
             val resultArray = message["result"]?.jsonArray
-            if (resultArray != null && resultArray.isNotEmpty() && pendingResponses.containsKey(messageId)) {
-                val list = partialResults.getOrPut(messageId) { mutableListOf() }
-                list.addAll(resultArray)
+            if (resultArray == null || resultArray.isEmpty()) return true
+            // Only accumulate if a callback is still registered. If the request
+            // was cancelled between batches, dropping the partial avoids a leak.
+            if (!pendingResponses.load().containsKey(messageId)) return true
+            partialResults.update { current ->
+                val existing = current[messageId].orEmpty()
+                current + (messageId to existing + resultArray)
             }
             return true
         }
 
-        // Final response — remove callback and any accumulated partials.
-        val callback = pendingResponses.remove(messageId) ?: return true
-        val accumulated = partialResults.remove(messageId)
+        // Final response — atomically remove the callback and drain partials.
+        val callback = pendingResponses.getAndUpdate { it - messageId }[messageId]
+            ?: return true
+        val accumulated = partialResults.getAndUpdate { it - messageId }[messageId]
 
         val finalMessage = if (accumulated != null) {
-            val finalArray = message["result"]?.jsonArray
-            if (finalArray != null) accumulated.addAll(finalArray)
-            JsonObject(message.toMutableMap().apply { put("result", JsonArray(accumulated)) })
+            val merged = accumulated.toMutableList()
+            message["result"]?.jsonArray?.let(merged::addAll)
+            JsonObject(message.toMutableMap().apply { put("result", JsonArray(merged)) })
         } else {
             message
         }
@@ -69,17 +92,42 @@ class RpcEngine(private val onAuthError: () -> Unit) {
 
     /** Register a pending request callback by message_id. */
     fun registerCallback(messageId: String, callback: (Answer) -> Unit) {
-        pendingResponses[messageId] = callback
+        pendingResponses.update { it + (messageId to callback) }
     }
 
     /** Remove a pending request callback (for cancellation on send failure). */
     fun removeCallback(messageId: String) {
-        pendingResponses.remove(messageId)
+        pendingResponses.update { it - messageId }
+        // Drop any partials accumulated for a request that will never resolve.
+        partialResults.update { it - messageId }
     }
 
     /** Cancel all pending requests — call on disconnect to prevent leaks. */
     fun clear() {
-        pendingResponses.clear()
-        partialResults.clear()
+        pendingResponses.store(emptyMap())
+        partialResults.store(emptyMap())
+    }
+}
+
+@OptIn(ExperimentalAtomicApi::class)
+private inline fun <T> AtomicReference<T>.update(transform: (T) -> T) {
+    while (true) {
+        val current = load()
+        val updated = transform(current)
+        if (compareAndSet(current, updated)) return
+    }
+}
+
+/**
+ * Atomically apply [transform] and return the snapshot that was replaced.
+ * Mirrors `java.util.concurrent.atomic.AtomicReference.getAndUpdate`; handy
+ * when you want to take a value out of a map as part of the CAS.
+ */
+@OptIn(ExperimentalAtomicApi::class)
+private inline fun <T> AtomicReference<T>.getAndUpdate(transform: (T) -> T): T {
+    while (true) {
+        val current = load()
+        val updated = transform(current)
+        if (compareAndSet(current, updated)) return current
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/Player.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/Player.kt
@@ -80,7 +80,11 @@ data class Player(
             id = playerId,
             name = displayName,
             provider = provider,
-            type = type,
+            // Unknown/new server-side player types (coerced to null by myJson) are
+            // treated as regular players so they still show up and aren't mistaken
+            // for a group. If the server adds a genuinely new group-like type we
+            // can surface it explicitly once the mobile app learns about it.
+            type = type ?: PlayerType.PLAYER,
             shouldBeShown = available && enabled && (hidden != true),
             canSetVolume = supportedFeatures.contains(PlayerFeature.VOLUME_SET),
             volumeLevel = volumeLevel,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerPlayer.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerPlayer.kt
@@ -3,17 +3,31 @@ package io.music_assistant.client.data.model.server
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/**
+ * Server-side player payload.
+ *
+ * This arrives from a server that evolves independently of the app: new player
+ * types, new volume-control identifiers, new providers can all appear without a
+ * client update. Non-essential fields carry safe defaults so a single
+ * missing-or-renamed field doesn't take down deserialization of the whole
+ * `ServerPlayer` (and by extension, whatever event or RPC carries it). Combined
+ * with `coerceInputValues = true` in [myJson], unknown enum variants degrade to
+ * `null` rather than aborting the decode.
+ *
+ * `playerId` is the one field kept required — without it there's no identity
+ * and nothing useful we can do with the payload.
+ */
 @Serializable
 data class ServerPlayer(
     @SerialName("player_id") val playerId: String,
-    @SerialName("provider") val provider: String,
-    @SerialName("type") val type: PlayerType,
+    @SerialName("provider") val provider: String = "",
+    @SerialName("type") val type: PlayerType? = null,
     //@SerialName("name") val name: String,
     @SerialName("available") val available: Boolean = false,
     //@SerialName("device_info") val deviceInfo: DeviceInfo,
-    @SerialName("supported_features") val supportedFeatures: List<String>,
+    @SerialName("supported_features") val supportedFeatures: List<String> = emptyList(),
     @SerialName("can_group_with") val canGroupWith: List<String>? = null,
-    @SerialName("enabled") val enabled: Boolean,
+    @SerialName("enabled") val enabled: Boolean = true,
     //@SerialName("elapsed_time") val elapsedTime: Double? = null,
     //@SerialName("elapsed_time_last_updated") val elapsedTimeLastUpdated: Double? = null,
     @SerialName("current_media") val currentMedia: PlayerMedia? = null,
@@ -28,11 +42,11 @@ data class ServerPlayer(
     @SerialName("active_group") val activeGroup: String? = null,
     @SerialName("synced_to") val syncedTo: String? = null,
     @SerialName("group_volume") val groupVolume: Float? = null,
-    @SerialName("display_name") val displayName: String,
+    @SerialName("display_name") val displayName: String = "",
     @SerialName("hidden") val hidden: Boolean? = null,
     //@SerialName("icon") val icon: String,
     //@SerialName("power_control") val powerControl: String,
-    @SerialName("volume_control") val volumeControl: String,
+    @SerialName("volume_control") val volumeControl: String = "",
     @SerialName("mute_control") val muteControl: String? = null,
     //@SerialName("enabled_by_default") val enabledByDefault: Boolean? = null,
     //@SerialName("needs_poll") val needsPoll: Boolean? = null,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerQueue.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerQueue.kt
@@ -3,15 +3,21 @@ package io.music_assistant.client.data.model.server
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/**
+ * Server-side queue payload. Non-critical fields default to safe values so an
+ * older/newer server omitting a field doesn't abort the whole
+ * `List<ServerQueue>` decode — one missing field on one queue would otherwise
+ * throw `MissingFieldException` and take down the whole queue-listing RPC.
+ */
 @Serializable
 data class ServerQueue(
     @SerialName("queue_id") val queueId: String,
     //@SerialName("active") val active: Boolean,
     //@SerialName("display_name") val displayName: String,
-    @SerialName("available") val available: Boolean,
+    @SerialName("available") val available: Boolean = false,
     //@SerialName("items") val items: Int,
-    @SerialName("shuffle_enabled") val shuffleEnabled: Boolean,
-    @SerialName("repeat_mode") val repeatMode: RepeatMode,
+    @SerialName("shuffle_enabled") val shuffleEnabled: Boolean = false,
+    @SerialName("repeat_mode") val repeatMode: RepeatMode = RepeatMode.OFF,
     //@SerialName("dont_stop_the_music_enabled") val dontStopTheMusicEnabled: Boolean,
     //@SerialName("current_index") val currentIndex: Int? = null,
     //@SerialName("index_in_buffer") val indexInBuffer: Int? = null,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/myJson.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/myJson.kt
@@ -6,4 +6,8 @@ val myJson = Json {
     prettyPrint = true
     encodeDefaults = true
     ignoreUnknownKeys = true
+    // New fields added server-side (unknown keys) are already tolerated; with this
+    // we also tolerate unknown enum variants by falling back to the field's default
+    // (for non-null fields) or null (for nullable fields) instead of throwing.
+    coerceInputValues = true
 }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/api/AnswerTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/api/AnswerTest.kt
@@ -1,0 +1,75 @@
+package io.music_assistant.client.api
+
+import io.music_assistant.client.data.model.server.ServerPlayer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Guards the contract of [Answer.resultAs]: a decode failure must stay
+ * local to the affected RPC rather than escape into the calling coroutine.
+ * An uncaught [SerializationException] on a background dispatcher on
+ * Kotlin/Native aborts the whole process, so `resultAs` must:
+ *
+ *  - return the decoded model on success,
+ *  - return `null` when `result` is absent,
+ *  - return `null` (and log) when the payload shape doesn't match `T`.
+ */
+class AnswerTest {
+
+    private fun envelope(resultJson: String): Answer {
+        val raw = """{"message_id": "m1", "result": $resultJson}"""
+        return Answer(Json.parseToJsonElement(raw) as JsonObject)
+    }
+
+    private fun envelopeNoResult(): Answer {
+        val raw = """{"message_id": "m1"}"""
+        return Answer(Json.parseToJsonElement(raw) as JsonObject)
+    }
+
+    @Test
+    fun decodesValidResult() {
+        val answer = envelope("""{"player_id": "p1", "type": "player"}""")
+
+        val player = answer.resultAs<ServerPlayer>()
+
+        assertNotNull(player)
+        assertEquals("p1", player.playerId)
+    }
+
+    @Test
+    fun returnsNullWhenResultIsAbsent() {
+        val answer = envelopeNoResult()
+
+        assertNull(answer.resultAs<ServerPlayer>())
+    }
+
+    @Test
+    fun returnsNullOnUnrecoverableShapeMismatch() {
+        // Use a shape that cannot possibly decode into ServerPlayer — an
+        // array where an object is required. The try/catch must contain
+        // the failure instead of letting it escape the coroutine.
+        val answer = envelope("""[1,2,3]""")
+
+        val player = answer.resultAs<ServerPlayer>()
+
+        assertNull(player, "Shape mismatch must return null, not throw")
+    }
+
+    @Test
+    fun returnsNullWhenResultIsWrongPrimitive() {
+        val answer = envelope(""""just a string"""")
+
+        assertNull(answer.resultAs<ServerPlayer>())
+    }
+
+    @Test
+    fun messageIdIsReadable() {
+        val answer = envelopeNoResult()
+
+        assertEquals("m1", answer.messageId)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/api/EventTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/api/EventTest.kt
@@ -1,0 +1,113 @@
+package io.music_assistant.client.api
+
+import io.music_assistant.client.data.model.server.events.PlayerRemovedEvent
+import io.music_assistant.client.data.model.server.events.PlayerUpdatedEvent
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Guards the contract of [Event.event]: event deserialization is the one
+ * place where *any* server-side schema drift reaches the app, because
+ * events are pushed over the websocket rather than pulled by an RPC we
+ * could defensively retry. An uncaught [SerializationException] here
+ * would bubble to the websocket message-collector coroutine and abort the
+ * process, so `event()` must:
+ *
+ *  - decode known event types normally,
+ *  - return `null` for unknown event types,
+ *  - return `null` when the payload shape for a known event type is wrong,
+ *  - return `null` when the envelope itself fails to parse (no `event`
+ *    field, non-string value, etc.) — including not throwing out of the
+ *    `Event` constructor.
+ */
+class EventTest {
+
+    private fun parse(raw: String): Event =
+        Event(Json.parseToJsonElement(raw) as JsonObject)
+
+    @Test
+    fun decodesKnownEvent() {
+        val raw = """{
+            "event": "player_removed",
+            "object_id": "pl1",
+            "data": null
+        }"""
+
+        val decoded = parse(raw).event()
+
+        assertNotNull(decoded)
+        assertTrue(decoded is PlayerRemovedEvent)
+        assertEquals("pl1", decoded.objectId)
+    }
+
+    @Test
+    fun decodesPlayerUpdatedEventWithMinimalServerPlayer() {
+        // The ServerPlayer inside PLAYER_UPDATED events carries only the
+        // fields the server feels like sending on that update; all
+        // non-identity fields fall back to defaults.
+        val raw = """{
+            "event": "player_updated",
+            "object_id": "pl1",
+            "data": {"player_id": "pl1"}
+        }"""
+
+        val decoded = parse(raw).event()
+
+        assertNotNull(decoded)
+        assertTrue(decoded is PlayerUpdatedEvent)
+        assertEquals("pl1", decoded.data.playerId)
+    }
+
+    @Test
+    fun decodesPlayerUpdatedEventWithUnknownPlayerType() {
+        // `coerceInputValues` on [myJson] combined with ServerPlayer.type
+        // being nullable with a null default means an unknown `type`
+        // string degrades to `null` rather than aborting the decode.
+        val raw = """{
+            "event": "player_updated",
+            "object_id": "pl1",
+            "data": {"player_id": "pl1", "type": "some_new_server_type"}
+        }"""
+
+        val decoded = parse(raw).event()
+
+        assertNotNull(decoded)
+        assertTrue(decoded is PlayerUpdatedEvent)
+        assertNull(decoded.data.type)
+    }
+
+    @Test
+    fun returnsNullForUnknownEventType() {
+        val raw = """{"event": "something_the_client_doesnt_know_about"}"""
+
+        assertNull(parse(raw).event())
+    }
+
+    @Test
+    fun returnsNullWhenEnvelopeMissingEventField() {
+        // Envelope parse fails (`event` is required in GenericEvent). The
+        // constructor must swallow that and leave `type = null` rather than
+        // throwing at construction time.
+        val raw = """{"object_id": "pl1"}"""
+
+        assertNull(parse(raw).event())
+    }
+
+    @Test
+    fun returnsNullWhenPayloadShapeIsWrong() {
+        // Event type is valid, but `data` is a string where an object is
+        // expected — the shape mismatch must be contained, not thrown.
+        val raw = """{
+            "event": "player_updated",
+            "object_id": "pl1",
+            "data": "not an object"
+        }"""
+
+        assertNull(parse(raw).event())
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/api/RpcEngineTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/api/RpcEngineTest.kt
@@ -1,0 +1,290 @@
+package io.music_assistant.client.api
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Guards both the functional contract and the thread-safety contract of
+ * [RpcEngine].
+ *
+ * Functional: register a callback, feed the matching response (including
+ * partial-then-final sequences), and the callback fires with the merged
+ * `result`. `removeCallback` and `clear` prevent firing; auth error
+ * code 20 triggers the [onAuthError] hook.
+ *
+ * Thread-safety: `registerCallback` / `removeCallback` run on the
+ * request-issuing coroutine, while `handleResponse` runs on the websocket
+ * message-collector coroutine. On Kotlin/Native those dispatch to
+ * different threads, so the two `AtomicReference<Map>` fields must behave
+ * correctly under real contention. Two stress tests exercise this on
+ * `Dispatchers.Default` — on JVM unit tests that's the real multi-thread
+ * pool, which is where the plain-`HashMap` implementation used to corrupt
+ * its bucket array and throw `ArrayIndexOutOfBoundsException`.
+ */
+class RpcEngineTest {
+
+    private fun engine(onAuthError: () -> Unit = {}): RpcEngine = RpcEngine(onAuthError)
+
+    private fun message(raw: String): JsonObject =
+        Json.parseToJsonElement(raw) as JsonObject
+
+    @Test
+    fun finalResponseFiresRegisteredCallback() {
+        val engine = engine()
+        var received: Answer? = null
+        engine.registerCallback("m1") { received = it }
+
+        val handled = engine.handleResponse(
+            message("""{"message_id": "m1", "result": {"ok": true}}""")
+        )
+
+        assertTrue(handled)
+        val seen = received
+        assertNotNull(seen)
+        assertEquals("m1", seen.messageId)
+    }
+
+    @Test
+    fun handleResponseReturnsFalseForNonResponseMessage() {
+        val engine = engine()
+
+        val handled = engine.handleResponse(
+            message("""{"event": "player_updated"}""")
+        )
+
+        assertFalse(handled, "Events must not be consumed by RpcEngine")
+    }
+
+    @Test
+    fun partialResponsesAccumulateAndMergeIntoFinal() {
+        val engine = engine()
+        var received: Answer? = null
+        engine.registerCallback("m1") { received = it }
+
+        engine.handleResponse(
+            message("""{"message_id": "m1", "partial": true, "result": [1, 2]}""")
+        )
+        engine.handleResponse(
+            message("""{"message_id": "m1", "partial": true, "result": [3, 4]}""")
+        )
+        engine.handleResponse(
+            message("""{"message_id": "m1", "result": [5]}""")
+        )
+
+        val seen = received
+        assertNotNull(seen)
+        assertEquals("[1,2,3,4,5]", seen.json["result"]?.toString())
+    }
+
+    @Test
+    fun partialWithoutFinalDoesNotInvokeCallback() {
+        val engine = engine()
+        var fired = false
+        engine.registerCallback("m1") { fired = true }
+
+        engine.handleResponse(
+            message("""{"message_id": "m1", "partial": true, "result": [1]}""")
+        )
+
+        assertFalse(fired, "Callback must wait for the non-partial final frame")
+    }
+
+    @Test
+    fun removeCallbackPreventsLaterResponseFromFiring() {
+        val engine = engine()
+        var fired = false
+        engine.registerCallback("m1") { fired = true }
+
+        engine.removeCallback("m1")
+        engine.handleResponse(
+            message("""{"message_id": "m1", "result": {}}""")
+        )
+
+        assertFalse(fired, "Cancelled request must not receive a late response")
+    }
+
+    @Test
+    fun removeCallbackDropsAccumulatedPartials() {
+        val engine = engine()
+        engine.registerCallback("m1") { /* never invoked */ }
+
+        // Accumulate partials, then cancel.
+        engine.handleResponse(
+            message("""{"message_id": "m1", "partial": true, "result": [1, 2]}""")
+        )
+        engine.removeCallback("m1")
+
+        // Register a new request with the same id and a single-shot final
+        // response. The partials from the previous registration must not
+        // leak into this one.
+        var received: Answer? = null
+        engine.registerCallback("m1") { received = it }
+        engine.handleResponse(
+            message("""{"message_id": "m1", "result": [99]}""")
+        )
+
+        val seen = received
+        assertNotNull(seen)
+        assertEquals("[99]", seen.json["result"]?.toString())
+    }
+
+    @Test
+    fun clearDropsAllPendingCallbacks() {
+        val engine = engine()
+        var firedA = false
+        var firedB = false
+        engine.registerCallback("m1") { firedA = true }
+        engine.registerCallback("m2") { firedB = true }
+
+        engine.clear()
+        engine.handleResponse(message("""{"message_id": "m1", "result": {}}"""))
+        engine.handleResponse(message("""{"message_id": "m2", "result": {}}"""))
+
+        assertFalse(firedA)
+        assertFalse(firedB)
+    }
+
+    @Test
+    fun handleResponseOnUnknownMessageIdIsANoOp() {
+        val engine = engine()
+
+        val handled = engine.handleResponse(
+            message("""{"message_id": "ghost", "result": {}}""")
+        )
+
+        assertTrue(handled, "Still 'handled' in the RPC sense — not an event")
+    }
+
+    @Test
+    fun authErrorCallbackFiresOnErrorCode20() {
+        var authErrors = 0
+        val engine = engine(onAuthError = { authErrors++ })
+        engine.registerCallback("m1") { /* ignore */ }
+
+        engine.handleResponse(
+            message("""{"message_id": "m1", "error_code": 20, "error_message": "expired"}""")
+        )
+
+        assertEquals(1, authErrors)
+    }
+
+    @Test
+    fun authErrorNotTriggeredOnOtherErrorCodes() {
+        var authErrors = 0
+        val engine = engine(onAuthError = { authErrors++ })
+        engine.registerCallback("m1") { /* ignore */ }
+
+        engine.handleResponse(
+            message("""{"message_id": "m1", "error_code": 500, "error_message": "server"}""")
+        )
+
+        assertEquals(0, authErrors)
+    }
+
+    /**
+     * Fires many parallel register/respond cycles on `Dispatchers.Default`
+     * so the AtomicReference CAS loops inside [RpcEngine] run under real
+     * contention. The contract: no thrown exception, and every registered
+     * callback fires exactly once (no lost updates from a botched CAS).
+     * Kotlin/Native's new memory model gives the same multi-thread
+     * dispatch on the iOS simulator test target.
+     */
+    @Test
+    fun concurrentRegisterAndHandleDoesNotCrashOrLoseCallbacks() = runBlocking {
+        val engine = engine()
+        val callbackCount = 500
+        val fired = IntArray(callbackCount)
+
+        coroutineScope {
+            repeat(callbackCount) { idx ->
+                launch(Dispatchers.Default) {
+                    val id = "m$idx"
+                    engine.registerCallback(id) { fired[idx] = 1 }
+                    // Parallel thread delivers the response.
+                    respondAsync(engine, id)
+                }
+            }
+        }
+
+        // All responses delivered → all callbacks fired exactly once.
+        val totalFired = fired.sum()
+        assertEquals(
+            callbackCount,
+            totalFired,
+            "Every registered callback must have fired exactly once. " +
+                "Lost count = ${callbackCount - totalFired}",
+        )
+    }
+
+    /**
+     * Exercises the CAS loop in `partialResults.update` specifically.
+     * Many message ids each receive a sequence of partials and a final;
+     * all of that happens in parallel across ids on `Dispatchers.Default`,
+     * so CAS retries on the shared map are forced. Each callback must end
+     * up with the exact expected element count — a dropped update would
+     * surface as a short list.
+     */
+    @Test
+    fun concurrentPartialAccumulationProducesCorrectMergedResult() = runBlocking {
+        val engine = engine()
+        val messageIds = List(20) { "m$it" }
+        val receivedSizes = IntArray(messageIds.size)
+
+        // Register everything first, then flood partials + finals in parallel.
+        messageIds.forEachIndexed { idx, id ->
+            engine.registerCallback(id) { answer ->
+                receivedSizes[idx] =
+                    answer.json["result"]?.toString()?.let { it.count { c -> c == ',' } + 1 }
+                        ?: 0
+            }
+        }
+
+        coroutineScope {
+            messageIds.mapIndexed { idx, id ->
+                async(Dispatchers.Default) {
+                    repeat(10) { batch ->
+                        engine.handleResponse(
+                            message(
+                                """{"message_id": "$id", "partial": true, "result": [$batch]}"""
+                            )
+                        )
+                    }
+                    engine.handleResponse(
+                        message("""{"message_id": "$id", "result": [999]}""")
+                    )
+                    idx
+                }
+            }.awaitAll()
+        }
+
+        // 10 partial batches of 1 item each + 1 final item = 11 items per id.
+        receivedSizes.forEachIndexed { idx, size ->
+            assertEquals(
+                11,
+                size,
+                "Message ${messageIds[idx]} lost partial items under concurrency",
+            )
+        }
+    }
+
+    private fun CoroutineScope.respondAsync(engine: RpcEngine, id: String) {
+        launch(Dispatchers.Default) {
+            engine.handleResponse(
+                message("""{"message_id": "$id", "result": {"ok": true}}""")
+            )
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/ServerPlayerSerializationTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/ServerPlayerSerializationTest.kt
@@ -1,0 +1,128 @@
+package io.music_assistant.client.data.model.server
+
+import io.music_assistant.client.data.model.client.Player.Companion.toPlayer
+import io.music_assistant.client.utils.myJson
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Guards the tolerance contract of [ServerPlayer] deserialization: the
+ * server evolves independently of the client, so any non-identity field
+ * must be absent-tolerant and any enum field must survive an unknown
+ * variant. Specifically:
+ *
+ *  - Only `player_id` is required; every other field has a default so a
+ *    missing wire field does not throw `MissingFieldException`.
+ *  - Unknown `PlayerType` / `PlayerState` variants coerce to `null` via
+ *    `coerceInputValues = true` on [myJson], rather than throwing
+ *    `SerializationException` out of `decodeTaggedEnum`.
+ *  - [ServerPlayer.toPlayer] maps a null `type` back to [PlayerType.PLAYER]
+ *    so a new server-side type still renders as something, instead of
+ *    being silently misclassified as a group.
+ */
+class ServerPlayerSerializationTest {
+
+    @Test
+    fun deserializesWithOnlyPlayerIdPresent() {
+        val json = """{"player_id": "pl1"}"""
+
+        val player = myJson.decodeFromString<ServerPlayer>(json)
+
+        assertEquals("pl1", player.playerId)
+        assertEquals("", player.provider)
+        assertNull(player.type)
+        assertEquals(false, player.available)
+        assertTrue(player.supportedFeatures.isEmpty())
+        assertEquals(true, player.enabled)
+        assertEquals("", player.displayName)
+        assertEquals("", player.volumeControl)
+    }
+
+    @Test
+    fun deserializesUnknownPlayerTypeAsNull() {
+        val json = """{
+            "player_id": "pl1",
+            "type": "surround_group",
+            "display_name": "Living Room"
+        }"""
+
+        val player = myJson.decodeFromString<ServerPlayer>(json)
+
+        assertNull(player.type, "Unknown PlayerType must coerce to null, not throw")
+        assertEquals("Living Room", player.displayName)
+    }
+
+    @Test
+    fun deserializesUnknownPlayerStateAsNull() {
+        val json = """{
+            "player_id": "pl1",
+            "state": "buffering"
+        }"""
+
+        val player = myJson.decodeFromString<ServerPlayer>(json)
+
+        assertNull(player.state, "Unknown PlayerState must coerce to null, not throw")
+    }
+
+    @Test
+    fun deserializesKnownPlayerTypeNormally() {
+        val json = """{"player_id": "pl1", "type": "group"}"""
+
+        val player = myJson.decodeFromString<ServerPlayer>(json)
+
+        assertEquals(PlayerType.GROUP, player.type)
+    }
+
+    @Test
+    fun toPlayerMapsNullTypeToPlainPlayer() {
+        val server = myJson.decodeFromString<ServerPlayer>("""{"player_id": "pl1"}""")
+
+        val player = server.toPlayer()
+
+        assertEquals(PlayerType.PLAYER, player.type)
+        assertEquals(false, player.isGroup)
+    }
+
+    @Test
+    fun toPlayerPreservesKnownGroupType() {
+        val server = myJson.decodeFromString<ServerPlayer>(
+            """{"player_id": "pl1", "type": "group"}"""
+        )
+
+        val player = server.toPlayer()
+
+        assertEquals(PlayerType.GROUP, player.type)
+        assertTrue(player.isGroup)
+    }
+
+    @Test
+    fun deserializesInsideListEvenWhenOneElementHasUnknownEnum() {
+        // RPCs returning List<ServerPlayer> must not lose the entire list when
+        // one entry has a `type` the client doesn't know about — coercion is
+        // applied per-element, not dropped at the collection boundary.
+        val json = """[
+            {"player_id": "good", "type": "player"},
+            {"player_id": "weird", "type": "unknown_future_type"}
+        ]"""
+
+        val players = myJson.decodeFromString<List<ServerPlayer>>(json)
+
+        assertEquals(2, players.size)
+        assertEquals(PlayerType.PLAYER, players[0].type)
+        assertNull(players[1].type)
+    }
+
+    @Test
+    fun toleratesUnknownTopLevelFields() {
+        val json = """{
+            "player_id": "pl1",
+            "brand_new_field_server_added_last_week": { "nested": true }
+        }"""
+
+        val player = myJson.decodeFromString<ServerPlayer>(json)
+
+        assertEquals("pl1", player.playerId)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/ServerQueueSerializationTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/ServerQueueSerializationTest.kt
@@ -1,0 +1,68 @@
+package io.music_assistant.client.data.model.server
+
+import io.music_assistant.client.utils.myJson
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Guards the tolerance contract of [ServerQueue] deserialization: only
+ * `queue_id` is required, every other field carries a default, and an
+ * unknown [RepeatMode] variant coerces to [RepeatMode.OFF] via
+ * `coerceInputValues = true` on [myJson]. The upshot is that one stale
+ * entry in a `List<ServerQueue>` payload never aborts the whole
+ * queue-listing decode.
+ */
+class ServerQueueSerializationTest {
+
+    @Test
+    fun deserializesWithOnlyQueueIdPresent() {
+        val json = """{"queue_id": "q1"}"""
+
+        val queue = myJson.decodeFromString<ServerQueue>(json)
+
+        assertEquals("q1", queue.queueId)
+        assertEquals(false, queue.available)
+        assertEquals(false, queue.shuffleEnabled)
+        assertEquals(RepeatMode.OFF, queue.repeatMode)
+    }
+
+    @Test
+    fun deserializesUnknownRepeatModeAsOff() {
+        val json = """{"queue_id": "q1", "repeat_mode": "random_future_mode"}"""
+
+        val queue = myJson.decodeFromString<ServerQueue>(json)
+
+        assertEquals(
+            RepeatMode.OFF,
+            queue.repeatMode,
+            "Unknown RepeatMode must coerce to the default OFF, not throw",
+        )
+    }
+
+    @Test
+    fun deserializesKnownRepeatModeNormally() {
+        val json = """{"queue_id": "q1", "repeat_mode": "all"}"""
+
+        val queue = myJson.decodeFromString<ServerQueue>(json)
+
+        assertEquals(RepeatMode.ALL, queue.repeatMode)
+    }
+
+    @Test
+    fun listDecodeSurvivesEntryMissingOptionalFields() {
+        // Collection decode is per-element; a sparse entry falls back to
+        // the field defaults rather than throwing out of the list decode.
+        val json = """[
+            {"queue_id": "q1", "available": true, "shuffle_enabled": true, "repeat_mode": "one"},
+            {"queue_id": "q2"}
+        ]"""
+
+        val queues = myJson.decodeFromString<List<ServerQueue>>(json)
+
+        assertEquals(2, queues.size)
+        assertEquals("q1", queues[0].queueId)
+        assertEquals(RepeatMode.ONE, queues[0].repeatMode)
+        assertEquals("q2", queues[1].queueId)
+        assertEquals(RepeatMode.OFF, queues[1].repeatMode)
+    }
+}


### PR DESCRIPTION
I was going through Test Flight stuff and noticed that we've been collecting crash reports and feedback from our initial wave of users, which is *lovely*. Here is a collection of fixes for the four types of crashes that we've seen so far.


ServerPlayer and ServerQueue declared required fields that the server sometimes omits, and their enum fields (PlayerType, PlayerState, RepeatMode) threw SerializationException on unknown wire variants. Non-identity fields now carry safe defaults, and myJson opts into coerceInputValues so unknown enum variants degrade to the default (or null) instead of throwing. Answer.resultAs, Event.event, and the ServerInfo handshake catch SerializationException at the decode boundary so schema drift stays local to the affected RPC. Both platforms benefit: on Kotlin/Native the uncaught exception aborted the whole process, on JVM it would have killed the background coroutine and dropped events.

RpcEngine.pendingResponses and partialResults were plain HashMaps mutated from both the request-issuing coroutines and the websocket message-collector coroutine. HashMap isn't concurrency-safe on either platform; Kotlin/Native surfaced it as
ArrayIndexOutOfBoundsException out of HashMap#addKey, but the JVM was latently vulnerable to the same bucket-array corruption. Both maps are now AtomicReference<Map> with copy-on-write CAS updates, matching the pattern already used elsewhere in the codebase.

Tests (commonTest, 35 new cases across five files) cover minimal ServerPlayer/ServerQueue payloads, unknown enum coercion, list decode surviving sparse entries, Answer/Event behaviour under decode failure, plus two stress tests that hammer RpcEngine on Dispatchers.Default to exercise the AtomicReference CAS loops.