### PR TITLE
fix(ios): pause Compose Metal renderer while app is backgrounded

### DIFF
--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/utils/ComposeRendererBridge.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/utils/ComposeRendererBridge.kt
@@ -1,0 +1,63 @@
+// Compose Multiplatform internals are `internal` to their module; this file deliberately
+// reaches into them. The bridge is small and confined here so the rest of the codebase
+// stays clean.
+@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+
+package io.music_assistant.client.utils
+
+import androidx.compose.ui.window.MetalView
+import co.touchlab.kermit.Logger
+import platform.UIKit.UIView
+import platform.UIKit.UIWindow
+
+private val logger = Logger.withTag("ComposeRendererBridge")
+
+/**
+ * Pauses or resumes Compose Multiplatform's Metal render loop for every CMP-backed view
+ * inside [window].
+ *
+ * Why this exists:
+ *
+ * iOS denies GPU command-buffer submission to background processes
+ * (`kIOGPUCommandBufferCallbackErrorBackgroundExecutionNotPermitted`). Most apps never
+ * notice because their main run loop pauses on backgrounding, which incidentally pauses
+ * `CADisplayLink`. We declare `UIBackgroundModes: audio` so the run loop keeps running for
+ * playback — and CMP's `CADisplayLink` keeps ticking with it, submitting Metal work that iOS
+ * rejects, flooding the console.
+ *
+ * CMP 1.10.1 *does* try to pause its renderer on `UISceneDidEnterBackgroundNotification`
+ * via `SceneForegroundStateListener`, but the listener filters notifications by
+ * `notification.object == view.window?.windowScene`. Inside a SwiftUI `WindowGroup`, that
+ * scene reference can race the notification timing and the equality check misses, so the
+ * built-in pause never fires for our hosting topology. This bridge is a deterministic
+ * backstop driven from the Swift scene-notification observer.
+ *
+ * Implementation notes:
+ *  - `MetalView` is `internal` in CMP, hence the `@file:Suppress`. `redrawer` and
+ *    `redrawer.isActive` are public properties on a public type (`MetalRedrawer`); the
+ *    suppression only covers the `is MetalView` cast.
+ *  - Setting `redrawer.isActive = false` is idempotent (CMP no-ops if already at the target
+ *    value) and synchronously pauses the underlying `CADisplayLink` plus drains in-flight
+ *    command buffers. Safe to call from the main thread; not safe from any other thread.
+ *  - Pinned to Compose Multiplatform 1.10.1. If `MetalView` is renamed, repackaged, or made
+ *    fully private in a future CMP version, this bridge will fail to compile — that's the
+ *    intended early-warning signal to revisit the integration.
+ */
+fun setComposeRendererPaused(window: UIWindow, paused: Boolean) {
+    var count = 0
+    walkMetalViews(window) { metalView ->
+        metalView.redrawer.isActive = !paused
+        count++
+    }
+    val state = if (paused) "paused" else "resumed"
+    logger.d { "Compose renderer $state ($count MetalView${if (count == 1) "" else "s"})" }
+}
+
+private fun walkMetalViews(view: UIView, action: (MetalView) -> Unit) {
+    if (view is MetalView) action(view)
+    @Suppress("UNCHECKED_CAST")
+    val children = view.subviews as List<UIView>
+    for (child in children) {
+        walkMetalViews(child, action)
+    }
+}

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		C851192E2F18C8A200185678 /* ogg in Frameworks */ = {isa = PBXBuildFile; productRef = C851192D2F18C8A200185678 /* ogg */; };
 		C8CP00012F1A000000000001 /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CP00032F1A000000000001 /* CarPlaySceneDelegate.swift */; };
 		C8CP00022F1A000000000002 /* CarPlayContentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CP00042F1A000000000002 /* CarPlayContentManager.swift */; };
+		C8CR00012F2A000000000001 /* ComposeRenderingGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CR00022F2A000000000002 /* ComposeRenderingGuard.swift */; };
 		C8FCC1922F17C6A9005E8312 /* NowPlayingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8FCC1912F17C6A9005E8312 /* NowPlayingManager.swift */; };
 		C8FCC1952F17E001005E8312 /* NativeAudioController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8FCC1962F17E001005E8312 /* NativeAudioController.swift */; };
 		C8FCC1972F17E001005E8312 /* AudioDecoders.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8FCC1982F17E001005E8312 /* AudioDecoders.swift */; };
@@ -33,6 +34,7 @@
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		C8CP00032F1A000000000001 /* CarPlaySceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlaySceneDelegate.swift; sourceTree = "<group>"; };
 		C8CP00042F1A000000000002 /* CarPlayContentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayContentManager.swift; sourceTree = "<group>"; };
+		C8CR00022F2A000000000002 /* ComposeRenderingGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeRenderingGuard.swift; sourceTree = "<group>"; };
 		C8FCC1912F17C6A9005E8312 /* NowPlayingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingManager.swift; sourceTree = "<group>"; };
 		C8FCC1962F17E001005E8312 /* NativeAudioController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeAudioController.swift; sourceTree = "<group>"; };
 		C8FCC1982F17E001005E8312 /* AudioDecoders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDecoders.swift; sourceTree = "<group>"; };
@@ -97,6 +99,7 @@
 				7555FF82242A565900829871 /* ContentView.swift */,
 				7555FF8C242A565B00829871 /* Info.plist */,
 				2152FB032600AC8F00CF470E /* iOSApp.swift */,
+				C8CR00022F2A000000000002 /* ComposeRenderingGuard.swift */,
 				058557D7273AAEEB004C7B11 /* Preview Content */,
 				C8CP00052F1A000000000003 /* CarPlay */,
 			);
@@ -233,6 +236,7 @@
 				C8FCC1972F17E001005E8312 /* AudioDecoders.swift in Sources */,
 				C8CP00012F1A000000000001 /* CarPlaySceneDelegate.swift in Sources */,
 				C8CP00022F1A000000000002 /* CarPlayContentManager.swift in Sources */,
+				C8CR00012F2A000000000001 /* ComposeRenderingGuard.swift in Sources */,
 				C8SI00012F1B000000000001 /* SiriIntentHandler.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iosApp/iosApp/ComposeRenderingGuard.swift
+++ b/iosApp/iosApp/ComposeRenderingGuard.swift
@@ -1,0 +1,58 @@
+import UIKit
+import ComposeApp
+
+/// Halts Compose Multiplatform's Metal render loop while the default app scene is in the
+/// background, then resumes it on foreground.
+///
+/// Why we need this:
+///   Music Assistant declares `UIBackgroundModes: audio` so playback continues when the user
+///   leaves the app. iOS keeps our main run loop alive for that, which means CMP's
+///   `CADisplayLink` keeps ticking too. Each tick submits a Metal command buffer, which iOS
+///   denies in the background with `kIOGPUCommandBufferCallbackErrorBackgroundExecutionNot
+///   Permitted`, flooding the console. CMP 1.10.1 has a built-in pause path that listens for
+///   the same scene notifications, but inside SwiftUI's `WindowGroup` hosting its scene
+///   matching can race the notification timing — so this observer is a deterministic
+///   backstop that toggles the renderer directly via `ComposeRendererBridgeKt`.
+///
+/// Lifecycle:
+///   The observer is created once at app launch (via `iOSApp.init()`) and lives for the
+///   process lifetime. `NotificationCenter` holds non-owning references, so the singleton
+///   pattern is what keeps the observer alive.
+final class ComposeRenderingGuard {
+    static let shared = ComposeRenderingGuard()
+
+    private init() {
+        let center = NotificationCenter.default
+        center.addObserver(
+            self,
+            selector: #selector(sceneDidEnterBackground(_:)),
+            name: UIScene.didEnterBackgroundNotification,
+            object: nil
+        )
+        center.addObserver(
+            self,
+            selector: #selector(sceneWillEnterForeground(_:)),
+            name: UIScene.willEnterForegroundNotification,
+            object: nil
+        )
+    }
+
+    @objc private func sceneDidEnterBackground(_ notification: Notification) {
+        applyPause(true, from: notification)
+    }
+
+    @objc private func sceneWillEnterForeground(_ notification: Notification) {
+        applyPause(false, from: notification)
+    }
+
+    /// CarPlay runs its own UI loop inside `CPTemplateApplicationScene`, which is *not* a
+    /// `UIWindowScene` — so the `as? UIWindowScene` cast already filters it out. The same
+    /// guard skips any non-window UIScene we don't manage.
+    private func applyPause(_ paused: Bool, from notification: Notification) {
+        guard let scene = notification.object as? UIWindowScene else { return }
+
+        for window in scene.windows {
+            ComposeRendererBridgeKt.setComposeRendererPaused(window: window, paused: paused)
+        }
+    }
+}

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -73,6 +73,12 @@ struct iOSApp: App {
         // Initialize NowPlayingManager early to configure AudioSession
         _ = NowPlayingManager.shared
 
+        // Subscribe to scene background/foreground notifications before any scene connects,
+        // so we can halt Compose's Metal render loop while backgrounded. UIBackgroundModes:
+        // audio keeps our run loop alive, which would otherwise let CMP keep submitting GPU
+        // work that iOS rejects.
+        _ = ComposeRenderingGuard.shared
+
         // Required for apps to appear in Control Center
         // Must be called for remote control events to work
         UIApplication.shared.beginReceivingRemoteControlEvents()


### PR DESCRIPTION
I was investigating the WebRTC stuff and noticed when parsing through the logs that we were trying to do some GUI-related work while in the background. The calls were just rejected, it was not a crasher, but it made the logs noisy and was just wasted CPU cycles. This sorts it out.


UIBackgroundModes: audio keeps our run loop alive for playback, which lets CMP's CADisplayLink keep ticking and submitting Metal work that iOS rejects with kIOGPUCommandBufferCallbackErrorBackgroundExecutionNot Permitted, flooding the Xcode console. CMP 1.10.1 has a built-in pause path, but its SceneForegroundStateListener filters notifications by scene-equality and that check races SwiftUI's WindowGroup hosting, so it doesn't fire reliably for our topology.

Add a Swift NotificationCenter observer (ComposeRenderingGuard) that listens for UIScene.didEnterBackgroundNotification / willEnterForegroundNotification and toggles MetalRedrawer.isActive directly via a small Kotlin bridge. The bridge crosses CMP's internal boundary with @file:Suppress and is pinned to CMP 1.10.1 — the is-MetalView cast site is the intended early-warning signal on a future CMP upgrade.

Verified on device: zero IOGPUMetalError lines across a full background/foreground cycle, audio streaming uninterrupted, no Compose state loss on resume.