### PR TITLE
fix: WebRTC sendspin channel reuse + unify reauth-on-reconnect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ gha-creds-*.json
 
 # Local Claude Code settings
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 .mcp.json
 
 # Always use a venv for Python

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -117,6 +117,12 @@ class KtorServiceClient(private val settings: SettingsRepository) : ServiceClien
         val currentState = _sessionState.value as? SessionState.Connected.WebRTC ?: return
         logger.i { "Forcing WebRTC reconnect for fresh sendspin channel" }
 
+        // `connectionData` is carried verbatim so `Reconnecting.WebRTC` keeps the
+        // current `user` for UI display during the reconnect window. The reauth-
+        // sensitive fields (`serverInfo`, `needsServerReauth`, `authProcessState`)
+        // get rebuilt by `observeTransport` when the new peer connection lands and
+        // emits Connected; until then they're irrelevant because no collector acts
+        // on Reconnecting state.
         _sessionState.update {
             SessionState.Reconnecting.WebRTC(
                 attempt = 0,
@@ -297,6 +303,8 @@ class KtorServiceClient(private val settings: SettingsRepository) : ServiceClien
         backgroundInfo: () -> BackgroundedConnectionInfo,
         onFreshConnect: () -> Unit,
         onReconnected: suspend () -> Unit,
+        needsReauthOnReconnect: Boolean = false,
+        clearsServerInfoOnReconnect: Boolean = false,
     ) {
         transportObserverJob?.cancel()
         transportObserverJob = launch {
@@ -309,7 +317,47 @@ class KtorServiceClient(private val settings: SettingsRepository) : ServiceClien
                                 (_sessionState.value as? HasConnectionData)?.connectionData
                                     ?: ConnectionData()
                             val wasReconnecting = _sessionState.value is SessionState.Reconnecting
-                            _sessionState.update { createConnected(preserved) }
+                            // Both transports use per-connection auth state on the server,
+                            // so every reconnect needs a fresh `client/auth`. Rather than
+                            // call `authorize` from `onReconnected` (which races with the
+                            // session-state emit — MainDataSource can see Authenticated
+                            // and fire RPCs before the auth round-trip lands), flag
+                            // `needsServerReauth` and let AuthenticationManager drive
+                            // re-auth from the resulting `AwaitingAuth(NotStarted)` state.
+                            // While the flag is set, `dataConnectionState` keeps gating
+                            // RPCs even if `authorize` later fails — a `Failed` state with
+                            // `needsServerReauth=true` still reports `AwaitingAuth(Failed)`,
+                            // so MainDataSource's stale-data path holds the line until the
+                            // user retries login or the transport bounces again.
+                            //
+                            // `serverInfo` handling differs by transport. WebRTC clears
+                            // it because the gateway proxies the data channel onto a
+                            // fresh local WebSocket and races the two legs: if
+                            // `client/auth` is sent before the gateway has forwarded the
+                            // new `server/hello` back through the (not-yet-`open`)
+                            // channel, auth is silently lost. Clearing `serverInfo`
+                            // forces `AwaitingServerInfo`, holding `authorize` until the
+                            // fresh `server/hello` arrives. Direct WebSocket has no such
+                            // ordering gate — the new `server/hello` will refresh the
+                            // cached value over the same FIFO channel that carries
+                            // `client/auth` next, so we leave `serverInfo` populated and
+                            // let `AwaitingAuth` trigger immediately.
+                            //
+                            // `authProcessState` resets to `NotStarted` so AuthMgr's
+                            // collector actually fires; a stale `InProgress` from a
+                            // mid-flight auth at disconnect time would otherwise park
+                            // the collector. `user` is preserved so the UI keeps
+                            // showing the user as logged in throughout the reconnect.
+                            val emitData = if (wasReconnecting && needsReauthOnReconnect) {
+                                preserved.copy(
+                                    serverInfo = if (clearsServerInfoOnReconnect) null else preserved.serverInfo,
+                                    needsServerReauth = true,
+                                    authProcessState = AuthProcessState.NotStarted,
+                                )
+                            } else {
+                                preserved
+                            }
+                            _sessionState.update { createConnected(emitData) }
                             if (wasReconnecting) {
                                 onReconnected()
                             } else {
@@ -397,7 +445,16 @@ class KtorServiceClient(private val settings: SettingsRepository) : ServiceClien
                     ),
                 )
             },
-            onReconnected = {}, // Direct doesn't need re-auth — server preserves session
+            onReconnected = {
+                // Re-auth is owned by AuthenticationManager (driven by the
+                // `needsReauthOnReconnect = true` gate above); nothing to do here.
+                logger.i { "Direct reconnection successful — awaiting AuthenticationManager re-auth" }
+            },
+            needsReauthOnReconnect = true,
+            // serverInfo stays populated: Direct WS has no `server/hello`-before-`client/auth`
+            // ordering gate (unlike the WebRTC gateway), and the next `server/hello` will
+            // overwrite any stale cached value over the same FIFO channel that carries auth.
+            clearsServerInfoOnReconnect = false,
         )
         directTransport.connect()
     }
@@ -434,17 +491,15 @@ class KtorServiceClient(private val settings: SettingsRepository) : ServiceClien
                 )
             },
             onReconnected = {
-                // WebRTC-specific: re-authenticate with saved token after successful reconnection
-                logger.i { "WebRTC reconnection successful! Re-authenticating..." }
-                val serverIdentifier = settings.getWebRTCServerIdentifier(remoteId.rawId)
-                val token = settings.getTokenForServer(serverIdentifier)
-                if (token != null) {
-                    logger.i { "Re-authenticating after WebRTC reconnection with saved token" }
-                    authorize(token, isAutoLogin = true)
-                } else {
-                    logger.w { "No saved token to re-authenticate with for WebRTC server" }
-                }
+                // Re-auth is owned by AuthenticationManager (driven by the
+                // `needsReauthOnReconnect = true` gate above); nothing to do here.
+                logger.i { "WebRTC reconnection successful — awaiting AuthenticationManager re-auth" }
             },
+            needsReauthOnReconnect = true,
+            // serverInfo cleared: WebRTC gateway races data channel `on_message`
+            // for `client/auth` against forwarding the new `server/hello`. Forcing
+            // `AwaitingServerInfo` until the fresh hello arrives sidesteps the race.
+            clearsServerInfoOnReconnect = true,
         )
         webrtcTransport.connect()
     }
@@ -479,6 +534,18 @@ class KtorServiceClient(private val settings: SettingsRepository) : ServiceClien
         }
     }
 
+    /**
+     * Marks the current auth attempt as failed. Intentionally does NOT clear
+     * `needsServerReauth` — if the failure happened on a transport reconnect,
+     * the underlying server-side session is still invalid and only a successful
+     * `authorize` round-trip can clear the flag. With the flag set, the state
+     * stays `AwaitingAuth(Failed)` (per `ConnectionData.dataConnectionState`),
+     * which holds MainDataSource on stale data instead of letting it fire RPCs
+     * that would 401 against the unauthenticated session. Recovery is either a
+     * manual re-login (success path clears the flag) or another transport
+     * bounce (which resets `authProcessState` to `NotStarted` so AuthMgr
+     * re-fires).
+     */
     private fun setAuthFailed(reason: String) = setAuthState(AuthProcessState.Failed(reason))
 
     override suspend fun login(
@@ -610,6 +677,7 @@ class KtorServiceClient(private val settings: SettingsRepository) : ServiceClien
                         authProcessState = AuthProcessState.NotStarted,
                         user = user,
                         wasAutoLogin = isAutoLogin,
+                        needsServerReauth = false,
                     ) ?: it
                 }
             } ?: run {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/auth/AuthenticationManager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/auth/AuthenticationManager.kt
@@ -56,8 +56,7 @@ class AuthenticationManager(
                             when (dataConnectionState.authProcessState) {
                                 AuthProcessState.NotStarted -> {
                                     // Try auto-login with saved token (unless we're intentionally logging out)
-                                    val loggingOut = isLoggingOut
-                                    if (!loggingOut) {
+                                    if (!isLoggingOut) {
                                         val serverIdentifier = when (state) {
                                             is SessionState.Connected.Direct ->
                                                 settings.getDirectServerIdentifier(
@@ -68,8 +67,9 @@ class AuthenticationManager(
                                             is SessionState.Connected.WebRTC ->
                                                 settings.getWebRTCServerIdentifier(state.remoteId.rawId)
                                         }
-                                        val token = settings.getTokenForServer(serverIdentifier)
-                                        token?.let { authorizeWithSavedToken(it) }
+                                        settings.getTokenForServer(serverIdentifier)?.let {
+                                            authorizeWithSavedToken(it)
+                                        }
                                     }
                                 }
 
@@ -220,7 +220,6 @@ class AuthenticationManager(
             }
 
             // Timeout - connection not established
-            val currentState = serviceClient.sessionState.value
             Logger.e("Connection timeout - cannot authorize")
             _authState.value = AuthState.Error("Connection timeout. Please try again.")
         }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -277,65 +277,27 @@ class MainDataSource(
 
                                     when (currentState.reason) {
                                         StaleReason.RECONNECTING -> {
-                                            // Brief disconnection - data is still fresh!
-                                            // Transition stale data back to Data without fetching
-                                            // This prevents the "blink" from reloading the UI
+                                            // Brief disconnection — data is still fresh. Transition
+                                            // stale → Data without re-fetching to avoid a UI blink.
+                                            // This branch only runs when dataConnectionState is
+                                            // already Authenticated; if a reconnect requires re-auth,
+                                            // the else branch below preserves Stale data until
+                                            // AuthenticationManager finishes re-authorizing.
                                             log.i { "Seamless recovery - reusing cached data" }
                                             _serverPlayers.update {
                                                 DataState.Data(currentState.data)
                                             }
 
-                                            // Refresh queue items for the selected player.
-                                            // selectedPlayerIndex won't re-emit (same value),
-                                            // so the collector at line ~582 won't fire.
+                                            // selectedPlayerIndex doesn't re-emit on stale-recovery
+                                            // (same value before/after), so refresh manually.
                                             refreshSelectedPlayerQueueItems()
 
-                                            // CRITICAL: Re-authenticate the server session
-                                            // New WebSocket connection needs auth command sent
-                                            launch {
-                                                // Get token for current server
-                                                val serverIdentifier = when (
-                                                    val state =
-                                                    apiClient.sessionState.value
-                                                ) {
-                                                    is SessionState.Connected.Direct -> {
-                                                        state.connectionInfo.let { connInfo ->
-                                                            settings.getDirectServerIdentifier(
-                                                                connInfo.host,
-                                                                connInfo.port,
-                                                                connInfo.isTls,
-                                                            )
-                                                        }
-                                                    }
-
-                                                    is SessionState.Connected.WebRTC -> {
-                                                        settings.getWebRTCServerIdentifier(state.remoteId.rawId)
-                                                    }
-
-                                                    else -> null
-                                                }
-
-                                                val token = serverIdentifier?.let {
-                                                    settings.getTokenForServer(it)
-                                                }
-
-                                                if (token != null) {
-                                                    log.i { "Re-authenticating after reconnection with saved token" }
-                                                    apiClient.authorize(token, isAutoLogin = true)
-                                                } else {
-                                                    log.w { "No saved token to re-authenticate with" }
-                                                }
-                                            }
-
-                                            // Reinit Sendspin — safe because initSendspinIfEnabled()
-                                            // returns early if already Connected/Reconnecting.
-                                            // Needed because:
-                                            //  - WebRTC: new data channels were created on reconnect;
-                                            //    old SendspinClient holds a dead channel (Idle state).
-                                            //  - WebSocket: reconnection may have given up;
-                                            //    server removes the player when the socket closes.
-                                            sendspinClientFactory.onFreshWebRTCConnection()
+                                            // Sendspin reinit: WebRTC sendspin auth is inherited
+                                            // from the data channel itself, not JSON-RPC auth state,
+                                            // so it must be re-driven independently of the main
+                                            // connection's auth lifecycle.
                                             launch { initSendspinIfEnabled() }
+
                                             // Drain any commands queued while disconnected
                                             localPlayerRepository.drainCommandQueue()
                                         }
@@ -360,8 +322,9 @@ class MainDataSource(
                                     updateProvidersManifests()
                                     updatePlayersAndQueues()
                                     refreshSelectedPlayerQueueItems()
-                                    // Safety net: reinit Sendspin if it's not already connected
-                                    sendspinClientFactory.onFreshWebRTCConnection()
+                                    // Safety net: reinit Sendspin if it's not already connected.
+                                    // Factory detects channel freshness from the DataChannelWrapper
+                                    // identity, so no manual reset needed here.
                                     launch { initSendspinIfEnabled() }
                                 }
 
@@ -369,7 +332,6 @@ class MainDataSource(
                                     // Fresh connection or error recovery - show loading
                                     _serverPlayers.update { DataState.Loading() }
                                     updateProvidersManifests()
-                                    sendspinClientFactory.onFreshWebRTCConnection()
                                     initSendspinIfEnabled()
                                     updatePlayersAndQueues()
                                 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/SendspinClientFactory.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/SendspinClientFactory.kt
@@ -51,6 +51,13 @@ class SendspinClientFactory(
     private var sharedClockSynchronizer: ClockSynchronizer? = null
     private var sharedPipeline: AudioStreamManager? = null
     private var delayCollectorJob: Job? = null
+
+    // The WebRTC sendspin channel is single-use: after we send client/goodbye,
+    // the server tears down its handler for that channel even though it remains
+    // Open at the WebRTC layer. The DataChannelWrapper instance is the canonical
+    // "channel freshness" identity — a brand-new instance is created only when
+    // WebRTCConnectionManager negotiates a new peer connection.
+    private var lastObservedChannel: DataChannelWrapper? = null
     private var webrtcSendspinUsed = false
 
     /**
@@ -74,14 +81,6 @@ class SendspinClientFactory(
     }
 
     /**
-     * Reset the WebRTC channel flag. Called after a fresh WebRTC connection is established
-     * (new SDP-negotiated channels are available).
-     */
-    fun onFreshWebRTCConnection() {
-        webrtcSendspinUsed = false
-    }
-
-    /**
      * Fully destroys the shared pipeline (called on user logout or persistent error).
      * Next createIfEnabled() will allocate a fresh pipeline.
      */
@@ -93,6 +92,17 @@ class SendspinClientFactory(
         sharedPipeline?.close()
         sharedPipeline = null
         sharedClockSynchronizer = null
+        // Channel-freshness state (`lastObservedChannel`, `webrtcSendspinUsed`)
+        // is intentionally NOT reset here. Tearing down the audio pipeline does
+        // not un-send the `client/goodbye` we shipped on the existing sendspin
+        // channel — the server-side handler is gone. If the same wrapper comes
+        // back on the next attempt (e.g. user disables-then-re-enables sendspin
+        // without a WebRTC reconnect), we need the identity check to still
+        // report `webrtcSendspinUsed=true` so the caller forces a real WebRTC
+        // reconnect. Resetting alongside the pipeline would let a zombie
+        // channel be reused and silently corrupt audio. The flags are
+        // implicitly reset when a new peer connection produces a new wrapper
+        // instance — that's the only correct trigger.
     }
 
     /**
@@ -143,11 +153,19 @@ class SendspinClientFactory(
         pipeline: AudioStreamManager,
         clockSync: ClockSynchronizer,
     ): Result<SendspinClient> {
+        // Identity-based freshness check: a different DataChannelWrapper instance means
+        // WebRTCConnectionManager negotiated a new peer connection, so this channel has
+        // never sent goodbye and is safe to use. Reusing the same instance after goodbye
+        // hits a zombie channel (Open client-side, dead server-side) — refuse and let the
+        // caller force a real WebRTC reconnect.
+        if (lastObservedChannel !== webrtcChannel) {
+            webrtcSendspinUsed = false
+            lastObservedChannel = webrtcChannel
+        }
         if (webrtcSendspinUsed) {
             log.i { "Sendspin channel exhausted — need WebRTC reconnect" }
             return Result.failure(WebRTCSendspinChannelExhausted())
         }
-        webrtcSendspinUsed = true
 
         log.i { "Creating Sendspin client over WebRTC data channel" }
 
@@ -177,6 +195,12 @@ class SendspinClientFactory(
         )
         val transport = WebRTCDataChannelTransport(webrtcChannel)
         client.connectWithTransport(transport)
+        // Mark used only AFTER `connectWithTransport` succeeds: a thrown attach
+        // hasn't sent `client/goodbye`, so the channel is still virgin and the
+        // caller can retry without forcing a (slow) WebRTC peer reconnect. The
+        // exhaustion guard applies to attach-success-then-goodbye, which is the
+        // actual zombie-channel condition.
+        webrtcSendspinUsed = true
         log.i { "Sendspin client connected via WebRTC (auth inherited, direct hello, shared pipeline)" }
         return Result.success(client)
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/ConnectionData.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/ConnectionData.kt
@@ -12,11 +12,20 @@ data class ConnectionData(
     val user: User? = null,
     val authProcessState: AuthProcessState = AuthProcessState.NotStarted,
     val wasAutoLogin: Boolean = false,
+    /**
+     * True when the transport reconnected and the underlying server-side session
+     * does NOT survive that reconnect (e.g. WebRTC: every new peer connection is a
+     * brand-new session on the server). The `user` field is intentionally preserved
+     * so the UI keeps showing the user as logged in, but [dataConnectionState]
+     * reports `AwaitingAuth` until a fresh `authorize` round-trip completes.
+     * Cleared automatically by `KtorServiceClient.authorize` on success.
+     */
+    val needsServerReauth: Boolean = false,
 ) {
     val dataConnectionState: DataConnectionState
         get() = when {
             serverInfo == null -> DataConnectionState.AwaitingServerInfo
-            user == null -> DataConnectionState.AwaitingAuth(authProcessState)
+            user == null || needsServerReauth -> DataConnectionState.AwaitingAuth(authProcessState)
             else -> DataConnectionState.Authenticated
         }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/SessionState.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/SessionState.kt
@@ -84,8 +84,9 @@ fun SessionState.Connected.update(
     user: User? = this.user,
     authProcessState: AuthProcessState = this.authProcessState,
     wasAutoLogin: Boolean = this.wasAutoLogin,
+    needsServerReauth: Boolean = this.connectionData.needsServerReauth,
 ): SessionState.Connected = update(
-    connectionData = ConnectionData(serverInfo, user, authProcessState, wasAutoLogin),
+    connectionData = ConnectionData(serverInfo, user, authProcessState, wasAutoLogin, needsServerReauth),
 )
 
 /**
@@ -116,8 +117,9 @@ fun SessionState.Reconnecting.update(
     user: User? = this.user,
     authProcessState: AuthProcessState = this.authProcessState,
     wasAutoLogin: Boolean = this.wasAutoLogin,
+    needsServerReauth: Boolean = this.connectionData.needsServerReauth,
 ): SessionState.Reconnecting = update(
-    connectionData = ConnectionData(serverInfo, user, authProcessState, wasAutoLogin),
+    connectionData = ConnectionData(serverInfo, user, authProcessState, wasAutoLogin, needsServerReauth),
 )
 
 /**


### PR DESCRIPTION
This started when I was testing out re-enabling Opus, and discovered that I could 'lose' the ability to use the local sendspin client until I force quit the app and relaunched. Tracking down what was going on led to a small refactoring of the reconnection logic. There's lots of code comments, much more than actual code, because the state machine is complex and understanding why various things are and are not reset/cleared at various points matters. I've tested this as thoroughly as I can locally, with both direct and webrtc connections, resetting the local sendspin client, changing formats, logging out and back in. But I may have missed a path - there are lots. Anyway, robot sidekick explanation follows.


The WebRTC sendspin protocol is single-use per data channel: after client/goodbye, the server-side handler is gone but the channel stays Open client-side. Reusing it (e.g. toggling the local sendspin player to swap codec) hit a zombie — Open client-side, dead server-side — and silently failed to reconnect. SendspinClientFactory now identifies channel freshness by DataChannelWrapper instance equality and refuses reuse; the caller forces a real WebRTC peer reconnect.

While in there, unified Direct + WebRTC reconnect-auth handling. KtorServiceClient.observeTransport gains needsReauthOnReconnect and clearsServerInfoOnReconnect flags. Both transports route post-reconnect re-auth through AuthenticationManager via the needsServerReauth gate instead of an inline authorize() call in onReconnected. This fixes two latent bugs in the Direct path: (1) auth-failure left dataConnectionState reporting Authenticated despite authProcessState being Failed, letting MainDataSource fire RPCs that 401; (2) the success-path race where MainDataSource's collector could see Authenticated before onReconnected's authorize() landed on the wire. WebRTC continues to clear serverInfo to sidestep the gateway's on_message-vs-server/hello forwarding race; Direct preserves it since WS has no such ordering gate.

Also moves SendspinClientFactory's webrtcSendspinUsed=true flag set to AFTER connectWithTransport succeeds — a thrown attach hasn't sent goodbye, so the channel is still salvageable on retry.

Adds .claude/scheduled_tasks.lock to .gitignore.