### PR TITLE
"Now Playing" fixes

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/music_assistant/client/player/MediaPlayerController.android.kt
+++ b/composeApp/src/androidMain/kotlin/io/music_assistant/client/player/MediaPlayerController.android.kt
@@ -477,8 +477,8 @@ actual class MediaPlayerController actual constructor(platformContext: PlatformC
         artist: String?,
         album: String?,
         artworkUrl: String?,
-        duration: Double,
-        elapsedTime: Double,
+        duration: Double?,
+        elapsedTime: Double?,
         playbackRate: Double,
     ) {
         // Android handles Now Playing via MediaSession, not implemented here

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -66,6 +66,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
@@ -577,24 +578,110 @@ class MainDataSource(
                 }
             }
         }
-        // Keep Now Playing (iOS Control Center / Lock Screen) in sync with local player state.
-        // Runs every ~500 ms driven by the position calculation loop above.
+        // Keep Now Playing (iOS Control Center / Lock Screen) in sync with the
+        // local player. iOS interpolates the playback bar internally from the
+        // `(elapsed, timestamp, rate)` triple on every `setNowPlayingInfo`
+        // call; per Apple's guidance the right pattern is one anchor write
+        // per server event, plus track/rate transitions, and let iOS take
+        // it from there. So we drive this off `localPlayer` — which re-emits
+        // on track change, play/pause, and server queue event — and dedupe
+        // via [NowPlayingSnapshot.sameDictWriteWouldBe] so sub-second
+        // position jitter doesn't cause a write per tick. Mid-pause
+        // `elapsed_time = null` events flow through as `null` and the iOS
+        // adapter's skip-on-nil semantics preserve the previous anchor.
         launch {
-            localPlayer.collect { playerData ->
-                val track = playerData?.queueInfo?.currentItem?.track
-                val serverUrl = apiClient.serverBaseUrl.value
-                if (track != null) {
-                    mediaPlayerController.updateNowPlaying(
-                        title = track.title,
-                        artist = track.subtitle,
-                        album = track.parentName,
-                        artworkUrl = track.imageInfo?.url(serverUrl),
-                        duration = track.duration ?: 0.0,
-                        elapsedTime = playerData.queueInfo.elapsedTime ?: 0.0,
-                        playbackRate = if (playerData.player.isPlaying) 1.0 else 0.0,
-                    )
-                } else {
-                    mediaPlayerController.clearNowPlaying()
+            localPlayer
+                .map { pd ->
+                    val track = pd?.queueInfo?.currentItem?.track
+                    if (track == null) {
+                        NowPlayingSnapshot.Cleared
+                    } else {
+                        NowPlayingSnapshot.Active(
+                            title = track.title,
+                            artist = track.subtitle,
+                            album = track.parentName,
+                            artworkUrl = track.imageInfo?.url(apiClient.serverBaseUrl.value),
+                            duration = track.duration,
+                            elapsedTime = pd.queueInfo?.elapsedTime,
+                            isPlaying = pd.player.isPlaying,
+                        )
+                    }
+                }
+                .distinctUntilChanged { a, b -> NowPlayingSnapshot.sameDictWriteWouldBe(a, b) }
+                .collect { snapshot ->
+                    when (snapshot) {
+                        NowPlayingSnapshot.Cleared -> mediaPlayerController.clearNowPlaying()
+                        is NowPlayingSnapshot.Active -> mediaPlayerController.updateNowPlaying(
+                            title = snapshot.title,
+                            artist = snapshot.artist,
+                            album = snapshot.album,
+                            artworkUrl = snapshot.artworkUrl,
+                            duration = snapshot.duration,
+                            elapsedTime = snapshot.elapsedTime,
+                            playbackRate = if (snapshot.isPlaying) 1.0 else 0.0,
+                        )
+                    }
+                }
+        }
+    }
+
+    /**
+     * Captures the fields a single emission would push to iOS's Now Playing
+     * dict — [Active] when the local player has a track, [Cleared] when it
+     * doesn't. Paired with [Companion.sameDictWriteWouldBe] as a
+     * [distinctUntilChanged] key so the flow only emits once per visible
+     * anchor change (new track, pause/play, real elapsed jump).
+     */
+    internal sealed interface NowPlayingSnapshot {
+        data object Cleared : NowPlayingSnapshot
+        data class Active(
+            val title: String?,
+            val artist: String?,
+            val album: String?,
+            val artworkUrl: String?,
+            val duration: Double?,
+            val elapsedTime: Double?,
+            val isPlaying: Boolean,
+        ) : NowPlayingSnapshot
+
+        companion object {
+            /**
+             * Threshold (seconds) below which two `elapsed` values are treated
+             * as the same anchor: iOS's own interpolator covers sub-second
+             * drift from `(elapsed, timestamp, rate)`, so writing a fresh
+             * value within this window is a no-op the user can't see.
+             *
+             * 2 s is comfortably wider than typical position-tracker jitter
+             * (we tick at 500 ms with ±50 ms of dispatch noise) and tighter
+             * than any user-visible seek.
+             */
+            internal const val ELAPSED_ANCHOR_EPSILON_S = 2.0
+
+            /**
+             * Returns `true` when [a] and [b] would produce indistinguishable
+             * `MPNowPlayingInfoCenter` dict writes — i.e. emitting [b] after
+             * [a] would not visibly change the lock screen / CarPlay bar.
+             *
+             * Most fields compare by value equality. `elapsedTime` is the
+             * exception: small drifts (within [ELAPSED_ANCHOR_EPSILON_S]) are
+             * treated as equal because iOS is already interpolating from the
+             * last anchor. Crossing the threshold (e.g. a server-side seek,
+             * a reconnect re-anchoring with a wildly different value) emits.
+             */
+            fun sameDictWriteWouldBe(a: NowPlayingSnapshot, b: NowPlayingSnapshot): Boolean {
+                if (a !is Active || b !is Active) return a === b
+                if (a.title != b.title) return false
+                if (a.artist != b.artist) return false
+                if (a.album != b.album) return false
+                if (a.artworkUrl != b.artworkUrl) return false
+                if (a.duration != b.duration) return false
+                if (a.isPlaying != b.isPlaying) return false
+                val ae = a.elapsedTime
+                val be = b.elapsedTime
+                return when {
+                    ae == null && be == null -> true
+                    ae == null || be == null -> false
+                    else -> kotlin.math.abs(ae - be) < ELAPSED_ANCHOR_EPSILON_S
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/MediaPlayerController.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/MediaPlayerController.kt
@@ -46,13 +46,20 @@ expect class MediaPlayerController(platformContext: PlatformContext) {
     fun release()
 
     // Now Playing (Control Center / Lock Screen) - iOS only, no-op on other platforms
+    //
+    // `duration` and `elapsedTime` are nullable: iOS's `MPNowPlayingInfoCenter` uses
+    // `(elapsed, timestamp, rate)` to interpolate the playback bar locally. If we pass 0
+    // for "unknown elapsed", the bar visibly resets to 0; passing null tells the iOS
+    // adapter to leave that field alone and let iOS keep extrapolating from the last
+    // known good value. See the position-tracker overlay in `MainDataSource` and the
+    // skip-nil-fields merge in `NowPlayingManager.updateNowPlayingInfo` (Swift).
     fun updateNowPlaying(
         title: String?,
         artist: String?,
         album: String?,
         artworkUrl: String?,
-        duration: Double,
-        elapsedTime: Double,
+        duration: Double?,
+        elapsedTime: Double?,
         playbackRate: Double,
     )
 

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/NowPlayingSnapshotDedupTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/NowPlayingSnapshotDedupTest.kt
@@ -1,0 +1,153 @@
+package io.music_assistant.client.data
+
+import io.music_assistant.client.data.MainDataSource.NowPlayingSnapshot
+import io.music_assistant.client.data.MainDataSource.NowPlayingSnapshot.Companion.ELAPSED_ANCHOR_EPSILON_S
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the dedup contract used to gate `MPNowPlayingInfoCenter` writes.
+ *
+ * The lock-screen bar is interpolated locally by iOS from the last
+ * `(elapsed, timestamp, rate)` anchor. Writing the dict at our position-
+ * tracker tick (500 ms) is fighting iOS rather than working with it; the
+ * `distinctUntilChanged` gate in `MainDataSource` collapses sub-anchor
+ * drift to a single anchor write per actually-visible change.
+ *
+ * This test pins the boundary cases so a future "I'll just simplify this"
+ * doesn't accidentally restore the 2 Hz write-loop.
+ */
+class NowPlayingSnapshotDedupTest {
+    private val sample = NowPlayingSnapshot.Active(
+        title = "About Farewell",
+        artist = "Alela Diane",
+        album = "About Farewell",
+        artworkUrl = "https://example.invalid/cover.jpg",
+        duration = 240.0,
+        elapsedTime = 30.0,
+        isPlaying = true,
+    )
+
+    @Test
+    fun identicalSnapshotsDedupe() {
+        assertTrue(NowPlayingSnapshot.sameDictWriteWouldBe(sample, sample))
+    }
+
+    @Test
+    fun titleChangeEmits() {
+        assertFalse(
+            NowPlayingSnapshot.sameDictWriteWouldBe(sample, sample.copy(title = "Different")),
+        )
+    }
+
+    @Test
+    fun artistChangeEmits() {
+        assertFalse(
+            NowPlayingSnapshot.sameDictWriteWouldBe(sample, sample.copy(artist = "Different")),
+        )
+    }
+
+    @Test
+    fun albumChangeEmits() {
+        // Same title + artist with a different album is a legitimately different
+        // item (single vs. album cut, remaster vs. original); the dict has to
+        // refresh artwork.
+        assertFalse(
+            NowPlayingSnapshot.sameDictWriteWouldBe(sample, sample.copy(album = "Different")),
+        )
+    }
+
+    @Test
+    fun artworkUrlChangeEmits() {
+        assertFalse(
+            NowPlayingSnapshot.sameDictWriteWouldBe(
+                sample,
+                sample.copy(artworkUrl = "https://example.invalid/other.jpg"),
+            ),
+        )
+    }
+
+    @Test
+    fun durationChangeEmits() {
+        assertFalse(
+            NowPlayingSnapshot.sameDictWriteWouldBe(sample, sample.copy(duration = 999.0)),
+        )
+    }
+
+    @Test
+    fun rateChangeEmits() {
+        // Pause/play transitions are exactly the anchor iOS needs to stop or
+        // start interpolating; never dedupe these.
+        assertFalse(
+            NowPlayingSnapshot.sameDictWriteWouldBe(sample, sample.copy(isPlaying = false)),
+        )
+    }
+
+    @Test
+    fun subSecondElapsedDriftDedupes() {
+        // Position-tracker tick (500 ms) plus dispatch jitter — well under the
+        // anchor epsilon. iOS's own interpolator covers this.
+        assertTrue(
+            NowPlayingSnapshot.sameDictWriteWouldBe(
+                sample,
+                sample.copy(elapsedTime = sample.elapsedTime!! + 0.7),
+            ),
+        )
+    }
+
+    @Test
+    fun elapsedJumpAtThresholdEmits() {
+        // A jump >= the epsilon is treated as a re-anchor (e.g. server-side
+        // seek). Has to flush so iOS picks up the new base.
+        assertFalse(
+            NowPlayingSnapshot.sameDictWriteWouldBe(
+                sample,
+                sample.copy(elapsedTime = sample.elapsedTime!! + ELAPSED_ANCHOR_EPSILON_S),
+            ),
+        )
+    }
+
+    @Test
+    fun elapsedJustUnderThresholdDedupes() {
+        // Strict less-than on the comparison: just-under-threshold is dedup,
+        // at-or-over-threshold is emit. Pin the boundary explicitly.
+        assertTrue(
+            NowPlayingSnapshot.sameDictWriteWouldBe(
+                sample,
+                sample.copy(elapsedTime = sample.elapsedTime!! + (ELAPSED_ANCHOR_EPSILON_S - 0.001)),
+            ),
+        )
+    }
+
+    @Test
+    fun nullToValueElapsedEmits() {
+        // Mid-pause-transition events arrive with `elapsed = null`; the next
+        // event with a real value is a re-anchor. Has to flush.
+        val nullElapsed = sample.copy(elapsedTime = null)
+        assertFalse(NowPlayingSnapshot.sameDictWriteWouldBe(nullElapsed, sample))
+    }
+
+    @Test
+    fun bothNullElapsedDedupes() {
+        val nullElapsed = sample.copy(elapsedTime = null)
+        assertTrue(NowPlayingSnapshot.sameDictWriteWouldBe(nullElapsed, nullElapsed))
+    }
+
+    @Test
+    fun clearedDedupesWithItself() {
+        assertTrue(NowPlayingSnapshot.sameDictWriteWouldBe(NowPlayingSnapshot.Cleared, NowPlayingSnapshot.Cleared))
+    }
+
+    @Test
+    fun clearedToActiveEmits() {
+        // Going from "no track" to "track": iOS needs the metadata anchor
+        // before it can render anything.
+        assertFalse(NowPlayingSnapshot.sameDictWriteWouldBe(NowPlayingSnapshot.Cleared, sample))
+    }
+
+    @Test
+    fun activeToClearedEmits() {
+        assertFalse(NowPlayingSnapshot.sameDictWriteWouldBe(sample, NowPlayingSnapshot.Cleared))
+    }
+}

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/player/MediaPlayerController.ios.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/player/MediaPlayerController.ios.kt
@@ -85,8 +85,8 @@ actual class MediaPlayerController actual constructor(platformContext: PlatformC
         artist: String?,
         album: String?,
         artworkUrl: String?,
-        duration: Double,
-        elapsedTime: Double,
+        duration: Double?,
+        elapsedTime: Double?,
         playbackRate: Double,
     ) {
         PlatformPlayerProvider.player?.updateNowPlaying(

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/player/PlatformAudioPlayer.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/player/PlatformAudioPlayer.kt
@@ -27,14 +27,18 @@ interface PlatformAudioPlayer {
     fun setMuted(muted: Boolean)
     fun dispose()
 
-    // Now Playing (Control Center / Lock Screen)
+    // Now Playing (Control Center / Lock Screen).
+    //
+    // Nullable `duration` / `elapsedTime` means "unknown — leave the iOS field alone."
+    // The Swift-side adapter merges into the existing `MPNowPlayingInfoCenter` dict
+    // rather than replacing it, so a nil here preserves whatever iOS last had.
     fun updateNowPlaying(
         title: String?,
         artist: String?,
         album: String?,
         artworkUrl: String?,
-        duration: Double,
-        elapsedTime: Double,
+        duration: Double?,
+        elapsedTime: Double?,
         playbackRate: Double,
     )
     fun clearNowPlaying()

--- a/iosApp/NativeAudioController.swift
+++ b/iosApp/NativeAudioController.swift
@@ -314,13 +314,19 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
     
     private var remoteCommandHandler: RemoteCommandHandler?
     
+    /// `duration` and `elapsedTime` are passed as `KotlinDouble?` because Kotlin/Native
+    /// boxes nullable primitives in interface signatures. A nil here means "value
+    /// unknown — leave the corresponding `MPNowPlayingInfoCenter` field alone" (vs.
+    /// the prior contract which forced callers to fabricate a 0 and visibly reset the
+    /// playback bar). See `MainDataSource`'s position-tracker overlay for why this
+    /// distinction matters in practice.
     func updateNowPlaying(
         title: String?,
         artist: String?,
         album: String?,
         artworkUrl: String?,
-        duration: Double,
-        elapsedTime: Double,
+        duration: KotlinDouble?,
+        elapsedTime: KotlinDouble?,
         playbackRate: Double
     ) {
         NowPlayingManager.shared.updateNowPlayingInfo(
@@ -328,8 +334,8 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
             artist: artist,
             album: album,
             artworkUrl: artworkUrl,
-            duration: duration,
-            elapsedTime: elapsedTime,
+            duration: duration?.doubleValue,
+            elapsedTime: elapsedTime?.doubleValue,
             playbackRate: playbackRate
         )
     }

--- a/iosApp/NowPlayingManager.swift
+++ b/iosApp/NowPlayingManager.swift
@@ -62,120 +62,213 @@ class NowPlayingManager {
     
     // Track pending update to handle race conditions
     private var pendingIdentifier: String?
-    
-    /// Updates the Now Playing info displayed in Control Center and Lock Screen
+
+    /// Stable string identifier derived from track metadata. Used for two purposes:
+    ///   1. `pendingIdentifier` (dedup of in-flight artwork loads when the user
+    ///      changes track twice quickly — drop the older fetch's result).
+    ///   2. `MPNowPlayingInfoPropertyExternalContentIdentifier`, telling
+    ///      `MediaRemote` "this is the *same* item across position-tick updates."
+    ///      Without it, every `setNowPlayingInfo` call gets a fresh auto-assigned
+    ///      ContentItemIdentifier, which causes `mediaremoted` to fire
+    ///      `PlaybackQueueInvalidation` on every 500 ms tick — the bar visibly
+    ///      thrashes and CarPlay treats each tick as a queue change.
+    ///
+    /// Duration is rounded to whole seconds because the value occasionally jitters
+    /// between near-equivalent doubles across queue updates (e.g. 199.99987 vs.
+    /// 200.000); we don't want that to look like a different item.
+    private func contentIdentifier(
+        title: String?,
+        artist: String?,
+        album: String?,
+        duration: Double?
+    ) -> String {
+        let durStr = duration.map { String(format: "%.0f", $0) } ?? ""
+        return "\(title ?? "")|\(artist ?? "")|\(album ?? "")|\(durStr)"
+    }
+
+    /// Updates the Now Playing info displayed in Control Center and Lock Screen.
+    ///
+    /// `duration` and `elapsedTime` are optional: nil means "value unknown — leave
+    /// the corresponding `MPNowPlayingInfoCenter` field alone." The same-track path
+    /// merges into the existing dict rather than replacing it, so a nil value here
+    /// preserves whatever iOS last had instead of pinning a field to 0. See the
+    /// position-tracker overlay in `MainDataSource` (Kotlin) for why upstream needs
+    /// to send nils across transient gaps in server data — without this, a queue
+    /// event arriving with `elapsed_time = null` (which MA does mid-pause) would
+    /// reset the playback bar to 0.
     func updateNowPlayingInfo(
         title: String?,
         artist: String?,
         album: String?,
         artworkUrl: String?,
-        duration: Double,
-        elapsedTime: Double,
+        duration: Double?,
+        elapsedTime: Double?,
         playbackRate: Double
     ) {
-        let newIdentifier = "\(title ?? "")-\(artist ?? "")-\(album ?? "")"
-        let isNewTrack = (title != currentTitle || artist != currentArtist)
-        
-        // If it's the same track, update immediately with existing/cached art
+        let newIdentifier = contentIdentifier(
+            title: title, artist: artist, album: album, duration: duration
+        )
+        // New-track detection has to mirror what `contentIdentifier` keys on,
+        // otherwise the lock-screen artwork pins to whichever cover loaded
+        // first. Two tracks with the same title and artist on different albums
+        // (a single vs. the album cut, a remaster vs. the original) are
+        // legitimately different items and need a fresh artwork load.
+        let isNewTrack = (
+            title != currentTitle ||
+            artist != currentArtist ||
+            album != currentAlbum
+        )
+
+        // If it's the same track, merge into the existing dict so nil-valued
+        // fields preserve iOS's last-known state.
         if !isNewTrack {
-            self.performUpdate(
+            self.applyMergedUpdate(
                 title: title, artist: artist, album: album,
                 artwork: self.cachedArtwork,
-                duration: duration, elapsedTime: elapsedTime, playbackRate: playbackRate
+                duration: duration, elapsedTime: elapsedTime, playbackRate: playbackRate,
+                contentId: newIdentifier,
+                isNewTrack: false
             )
             return
         }
-        
+
         // If it's a new track, we want to PREVENT FLICKER.
         // Strategy: Keep showing OLD metadata until NEW artwork is ready.
-        
+
         print("🎵 NowPlayingManager: Detected new track. Waiting for artwork to prevent flicker...")
-        
+
         // Mark this as the pending update
         self.pendingIdentifier = newIdentifier
-        
+
         // IMMEDIATE PAUSE FEEDBACK:
         // If the user paused (rate == 0), update the OLD metadata's rate immediately
-        // so the UI stops ticking/shows pause state, even while we load new art.
+        // so the UI stops ticking/shows pause state, even while we load new art. We
+        // intentionally only touch rate (and elapsed if known) — title/artist stay
+        // on the previous track until artwork arrives.
         if abs(playbackRate) < 0.001 {
-             var currentInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
-             currentInfo[MPNowPlayingInfoPropertyPlaybackRate] = 0.0
-             currentInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = max(0, min(elapsedTime, duration))
-             MPNowPlayingInfoCenter.default().nowPlayingInfo = currentInfo
+            var currentInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
+            currentInfo[MPNowPlayingInfoPropertyPlaybackRate] = 0.0
+            if let elapsed = elapsedTime {
+                let dur = duration
+                    ?? (currentInfo[MPMediaItemPropertyPlaybackDuration] as? Double)
+                    ?? .greatestFiniteMagnitude
+                currentInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = max(0, min(elapsed, dur))
+            }
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = currentInfo
         }
-        
+
         // Cancel any previous pending load
         currentTask?.cancel()
-        
+
         // If no artwork URL, update immediately with nil artwork
         guard let urlString = artworkUrl, let url = URL(string: urlString) else {
             self.cachedArtwork = nil
             self.updateCurrentState(title: title, artist: artist, album: album)
-            self.performUpdate(
+            self.applyMergedUpdate(
                 title: title, artist: artist, album: album,
                 artwork: nil,
-                duration: duration, elapsedTime: elapsedTime, playbackRate: playbackRate
+                duration: duration, elapsedTime: elapsedTime, playbackRate: playbackRate,
+                contentId: newIdentifier,
+                isNewTrack: true
             )
             return
         }
-        
+
         // Load artwork asynchronously
         self.currentTask = loadArtwork(from: url) { [weak self] artwork in
             guard let self = self else { return }
-            
+
             // Check if this result is still relevant
             if self.pendingIdentifier != newIdentifier {
                 print("🎵 NowPlayingManager: Ignoring stale artwork load for \(newIdentifier)")
                 return
             }
-            
+
             // On main thread, apply the FULL update (Text + New Art)
             DispatchQueue.main.async {
                 self.cachedArtwork = artwork
                 self.updateCurrentState(title: title, artist: artist, album: album)
-                
-                self.performUpdate(
+
+                self.applyMergedUpdate(
                     title: title, artist: artist, album: album,
                     artwork: artwork,
-                    duration: duration, elapsedTime: elapsedTime, playbackRate: playbackRate
+                    duration: duration, elapsedTime: elapsedTime, playbackRate: playbackRate,
+                    contentId: newIdentifier,
+                    isNewTrack: true
                 )
                 print("🎵 NowPlayingManager: Artwork loaded. Metadata updated.")
             }
         }
     }
-    
+
     private func updateCurrentState(title: String?, artist: String?, album: String?) {
         self.currentTitle = title
         self.currentArtist = artist
         self.currentAlbum = album
     }
-    
-    private func performUpdate(
+
+    /// Merges new fields into the existing `MPNowPlayingInfoCenter.nowPlayingInfo`
+    /// dict.
+    ///
+    /// When `isNewTrack` is `false` (same-track tick): nil-valued fields are
+    /// skipped (preserving iOS's last-known value) and non-nil fields overwrite.
+    /// This is the right semantics for position-tick / pause-rate updates where
+    /// upstream legitimately doesn't know elapsed.
+    ///
+    /// When `isNewTrack` is `true`: previous-track fields are explicitly cleared
+    /// before the merge — otherwise transitioning to a track that has, say, no
+    /// artwork URL would leave the previous track's cover pinned in the dict
+    /// because the skip-on-nil rule preserves it. The merge then writes whatever
+    /// values the caller has; missing values become absent rather than
+    /// previous-track holdovers.
+    ///
+    /// The stable `contentId` is always set so iOS doesn't auto-assign a fresh
+    /// `ContentItemIdentifier` per call (which would make `mediaremoted` fire
+    /// `PlaybackQueueInvalidation` on every position tick).
+    private func applyMergedUpdate(
         title: String?,
         artist: String?,
         album: String?,
         artwork: MPMediaItemArtwork?,
-        duration: Double,
-        elapsedTime: Double,
-        playbackRate: Double
+        duration: Double?,
+        elapsedTime: Double?,
+        playbackRate: Double,
+        contentId: String,
+        isNewTrack: Bool
     ) {
         DispatchQueue.main.async {
-            var nowPlayingInfo = [String: Any]()
-            
-            if let title = title { nowPlayingInfo[MPMediaItemPropertyTitle] = title }
-            if let artist = artist { nowPlayingInfo[MPMediaItemPropertyArtist] = artist }
-            if let album = album { nowPlayingInfo[MPMediaItemPropertyAlbumTitle] = album }
-            
-            nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = duration
-            let clampedElapsed = max(0, min(elapsedTime, duration))
-            nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = clampedElapsed
-            nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = playbackRate
-            
-            if let artwork = artwork {
-                nowPlayingInfo[MPMediaItemPropertyArtwork] = artwork
+            var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
+
+            if isNewTrack {
+                // Wipe previous-track holdovers so a missing field on the new
+                // track doesn't render as a pinned stale value.
+                info.removeValue(forKey: MPMediaItemPropertyTitle)
+                info.removeValue(forKey: MPMediaItemPropertyArtist)
+                info.removeValue(forKey: MPMediaItemPropertyAlbumTitle)
+                info.removeValue(forKey: MPMediaItemPropertyArtwork)
+                info.removeValue(forKey: MPMediaItemPropertyPlaybackDuration)
+                info.removeValue(forKey: MPNowPlayingInfoPropertyElapsedPlaybackTime)
             }
-            
-            MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+
+            if let title = title { info[MPMediaItemPropertyTitle] = title }
+            if let artist = artist { info[MPMediaItemPropertyArtist] = artist }
+            if let album = album { info[MPMediaItemPropertyAlbumTitle] = album }
+            if let duration = duration { info[MPMediaItemPropertyPlaybackDuration] = duration }
+            if let elapsed = elapsedTime {
+                // Clamp against the freshly supplied duration if we have one,
+                // otherwise the duration already cached on iOS, otherwise unbounded.
+                let dur = duration
+                    ?? (info[MPMediaItemPropertyPlaybackDuration] as? Double)
+                    ?? .greatestFiniteMagnitude
+                info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = max(0, min(elapsed, dur))
+            }
+            info[MPNowPlayingInfoPropertyPlaybackRate] = playbackRate
+            if let artwork = artwork {
+                info[MPMediaItemPropertyArtwork] = artwork
+            }
+            info[MPNowPlayingInfoPropertyExternalContentIdentifier] = contentId
+
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = info
         }
     }
     


### PR DESCRIPTION
We've had bugs where the "now playing" state isn't in sync with the actual player, where the thumbnail doesn't match the currently playing track, etc. This (hopefully!) addresses that.

Robot sidekick's summary of the changes:

iOS extrapolates the lock-screen / Control Center playback bar locally from the `(elapsed, timestamp, rate)` triple. Replacing the dict on every position-tick — the prior contract — fights that interpolator: pinning `elapsed` to `0.0` for "unknown" visibly resets the bar, and queue events that legitimately arrive with `elapsed_time = null` mid-pause-transition clobber a perfectly good iOS-side extrapolation.

Contract change. `MediaPlayerController.updateNowPlaying` (commonMain `expect`) and `PlatformAudioPlayer.updateNowPlaying` now take `duration: Double?` and `elapsedTime: Double?`. `null` means "value unknown — leave the corresponding `MPNowPlayingInfoCenter` field alone." The Android `actual` is a no-op stub that just gets the matching signature; Android handles Now Playing through `MediaSession` in `MainMediaPlaybackService` and isn't affected here.

iOS adapter rewrite. `NowPlayingManager.updateNowPlayingInfo` now merges into `MPNowPlayingInfoCenter.default().nowPlayingInfo` rather than replacing it. Nil-valued fields are skipped (preserving iOS's last-known value); non-nil fields overwrite. The new-track path explicitly clears the title/artist/album/artwork/duration/elapsed keys before merging so a missing field on the new track doesn't render as a pinned previous-track value. New-track keying mirrors the stable `contentIdentifier` (`title|artist|album|duration` rounded to whole seconds) — adding `album` to the key correctly disambiguates a single vs. the album cut and a remaster vs. the original.

Stable `MPNowPlayingInfoPropertyExternalContentIdentifier`. Set on every merge so iOS's `mediaremoted` doesn't auto-assign a fresh `ContentItemIdentifier` per call and fire `PlaybackQueueInvalidation` on every position tick (which made the bar visibly thrash and CarPlay treat each tick as a queue change).

Common-side flow. The Now Playing combine in `MainDataSource` is now sourced off `localPlayer` only and emits a `NowPlayingSnapshot` (a sealed `Active` / `Cleared` interface) deduped by
`sameDictWriteWouldBe`. Sub-second `elapsedTime` drift inside `ELAPSED_ANCHOR_EPSILON_S = 2.0` is treated as the same anchor — iOS's own interpolator covers that drift, so writing the dict at position-tick cadence is a no-op the user can't see and just costs us `mediaremoted` churn. Crossing the threshold (a server-side seek, a reconnect re-anchoring) emits.

Tests. `NowPlayingSnapshotDedupTest` (15 cases): identity, per-field sensitivity, sub-second elapsed dedup, threshold-boundary emit/dedup, null↔value re-anchor, Cleared transitions.