### PR TITLE
fix(player-selection): resolver never returns an invisible player id

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -1782,21 +1782,25 @@ class MainDataSource(
          * Resolves the effective selected player from the current state.
          * Pure function; re-evaluates on every input change.
          *
+         * Invariant: the result is always either `null` or a member of
+         * [visiblePlayerIds]. Returning a value not in the list would let a
+         * downstream consumer attempt to act on an unreachable player; the
+         * persisted choice is held in `SettingsRepository.lastSelectedPlayerId`
+         * across loading gaps, not here.
+         *
          * Resolution order:
          *  1. [userChoice] if it appears in [visiblePlayerIds] — persisted
          *     explicit pick.
          *  2. First visible player — fallback when no user choice or when
          *     the user's choice is offline.
-         *  3. [userChoice] as a last resort — preserves the persisted value
-         *     while the player list is loading or empty so the UI holds
-         *     steady across the gap.
+         *  3. `null` when [visiblePlayerIds] is empty.
          */
         internal fun resolveSelectedPlayerId(
             visiblePlayerIds: List<String>,
             userChoice: String?,
         ): String? {
             if (userChoice != null && userChoice in visiblePlayerIds) return userChoice
-            return visiblePlayerIds.firstOrNull() ?: userChoice
+            return visiblePlayerIds.firstOrNull()
         }
     }
 }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/SelectedPlayerResolutionTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/SelectedPlayerResolutionTest.kt
@@ -47,14 +47,17 @@ class SelectedPlayerResolutionTest {
     }
 
     @Test
-    fun `falls back to user choice when list is empty`() {
-        // Reconnecting / list still loading. Hold the persisted choice
-        // rather than emit null so the UI stays stable across the gap.
+    fun `returns null when list is empty even if user choice is set`() {
+        // Invariant: never return a player ID that isn't in the visible list.
+        // The persisted choice is held in `SettingsRepository.lastSelectedPlayerId`
+        // and re-emerges on the next resolver run when the list re-populates;
+        // there's no need to leak it through `_selectedPlayerId` while we have
+        // nothing to act on.
         val result = resolveSelectedPlayerId(
             visiblePlayerIds = emptyList(),
             userChoice = "kitchen",
         )
-        assertEquals("kitchen", result)
+        assertNull(result)
     }
 
     @Test


### PR DESCRIPTION
I thought I was protecting the user's selection but of course, the caller also resolved the ID and converted non-existent ones to null. Thanks to @formatBCE for pointing that out.

Drop the `?: userChoice` elvis fallback from `resolveSelectedPlayerId`'s empty-list branch. Returning a player id that isn't in `visiblePlayerIds` is unsafe — a downstream consumer could try to act on an unreachable player — and the "preserve across loading gaps" rationale didn't hold up: the persisted choice already lives in
`SettingsRepository.lastSelectedPlayerId` and re-emerges on the next resolver run when the list re-populates, so leaking it through `_selectedPlayerId` was redundant.

The downstream observers (`selectedPlayerIndex`,
`selectedPlayer`, `refreshSelectedPlayerQueueItems`) all already collapse "id not found in list" to a null/no-op, so the user-visible behavior is unchanged. The change tightens the resolver's contract: the result is now always either `null` or a member of `visiblePlayerIds`. Docstring updated to call this out explicitly.

Test renamed and updated: `falls back to user choice when list is empty` → `returns null when list is empty even if user choice is set`, asserting `null`.