### PR TITLE
feat(player-selection): persist user choice

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -178,7 +178,36 @@ class MainDataSource(
             .map { it.data.any { data -> data.queueInfo?.currentItem != null } }
             .stateIn(this, SharingStarted.Eagerly, false)
 
-    private val _selectedPlayerId = MutableStateFlow<String?>(null)
+    /**
+     * Persisted user choice. Restored from settings on startup and written
+     * only by [selectPlayer]; the persistence collector in [init] mirrors
+     * non-null values into [SettingsRepository.lastSelectedPlayerId] for
+     * the next app launch.
+     */
+    private val _userSelectedPlayerId =
+        MutableStateFlow(settings.lastSelectedPlayerId.value)
+
+    /**
+     * Effective selection consumed by the rest of the data source and UI.
+     * Derived from the current player list and the user choice via
+     * [resolveSelectedPlayerId] — pure function, re-evaluated on every
+     * input change. No state machine pushes a fallback into the upstream
+     * flow; the resolver computes it on the fly.
+     */
+    private val _selectedPlayerId: StateFlow<String?> =
+        combine(
+            _playersData,
+            _userSelectedPlayerId,
+        ) { playersDataState, user ->
+            val visibleIds = (playersDataState as? DataState.Data)
+                ?.data?.map { it.playerId }
+                .orEmpty()
+            resolveSelectedPlayerId(
+                visiblePlayerIds = visibleIds,
+                userChoice = user,
+            )
+        }.stateIn(this, SharingStarted.Eagerly, settings.lastSelectedPlayerId.value)
+
     val selectedPlayerIndex = combine(_playersData, _selectedPlayerId) { listState, selectedId ->
         selectedId?.let { id ->
             (listState as? DataState.Data)?.data?.indexOfFirst { it.playerId == id }
@@ -531,23 +560,15 @@ class MainDataSource(
             }
         }
         launch {
-            var wasLocalPlayerInList = false
-            playersData.mapNotNull { (it as? DataState.Data)?.data }.collect { playersList ->
-                // Auto-select first player if no player is selected
-                if (playersList.isNotEmpty() &&
-                    playersList.none { data -> data.playerId == _selectedPlayerId.value }
-                ) {
-                    _selectedPlayerId.update { playersList.getOrNull(0)?.playerId }
-                }
-                // When local player first appears at first position, select it
-                val localId = settings.sendspinClientId.value
-                if (playersList.firstOrNull()?.playerId == localId && !wasLocalPlayerInList) {
-                    _selectedPlayerId.update { localId }
-                }
-                wasLocalPlayerInList = playersList.any { it.playerId == localId }
-                // Don't call updatePlayersAndQueues() here - it creates a reactive loop!
-                // Updates are triggered by sessionState changes and API events.
-            }
+            // Persist user-driven selection so it survives app restarts.
+            // Only [selectPlayer] writes the upstream flow, so this captures
+            // explicit picks. Nulls are filtered out because clearing the
+            // persisted value isn't a product requirement and rarely the
+            // user's intent.
+            _userSelectedPlayerId
+                .filterNotNull()
+                .distinctUntilChanged()
+                .collect { settings.setLastSelectedPlayerId(it) }
         }
         launch {
             selectedPlayerIndex.filterNotNull().collect { index ->
@@ -1002,7 +1023,11 @@ class MainDataSource(
             .getOrNull()?.resultAs<List<DspConfigPreset>>() ?: emptyList()
 
     fun selectPlayer(player: Player) {
-        _selectedPlayerId.update { player.id }
+        // User-driven selection (UI player picker). Writes through
+        // [_userSelectedPlayerId] so the choice persists; the persistence
+        // launch in [init] mirrors it into [SettingsRepository] for the next
+        // app launch.
+        _userSelectedPlayerId.update { player.id }
     }
 
     fun playerAction(playerId: String, action: PlayerAction) {
@@ -1750,7 +1775,28 @@ class MainDataSource(
         supervisorJob.cancel()
     }
 
-    private companion object {
-        const val MAX_SENDSPIN_RETRIES = 5
+    internal companion object {
+        private const val MAX_SENDSPIN_RETRIES = 5
+
+        /**
+         * Resolves the effective selected player from the current state.
+         * Pure function; re-evaluates on every input change.
+         *
+         * Resolution order:
+         *  1. [userChoice] if it appears in [visiblePlayerIds] — persisted
+         *     explicit pick.
+         *  2. First visible player — fallback when no user choice or when
+         *     the user's choice is offline.
+         *  3. [userChoice] as a last resort — preserves the persisted value
+         *     while the player list is loading or empty so the UI holds
+         *     steady across the gap.
+         */
+        internal fun resolveSelectedPlayerId(
+            visiblePlayerIds: List<String>,
+            userChoice: String?,
+        ): String? {
+            if (userChoice != null && userChoice in visiblePlayerIds) return userChoice
+            return visiblePlayerIds.firstOrNull() ?: userChoice
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/SettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/SettingsRepository.kt
@@ -259,6 +259,25 @@ class SettingsRepository(
         _lastConnectionMode.update { mode }
     }
 
+    // Persisted user player choice. Null means "no explicit choice yet" — on
+    // first launch the resolver in `MainDataSource.resolveSelectedPlayerId`
+    // falls back to the first visible player. Written by
+    // `MainDataSource.selectPlayer` (driven by the in-app player picker); no
+    // other path touches it today.
+    private val _lastSelectedPlayerId = MutableStateFlow(
+        settings.getStringOrNull("last_selected_player_id"),
+    )
+    val lastSelectedPlayerId = _lastSelectedPlayerId.asStateFlow()
+
+    fun setLastSelectedPlayerId(id: String?) {
+        if (id.isNullOrBlank()) {
+            settings.remove("last_selected_player_id")
+        } else {
+            settings.putString("last_selected_player_id", id)
+        }
+        _lastSelectedPlayerId.update { id }
+    }
+
     // Connection history (most-recent-first, max 10 entries)
     private val _connectionHistory = MutableStateFlow(loadConnectionHistory())
     val connectionHistory = _connectionHistory.asStateFlow()

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/SelectedPlayerResolutionTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/SelectedPlayerResolutionTest.kt
@@ -1,0 +1,95 @@
+package io.music_assistant.client.data
+
+import io.music_assistant.client.data.MainDataSource.Companion.resolveSelectedPlayerId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Unit tests for [MainDataSource.resolveSelectedPlayerId].
+ *
+ * The resolver is a pure function over (visible players, user choice). It
+ * must never require a write-back into the persisted user setting to reach
+ * the right answer — these tests pin that property down.
+ */
+class SelectedPlayerResolutionTest {
+    @Test
+    fun `persisted user choice wins when visible`() {
+        val result = resolveSelectedPlayerId(
+            visiblePlayerIds = listOf("bathroom", "kitchen", "office"),
+            userChoice = "kitchen",
+        )
+        assertEquals("kitchen", result)
+    }
+
+    @Test
+    fun `falls back to first visible when user choice is not in list`() {
+        // User's preferred player is offline (or removed). Don't pin them to
+        // a phantom selection — give them whatever's available.
+        val result = resolveSelectedPlayerId(
+            visiblePlayerIds = listOf("bathroom", "office"),
+            userChoice = "kitchen",
+        )
+        assertEquals("bathroom", result)
+    }
+
+    @Test
+    fun `falls back to first visible when no user choice`() {
+        // Fresh-install case before the user has tapped a player. The
+        // resolver returns this fallback on the fly; no write to the
+        // persisted user choice happens — the persistence collector only
+        // watches [_userSelectedPlayerId], which only [selectPlayer] writes.
+        val result = resolveSelectedPlayerId(
+            visiblePlayerIds = listOf("bathroom", "kitchen"),
+            userChoice = null,
+        )
+        assertEquals("bathroom", result)
+    }
+
+    @Test
+    fun `falls back to user choice when list is empty`() {
+        // Reconnecting / list still loading. Hold the persisted choice
+        // rather than emit null so the UI stays stable across the gap.
+        val result = resolveSelectedPlayerId(
+            visiblePlayerIds = emptyList(),
+            userChoice = "kitchen",
+        )
+        assertEquals("kitchen", result)
+    }
+
+    @Test
+    fun `returns null when nothing is set and list is empty`() {
+        val result = resolveSelectedPlayerId(
+            visiblePlayerIds = emptyList(),
+            userChoice = null,
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `tracks the visible list as it grows`() {
+        // The resolver depends only on its inputs, so adding a player to
+        // the visible list (e.g. local sendspin finishes registering with
+        // MA after launch) flips the result without any state machine
+        // having to react.
+        val before = resolveSelectedPlayerId(
+            visiblePlayerIds = listOf("bathroom"),
+            userChoice = null,
+        )
+        val after = resolveSelectedPlayerId(
+            visiblePlayerIds = listOf("sendspin-local", "bathroom"),
+            userChoice = null,
+        )
+        assertEquals("bathroom", before)
+        assertEquals("sendspin-local", after)
+    }
+
+    @Test
+    fun `respects an explicit user pick even when other players are first in the list`() {
+        val result = resolveSelectedPlayerId(
+            visiblePlayerIds = listOf("sendspin-local", "kitchen"),
+            userChoice = "kitchen",
+        )
+        assertEquals("kitchen", result)
+    }
+}


### PR DESCRIPTION
The iOS app would often switch to whatever player came first in the list of available players, vs. using what the user had selected last time, on launch. We now persist the user's selection.

Robot's detailed explanation:

Replace the auto-select coroutine that pushed first-available fallbacks
into `_selectedPlayerId` with a pure resolver over (visible players,
user choice). The effective selection is now a `combine` over
`_playersData` and `_userSelectedPlayerId`, computed by
`resolveSelectedPlayerId`:

  1. user choice if it appears in the visible list — persisted explicit
     pick wins
  2. first visible player — fallback when no user choice or when the
     user's choice is offline
  3. user choice as a last resort — preserves the persisted value while
     the player list is loading or empty so the UI holds steady across
     the gap

Only `selectPlayer` writes `_userSelectedPlayerId`, and a single
collector in `MainDataSource.init` mirrors non-null values into
`SettingsRepository.lastSelectedPlayerId` (backed by
`last_selected_player_id` in platform settings — SharedPreferences on
Android, NSUserDefaults on iOS). Restoration on startup is automatic:
the upstream flow seeds from `settings.lastSelectedPlayerId.value` and
the resolver re-evaluates on every player-list emission, so a player
that joins after launch (e.g. local sendspin finishing registration)
is picked up without state-machine help.

Tests. `SelectedPlayerResolutionTest`: all three resolver
branches plus edge cases (empty list, user choice not in list, list
growing post-launch, explicit user pick takes priority over a
sendspin-local that landed first in the order).