### PR TITLE
fix(api): hoist Answer logger to companion field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,5 +58,11 @@ gha-creds-*.json
 .claude/settings.local.json
 .mcp.json
 
+# Always use a venv for Python
+.venv/
+
+# Local TestFlight crash reports and tester feedback
+testflight-reports/
+
 # Downloaded binary frameworks (too large for git, see ios_build_instructions.md step 5)
 iosApp/Frameworks/

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Answer.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Answer.kt
@@ -28,11 +28,18 @@ data class Answer(
         return try {
             myJson.decodeFromJsonElement<T>(payload)
         } catch (e: SerializationException) {
-            Logger.withTag("Answer").w(e) {
+            logger.w(e) {
                 val preview = payload.toString().take(500)
                 "Failed to decode RPC result as ${T::class.simpleName}: $preview"
             }
             null
         }
+    }
+
+    companion object {
+        // `@PublishedApi internal` (not `private`) is required so the inline
+        // `resultAs` above can reference this from call-site bytecode.
+        @PublishedApi
+        internal val logger = Logger.withTag("Answer")
     }
 }


### PR DESCRIPTION
Address PR #262 review feedback (formatBCE) — avoid reconstructing Logger.withTag("Answer") on every decode failure by holding it in the companion object. @PublishedApi internal is required so the inline resultAs() can reference it from call-site bytecode.

Also a small tweak to the gitignore, didn't figure it was worth a separate PR.