### PR TITLE
fix(ios/carplay): black screen on launch

### DIFF
--- a/.claude/carplay.md
+++ b/.claude/carplay.md
@@ -48,8 +48,9 @@ Browse uses a `CPGridTemplate` with SF Symbol icons and adaptive theming:
 | `iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift` | Scene delegate, template creation, navigation |
 | `iosApp/iosApp/CarPlay/CarPlayContentManager.swift` | Data fetching bridge, maps `AppMediaItem` → `CPListItem`, image loading |
 | `iosApp/iosApp/CarPlay/SiriIntentHandler.swift` | `INPlayMediaIntentHandling` — resolve search + handle playback via Siri |
-| `iosApp/iosApp/iOSApp.swift` | `AppDelegate` for CarPlay scene routing + KMP ready notification |
+| `iosApp/iosApp/iOSApp.swift` | `AppDelegate` for CarPlay scene routing; calls `bootstrapKmp()` from `iOSApp.init()` before any scene connects |
 | `iosApp/NowPlayingManager.swift` | Control Center / lock screen / Now Playing artwork via `MPNowPlayingInfoCenter` |
+| `composeApp/src/iosMain/.../MainViewController.kt` | Hosts `bootstrapKmp()` (idempotent KMP/Koin init) and `MainViewController()` for the SwiftUI Compose bridge |
 | `composeApp/src/iosMain/.../KmpHelper.kt` | iOS-only bridge: fetch methods for all categories, recommendations, search, playback |
 | `iosApp/iosApp/CarPlay.entitlements` | `com.apple.developer.carplay-audio` entitlement |
 | `iosApp/iosApp/Info.plist` | `CPTemplateApplicationSceneSessionRoleApplication` scene config |
@@ -74,13 +75,11 @@ Swift-accessible methods in `KmpHelper.kt` (iosMain only):
 
 ## Koin Initialization Timing
 
-CarPlay scene may connect before the main SwiftUI view renders (which triggers `initKoin` via `MainViewController`). The solution:
+A cold launch from CarPlay (tapping the icon on the head unit) connects only the `CPTemplateApplicationScene` — SwiftUI's `WindowGroup` scene never connects, so `ContentView.onAppear` never fires. Anything tied to the SwiftUI lifecycle is therefore unreachable on this path.
 
-1. `iOSApp.swift` posts `Notification.Name("KMPReadyNotification")` when `ContentView` appears
-2. `CarPlaySceneDelegate` checks `KmpState.isReady` on connect
-3. If not ready, observes the notification and defers template setup
+`iOSApp.init()` calls `MainViewControllerKt.bootstrapKmp()` before any scene-delegate `didConnect` runs. `bootstrapKmp()` is idempotent — backed by a `Unit by lazy` because `startKoin` (inside `initKoin`) throws if invoked twice — so `MainViewController()`'s `ComposeUIViewController` configure block can still call it on the SwiftUI-only path without conflict.
 
-No core/common Kotlin files are modified — the guard is entirely in Swift.
+`KmpState.isReady` and `KMPReadyNotification` remain in `iOSApp.swift` for `SiriIntentHandler`, which can be invoked outside the scene lifecycle.
 
 ## Item Selection Flow
 

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/MainViewController.kt
@@ -16,12 +16,20 @@ import platform.Foundation.NSUTF8StringEncoding
 import platform.Foundation.create
 import platform.Foundation.writeToFile
 
+fun bootstrapKmp() {
+    kmpBootstrap
+}
+
+// `by lazy` because `startKoin` (in `initKoin`) throws if invoked twice;
+// callers from both Swift `iOSApp.init()` and `MainViewController()` below.
+private val kmpBootstrap: Unit by lazy {
+    initKoin(iosModule())
+    cleanupStaleLogFile()
+    installCrashHandler()
+}
+
 fun MainViewController() = ComposeUIViewController(
-    configure = {
-        initKoin(iosModule())
-        cleanupStaleLogFile()
-        installCrashHandler()
-    }
+    configure = { bootstrapKmp() }
 ) { App() }
 
 private fun cleanupStaleLogFile() {

--- a/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
+++ b/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
@@ -5,42 +5,19 @@ import ComposeApp
 class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
 
     var interfaceController: CPInterfaceController?
-    private var kmpReadyObserver: NSObjectProtocol?
 
     // MARK: - CPTemplateApplicationSceneDelegate
 
     func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene, didConnect interfaceController: CPInterfaceController) {
         self.interfaceController = interfaceController
         print("CP: Connected to CarPlay")
-
-        // Koin/KMP is initialized when ContentView renders (MainViewController configure block).
-        // CarPlay may connect before that, so check the shared flag first.
-        if KmpState.isReady {
-            KmpHelper.shared.onExternalConsumerActive()
-            setupTemplates()
-        } else {
-            kmpReadyObserver = NotificationCenter.default.addObserver(
-                forName: KmpState.readyNotification, object: nil, queue: .main
-            ) { [weak self] _ in
-                KmpHelper.shared.onExternalConsumerActive()
-                self?.setupTemplates()
-                if let observer = self?.kmpReadyObserver {
-                    NotificationCenter.default.removeObserver(observer)
-                    self?.kmpReadyObserver = nil
-                }
-            }
-        }
+        KmpHelper.shared.onExternalConsumerActive()
+        setupTemplates()
     }
 
     func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene, didDisconnectInterfaceController interfaceController: CPInterfaceController) {
         self.interfaceController = nil
-        if let observer = kmpReadyObserver {
-            NotificationCenter.default.removeObserver(observer)
-            kmpReadyObserver = nil
-        }
-        if KmpState.isReady {
-            KmpHelper.shared.onExternalConsumerInactive()
-        }
+        KmpHelper.shared.onExternalConsumerInactive()
         print("CP: Disconnected from CarPlay")
     }
 

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>10</string>
+	<string>11</string>
 	<key>INIntentsSupported</key>
 	<array>
 		<string>INPlayMediaIntent</string>

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -4,8 +4,6 @@ import UIKit
 import CarPlay
 import Intents
 
-/// Tracks Koin/KMP initialization state for CarPlay.
-/// ContentView triggers MainViewController which calls initKoin on first render.
 enum KmpState {
     static var isReady = false
     static let readyNotification = Notification.Name("KMPReadyNotification")
@@ -79,6 +77,13 @@ struct iOSApp: App {
         // work that iOS rejects.
         _ = ComposeRenderingGuard.shared
 
+        // Must precede any scene-delegate `didConnect`: both the default
+        // SwiftUI scene and `CarPlaySceneDelegate` resolve Koin in their
+        // connect callbacks.
+        MainViewControllerKt.bootstrapKmp()
+        KmpState.isReady = true
+        NotificationCenter.default.post(name: KmpState.readyNotification, object: nil)
+
         // Required for apps to appear in Control Center
         // Must be called for remote control events to work
         UIApplication.shared.beginReceivingRemoteControlEvents()
@@ -88,17 +93,10 @@ struct iOSApp: App {
         WindowGroup {
             ContentView()
                 .onAppear {
-                    // Koin is initialized by MainViewController's configure block
-                    // (called when ContentView first renders). Notify CarPlay.
-                    KmpState.isReady = true
-                    NotificationCenter.default.post(name: KmpState.readyNotification, object: nil)
-
-                    // Wire OAuth: Android does the equivalent in MainActivity.onCreate.
-                    // Must happen after Koin init, which onAppear guarantees.
+                    // OAuthHandler presents `ASWebAuthenticationSession`;
+                    // requires a live scene, so can't move to `init()`.
                     KmpHelper.shared.authManager.oauthHandler = OAuthHandler()
 
-                    // If a cold-launch OAuth callback arrived before Koin was ready,
-                    // replay it now.
                     if let pending = PendingOAuthCallback.url {
                         PendingOAuthCallback.url = nil
                         handleOAuthCallback(pending)


### PR DESCRIPTION
A cold launch from CarPlay connects only the CPTemplateApplicationScene;
SwiftUI's WindowGroup scene never connects, so ContentView.onAppear
never fires. Koin was initialized inside MainViewController's configure
block (driven by ContentView), so on this path Koin never started and
CarPlaySceneDelegate waited forever for KMPReadyNotification — no
setRootTemplate call, head unit shows black.

Move bootstrap to iOSApp.init(), which runs on the main thread before
any scene-delegate didConnect. Extract bootstrapKmp() in
MainViewController.kt as the single entry point, backed by a
Unit-by-lazy holder so callers from both Swift (iOSApp.init) and the
ComposeUIViewController configure block are safe — startKoin would
otherwise throw on the second call.

Drop the now-dead KMPReadyNotification observer branch from
CarPlaySceneDelegate. KmpState/KMPReadyNotification remain in
iOSApp.swift for SiriIntentHandler, which can be invoked outside the
scene lifecycle.

Update .claude/carplay.md to match the new architecture.