### PR TITLE
fix(queue): drop stale queue event replays; handle queue_added

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Event.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Event.kt
@@ -14,6 +14,7 @@ import io.music_assistant.client.data.model.server.events.MediaItemUpdatedEvent
 import io.music_assistant.client.data.model.server.events.PlayerAddedEvent
 import io.music_assistant.client.data.model.server.events.PlayerRemovedEvent
 import io.music_assistant.client.data.model.server.events.PlayerUpdatedEvent
+import io.music_assistant.client.data.model.server.events.QueueAddedEvent
 import io.music_assistant.client.data.model.server.events.QueueItemsUpdatedEvent
 import io.music_assistant.client.data.model.server.events.QueueTimeUpdatedEvent
 import io.music_assistant.client.data.model.server.events.QueueUpdatedEvent
@@ -52,11 +53,11 @@ data class Event(
             EventType.MEDIA_ITEM_ADDED -> myJson.decodeFromJsonElement<MediaItemAddedEvent>(json)
             EventType.MEDIA_ITEM_DELETED -> myJson.decodeFromJsonElement<MediaItemDeletedEvent>(json)
             EventType.MEDIA_ITEM_PLAYED -> myJson.decodeFromJsonElement<MediaItemPlayedEvent>(json)
+            EventType.QUEUE_ADDED -> myJson.decodeFromJsonElement<QueueAddedEvent>(json)
             EventType.QUEUE_UPDATED -> myJson.decodeFromJsonElement<QueueUpdatedEvent>(json)
             EventType.QUEUE_TIME_UPDATED -> myJson.decodeFromJsonElement<QueueTimeUpdatedEvent>(json)
             EventType.QUEUE_ITEMS_UPDATED -> myJson.decodeFromJsonElement<QueueItemsUpdatedEvent>(json)
             EventType.PLAYER_SETTINGS_UPDATED,
-            EventType.QUEUE_ADDED,
             EventType.QUEUE_SETTINGS_UPDATED,
             EventType.SHUTDOWN,
             EventType.PROVIDERS_UPDATED,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerRepository.kt
@@ -14,6 +14,7 @@ import io.music_assistant.client.player.MediaPlayerController
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.action.PlayerAction
+import io.music_assistant.client.utils.currentTimeMillis
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -40,6 +41,18 @@ class LocalPlayerRepository(
 
     private val _localPlayerData = MutableStateFlow<PlayerData?>(null)
     val localPlayerData: StateFlow<PlayerData?> = _localPlayerData.asStateFlow()
+
+    /**
+     * Fired whenever an optimistic queue mutation produces a new [QueueInfo]
+     * for the local player. [MainDataSource] sets this in its `init` block to
+     * mirror the bumped `elapsedTimeLastUpdated` into its own `_queueInfos`
+     * store, which is the single source of truth consulted by the staleness
+     * gate. Without the mirror, a stale server replay arriving after an
+     * optimistic toggle could pass the gate (it'd compare against the old
+     * server stamp, not the bumped optimistic one) and clobber the user's
+     * change.
+     */
+    var onOptimisticQueueChange: ((QueueInfo) -> Unit)? = null
 
     private val commandQueueMutex = Mutex()
     private val commandQueue = mutableListOf<QueuedEntry>()
@@ -145,6 +158,8 @@ class LocalPlayerRepository(
     }
 
     fun onServerQueueUpdate(queueInfo: QueueInfo) {
+        // Staleness gating happens upstream in [MainDataSource.gateOrSkip]
+        // before we're called, so this just absorbs the admitted event.
         _localPlayerData.update { current ->
             current?.copy(
                 queue = DataState.Data(
@@ -220,9 +235,21 @@ class LocalPlayerRepository(
         _localPlayerData.update { current ->
             current?.let { pd ->
                 val queueData = pd.queue as? DataState.Data ?: return@update pd
+                // Bump `elapsedTimeLastUpdated` to client wall clock so a server
+                // replay whose timestamp predates this optimistic write is
+                // rejected by the staleness gate in [MainDataSource.gateOrSkip].
+                // Assumes client and server clocks are roughly NTP-synced; drift
+                // of seconds is fine because legitimate confirmation events from
+                // the server (post-toggle) are always strictly newer than `now()`.
+                val transformed = transform(queueData.data.info).copy(
+                    elapsedTimeLastUpdated = currentTimeMillis() / 1000.0,
+                )
+                // Notify MainDataSource so the bumped stamp lands in its
+                // `_queueInfos` store — the gate's single source of truth.
+                onOptimisticQueueChange?.invoke(transformed)
                 pd.copy(
                     queue = DataState.Data(
-                        queueData.data.copy(info = transform(queueData.data.info)),
+                        queueData.data.copy(info = transformed),
                     ),
                 )
             }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerRepository.kt
@@ -14,7 +14,6 @@ import io.music_assistant.client.player.MediaPlayerController
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.action.PlayerAction
-import io.music_assistant.client.utils.currentTimeMillis
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -235,14 +234,18 @@ class LocalPlayerRepository(
         _localPlayerData.update { current ->
             current?.let { pd ->
                 val queueData = pd.queue as? DataState.Data ?: return@update pd
-                // Bump `elapsedTimeLastUpdated` to client wall clock so a server
-                // replay whose timestamp predates this optimistic write is
-                // rejected by the staleness gate in [MainDataSource.gateOrSkip].
-                // Assumes client and server clocks are roughly NTP-synced; drift
-                // of seconds is fine because legitimate confirmation events from
-                // the server (post-toggle) are always strictly newer than `now()`.
+                // Bump `elapsedTimeLastUpdated` to a value strictly above the
+                // last known server stamp. A stale server replay carries a
+                // stamp ≤ existing and is rejected by [MainDataSource.gateOrSkip];
+                // a legitimate server confirmation carries a stamp far above
+                // existing (network round-trip alone is orders of magnitude
+                // larger than [OPTIMISTIC_BUMP_EPSILON_S]) and correctly
+                // overrides the optimistic state. Avoids any client-wall-clock
+                // dependency, so DST, NTP step adjustments, and cross-machine
+                // skew are all irrelevant to staleness ordering.
+                val existingStamp = queueData.data.info.elapsedTimeLastUpdated ?: 0.0
                 val transformed = transform(queueData.data.info).copy(
-                    elapsedTimeLastUpdated = currentTimeMillis() / 1000.0,
+                    elapsedTimeLastUpdated = existingStamp + OPTIMISTIC_BUMP_EPSILON_S,
                 )
                 // Notify MainDataSource so the bumped stamp lands in its
                 // `_queueInfos` store — the gate's single source of truth.
@@ -294,5 +297,15 @@ class LocalPlayerRepository(
                 else -> commandQueue.add(entry)
             }
         }
+    }
+
+    private companion object {
+        /**
+         * Tiny offset added to the existing server stamp on each optimistic
+         * mutation. Chosen to be safely below any realistic server-confirmation
+         * round trip (≥ tens of milliseconds in practice) so the next legitimate
+         * server event always lands above the bumped stamp and overrides it.
+         */
+        const val OPTIMISTIC_BUMP_EPSILON_S = 0.0001
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerRepository.kt
@@ -18,11 +18,15 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -41,17 +45,9 @@ class LocalPlayerRepository(
     private val _localPlayerData = MutableStateFlow<PlayerData?>(null)
     val localPlayerData: StateFlow<PlayerData?> = _localPlayerData.asStateFlow()
 
-    /**
-     * Fired whenever an optimistic queue mutation produces a new [QueueInfo]
-     * for the local player. [MainDataSource] sets this in its `init` block to
-     * mirror the bumped `elapsedTimeLastUpdated` into its own `_queueInfos`
-     * store, which is the single source of truth consulted by the staleness
-     * gate. Without the mirror, a stale server replay arriving after an
-     * optimistic toggle could pass the gate (it'd compare against the old
-     * server stamp, not the bumped optimistic one) and clobber the user's
-     * change.
-     */
-    var onOptimisticQueueChange: ((QueueInfo) -> Unit)? = null
+    /** Optimistic local-queue mutations; mirrored into `_queueInfos` by `MainDataSource`. */
+    private val _optimisticQueueChanges = Channel<QueueInfo>(Channel.BUFFERED)
+    val optimisticQueueChanges: Flow<QueueInfo> = _optimisticQueueChanges.receiveAsFlow()
 
     private val commandQueueMutex = Mutex()
     private val commandQueue = mutableListOf<QueuedEntry>()
@@ -231,32 +227,19 @@ class LocalPlayerRepository(
     // --- Private helpers ---
 
     private fun updateOptimisticQueueInfo(transform: (QueueInfo) -> QueueInfo) {
-        _localPlayerData.update { current ->
+        // Bump elapsedTimeLastUpdated above the last known server stamp so
+        // stale replays drop while real confirmations (RTT >> epsilon) override.
+        val newState = _localPlayerData.updateAndGet { current ->
             current?.let { pd ->
-                val queueData = pd.queue as? DataState.Data ?: return@update pd
-                // Bump `elapsedTimeLastUpdated` to a value strictly above the
-                // last known server stamp. A stale server replay carries a
-                // stamp ≤ existing and is rejected by [MainDataSource.gateOrSkip];
-                // a legitimate server confirmation carries a stamp far above
-                // existing (network round-trip alone is orders of magnitude
-                // larger than [OPTIMISTIC_BUMP_EPSILON_S]) and correctly
-                // overrides the optimistic state. Avoids any client-wall-clock
-                // dependency, so DST, NTP step adjustments, and cross-machine
-                // skew are all irrelevant to staleness ordering.
+                val queueData = pd.queue as? DataState.Data ?: return@updateAndGet pd
                 val existingStamp = queueData.data.info.elapsedTimeLastUpdated ?: 0.0
                 val transformed = transform(queueData.data.info).copy(
                     elapsedTimeLastUpdated = existingStamp + OPTIMISTIC_BUMP_EPSILON_S,
                 )
-                // Notify MainDataSource so the bumped stamp lands in its
-                // `_queueInfos` store — the gate's single source of truth.
-                onOptimisticQueueChange?.invoke(transformed)
-                pd.copy(
-                    queue = DataState.Data(
-                        queueData.data.copy(info = transformed),
-                    ),
-                )
+                pd.copy(queue = DataState.Data(queueData.data.copy(info = transformed)))
             }
         }
+        (newState?.queue as? DataState.Data)?.data?.info?.let { _optimisticQueueChanges.trySend(it) }
     }
 
     private suspend fun enqueue(action: PlayerAction, request: Request) {
@@ -300,12 +283,7 @@ class LocalPlayerRepository(
     }
 
     private companion object {
-        /**
-         * Tiny offset added to the existing server stamp on each optimistic
-         * mutation. Chosen to be safely below any realistic server-confirmation
-         * round trip (≥ tens of milliseconds in practice) so the next legitimate
-         * server event always lands above the bumped stamp and overrides it.
-         */
+        /** Optimistic-bump offset; safely below any realistic server-confirmation RTT. */
         const val OPTIMISTIC_BUMP_EPSILON_S = 0.0001
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -16,6 +16,7 @@ import io.music_assistant.client.data.model.client.Queue
 import io.music_assistant.client.data.model.client.QueueInfo
 import io.music_assistant.client.data.model.client.QueueInfo.Companion.toQueue
 import io.music_assistant.client.data.model.client.QueueTrack.Companion.toQueueTrack
+import io.music_assistant.client.data.model.client.isBefore
 import io.music_assistant.client.data.model.server.DspConfig
 import io.music_assistant.client.data.model.server.DspConfigPreset
 import io.music_assistant.client.data.model.server.ProviderManifest
@@ -228,18 +229,15 @@ class MainDataSource(
     private var updateJob: Job? = null
 
     init {
-        // Mirror optimistic-bump stamps from LocalPlayerRepository into
-        // `_queueInfos` so [gateOrSkip] sees them when comparing against an
-        // incoming server event. Without this, a server replay arriving after
-        // an optimistic toggle would compare against the stale server stamp
-        // (still in `_queueInfos`) instead of the fresh optimistic one and
-        // pass the gate, clobbering the user's change.
-        localPlayerRepository.onOptimisticQueueChange = { queueInfo ->
-            _queueInfos.update { value ->
-                if (value.any { it.id == queueInfo.id }) {
-                    value.map { if (it.id == queueInfo.id) queueInfo else it }
-                } else {
-                    value + queueInfo
+        // Mirror optimistic-bump stamps into `_queueInfos` so the gate sees them.
+        launch {
+            localPlayerRepository.optimisticQueueChanges.collect { queueInfo ->
+                _queueInfos.update { value ->
+                    if (value.any { it.id == queueInfo.id }) {
+                        value.map { if (it.id == queueInfo.id) queueInfo else it }
+                    } else {
+                        value + queueInfo
+                    }
                 }
             }
         }
@@ -1047,28 +1045,16 @@ class MainDataSource(
         _userSelectedPlayerId.update { player.id }
     }
 
-    /**
-     * Stale-event gate. Returns `true` if [data] should be processed, `false`
-     * if it's a server replay older than what we already have for this queue
-     * id. See [QueueInfo.isStaleReplay] for the comparison rules.
-     *
-     * `_queueInfos` is the single source of truth: server-event handlers
-     * write to it on admit, and [LocalPlayerRepository.onOptimisticQueueChange]
-     * mirrors optimistic-bump stamps into it via the callback wired in [init].
-     * That removes the need for a cross-store merge — the gate only has to
-     * look in one place.
-     */
-    private fun gateOrSkip(data: QueueInfo, label: String): Boolean {
-        val existing = _queueInfos.value.find { it.id == data.id }
-        if (QueueInfo.isStaleReplay(incoming = data, existing = existing)) {
+    /** `null` if this event is older than what `_queueInfos` already holds for the same id. */
+    private fun QueueInfo.takeIfNotStale(label: String): QueueInfo? {
+        val existing = _queueInfos.value.find { it.id == id } ?: return this
+        if (isBefore(existing)) {
             log.d {
-                "Dropping stale $label for ${data.id}: " +
-                    "${data.elapsedTimeLastUpdated} < " +
-                    "${existing?.elapsedTimeLastUpdated}"
+                "Dropping stale $label for $id: $elapsedTimeLastUpdated < ${existing.elapsedTimeLastUpdated}"
             }
-            return false
+            return null
         }
-        return true
+        return this
     }
 
     fun playerAction(playerId: String, action: PlayerAction) {
@@ -1470,13 +1456,7 @@ class MainDataSource(
                         is QueueAddedEvent -> {
                             // Server announces a queue (typically when a new
                             // player connects and MA registers its queue).
-                            // Payload is a full QueueInfo including
-                            // current_item; the staleness gate still applies
-                            // for the rare re-add-after-add case, but on the
-                            // first sighting `existing == null` so it's a
-                            // straight upsert.
-                            val data = event.queue()
-                            if (!gateOrSkip(data, "QueueAdded")) return@collect
+                            val data = event.queue().takeIfNotStale("QueueAdded") ?: return@collect
                             Logger.i("Queue added $data")
 
                             val localPlayerId = settings.sendspinClientId.value
@@ -1514,15 +1494,7 @@ class MainDataSource(
                         }
 
                         is QueueUpdatedEvent -> {
-                            // Stale-event gate: see [QueueInfo.isStaleReplay]. The
-                            // MA server occasionally replays queue events that
-                            // predate fresher state we already received (observed
-                            // around Siri "next track" handoffs and rapid queue
-                            // mutations). Without this guard, a stale replay
-                            // clobbers the position tracker — the playhead visibly
-                            // snaps backward, or the prior track briefly reappears.
-                            val data = event.queue()
-                            if (!gateOrSkip(data, "QueueUpdated")) return@collect
+                            val data = event.queue().takeIfNotStale("QueueUpdated") ?: return@collect
                             Logger.i("Queue updated $data")
 
                             // Forward to local player repository if this is the local player's queue
@@ -1559,13 +1531,7 @@ class MainDataSource(
                         }
 
                         is QueueItemsUpdatedEvent -> {
-                            // Same staleness gate as QueueUpdatedEvent (see
-                            // [QueueInfo.isStaleReplay]): items can change without
-                            // the playhead advancing (e.g. queue reorder), but a
-                            // same-id event with an older `elapsedTimeLastUpdated`
-                            // is almost certainly a replay.
-                            val data = event.queue()
-                            if (!gateOrSkip(data, "QueueItemsUpdated")) return@collect
+                            val data = event.queue().takeIfNotStale("QueueItemsUpdated") ?: return@collect
                             _queueInfos.update { value ->
                                 value.map {
                                     if (it.id == data.id) data else it
@@ -1577,13 +1543,9 @@ class MainDataSource(
                         }
 
                         is QueueTimeUpdatedEvent -> {
-                            // NOT staleness-gated. The event payload is just
-                            // `(objectId, elapsed: Double)` with no server-side
-                            // `last_updated` timestamp, so we have nothing to compare
-                            // against. We rely on in-order WebSocket delivery (TCP
-                            // sequencing within a single transport session) to keep
-                            // these monotonic. If we ever introduce parallel
-                            // transports or out-of-order delivery, revisit this.
+                            // Not staleness-gated: payload has no server-side
+                            // `last_updated` to compare against. Relies on
+                            // in-order WebSocket delivery instead.
                             val oldQueue = _queueInfos.value.find { it.id == event.objectId }
                             // Update position tracker
                             event.objectId?.let { queueId ->

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -30,6 +30,7 @@ import io.music_assistant.client.data.model.server.events.MediaItemUpdatedEvent
 import io.music_assistant.client.data.model.server.events.PlayerAddedEvent
 import io.music_assistant.client.data.model.server.events.PlayerRemovedEvent
 import io.music_assistant.client.data.model.server.events.PlayerUpdatedEvent
+import io.music_assistant.client.data.model.server.events.QueueAddedEvent
 import io.music_assistant.client.data.model.server.events.QueueItemsUpdatedEvent
 import io.music_assistant.client.data.model.server.events.QueueTimeUpdatedEvent
 import io.music_assistant.client.data.model.server.events.QueueUpdatedEvent
@@ -227,6 +228,22 @@ class MainDataSource(
     private var updateJob: Job? = null
 
     init {
+        // Mirror optimistic-bump stamps from LocalPlayerRepository into
+        // `_queueInfos` so [gateOrSkip] sees them when comparing against an
+        // incoming server event. Without this, a server replay arriving after
+        // an optimistic toggle would compare against the stale server stamp
+        // (still in `_queueInfos`) instead of the fresh optimistic one and
+        // pass the gate, clobbering the user's change.
+        localPlayerRepository.onOptimisticQueueChange = { queueInfo ->
+            _queueInfos.update { value ->
+                if (value.any { it.id == queueInfo.id }) {
+                    value.map { if (it.id == queueInfo.id) queueInfo else it }
+                } else {
+                    value + queueInfo
+                }
+            }
+        }
+
         // Position calculation loop - runs independently to provide smooth position updates
         launch {
             while (isActive) {
@@ -1030,6 +1047,30 @@ class MainDataSource(
         _userSelectedPlayerId.update { player.id }
     }
 
+    /**
+     * Stale-event gate. Returns `true` if [data] should be processed, `false`
+     * if it's a server replay older than what we already have for this queue
+     * id. See [QueueInfo.isStaleReplay] for the comparison rules.
+     *
+     * `_queueInfos` is the single source of truth: server-event handlers
+     * write to it on admit, and [LocalPlayerRepository.onOptimisticQueueChange]
+     * mirrors optimistic-bump stamps into it via the callback wired in [init].
+     * That removes the need for a cross-store merge — the gate only has to
+     * look in one place.
+     */
+    private fun gateOrSkip(data: QueueInfo, label: String): Boolean {
+        val existing = _queueInfos.value.find { it.id == data.id }
+        if (QueueInfo.isStaleReplay(incoming = data, existing = existing)) {
+            log.d {
+                "Dropping stale $label for ${data.id}: " +
+                    "${data.elapsedTimeLastUpdated} < " +
+                    "${existing?.elapsedTimeLastUpdated}"
+            }
+            return false
+        }
+        return true
+    }
+
     fun playerAction(playerId: String, action: PlayerAction) {
         // Delegate to data-based overload for local player (handles optimistic + routing)
         if (playerId == settings.sendspinClientId.value) {
@@ -1426,8 +1467,62 @@ class MainDataSource(
                             }
                         }
 
-                        is QueueUpdatedEvent -> {
+                        is QueueAddedEvent -> {
+                            // Server announces a queue (typically when a new
+                            // player connects and MA registers its queue).
+                            // Payload is a full QueueInfo including
+                            // current_item; the staleness gate still applies
+                            // for the rare re-add-after-add case, but on the
+                            // first sighting `existing == null` so it's a
+                            // straight upsert.
                             val data = event.queue()
+                            if (!gateOrSkip(data, "QueueAdded")) return@collect
+                            Logger.i("Queue added $data")
+
+                            val localPlayerId = settings.sendspinClientId.value
+                            if (data.id == localPlayerId ||
+                                (_serverPlayers.value as? DataState.Data)?.data
+                                    ?.find { it.id == localPlayerId }?.queueId == data.id
+                            ) {
+                                localPlayerRepository.onServerQueueUpdate(data)
+                            }
+
+                            data.elapsedTime?.let { elapsed ->
+                                val player =
+                                    (_serverPlayers.value as? DataState.Data)?.data?.find { it.queueId == data.id }
+                                _positionTrackers.update { trackers ->
+                                    trackers + (
+                                        data.id to PositionTracker(
+                                        queueId = data.id,
+                                        basePosition = elapsed,
+                                        baseTimestamp = currentTimeMillis(),
+                                        isPlaying = player?.isPlaying ?: false,
+                                        duration = data.currentItem?.track?.duration,
+                                    )
+                                    )
+                                }
+                            }
+
+                            // Upsert: replace if present, append if new.
+                            _queueInfos.update { value ->
+                                if (value.any { it.id == data.id }) {
+                                    value.map { if (it.id == data.id) data else it }
+                                } else {
+                                    value + data
+                                }
+                            }
+                        }
+
+                        is QueueUpdatedEvent -> {
+                            // Stale-event gate: see [QueueInfo.isStaleReplay]. The
+                            // MA server occasionally replays queue events that
+                            // predate fresher state we already received (observed
+                            // around Siri "next track" handoffs and rapid queue
+                            // mutations). Without this guard, a stale replay
+                            // clobbers the position tracker — the playhead visibly
+                            // snaps backward, or the prior track briefly reappears.
+                            val data = event.queue()
+                            if (!gateOrSkip(data, "QueueUpdated")) return@collect
                             Logger.i("Queue updated $data")
 
                             // Forward to local player repository if this is the local player's queue
@@ -1464,7 +1559,13 @@ class MainDataSource(
                         }
 
                         is QueueItemsUpdatedEvent -> {
+                            // Same staleness gate as QueueUpdatedEvent (see
+                            // [QueueInfo.isStaleReplay]): items can change without
+                            // the playhead advancing (e.g. queue reorder), but a
+                            // same-id event with an older `elapsedTimeLastUpdated`
+                            // is almost certainly a replay.
                             val data = event.queue()
+                            if (!gateOrSkip(data, "QueueItemsUpdated")) return@collect
                             _queueInfos.update { value ->
                                 value.map {
                                     if (it.id == data.id) data else it
@@ -1476,6 +1577,13 @@ class MainDataSource(
                         }
 
                         is QueueTimeUpdatedEvent -> {
+                            // NOT staleness-gated. The event payload is just
+                            // `(objectId, elapsed: Double)` with no server-side
+                            // `last_updated` timestamp, so we have nothing to compare
+                            // against. We rely on in-order WebSocket delivery (TCP
+                            // sequencing within a single transport session) to keep
+                            // these monotonic. If we ever introduce parallel
+                            // transports or out-of-order delivery, revisit this.
                             val oldQueue = _queueInfos.value.find { it.id == event.objectId }
                             // Update position tracker
                             event.objectId?.let { queueId ->

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/PlayerDataFixtures.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/PlayerDataFixtures.kt
@@ -44,6 +44,7 @@ object PlayerDataFixtures {
                         shuffleEnabled = false,
                         repeatMode = RepeatMode.OFF,
                         elapsedTime = 100.0,
+                        elapsedTimeLastUpdated = null,
                         currentItem = null,
                     ),
                     items = DataState.NoData(),

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/QueueInfo.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/QueueInfo.kt
@@ -11,22 +11,9 @@ data class QueueInfo(
     val repeatMode: RepeatMode?,
     val elapsedTime: Double?,
     /**
-     * Server wall clock (Unix epoch seconds, fractional, UTC — DST and
-     * timezone changes don't affect this value) when [elapsedTime] was last
-     * recomputed. Used as the monotonic staleness signal — a queue event with
-     * an older value than the one currently stored for this [id] is a server
-     * replay and is dropped.
-     *
-     * Optimistic UI writes (`LocalPlayerRepository.updateOptimisticQueueInfo`)
-     * bump this to a value strictly above the last known server stamp so a
-     * subsequent stale server event can't clobber the optimistic state, while
-     * any legitimate server confirmation lands far above the bump and
-     * overrides it.
-     *
-     * Nullable to handle the (currently theoretical) case where the server
-     * omits the field. A `null` on either side disables the staleness gate
-     * for that comparison so a missing stamp can never silently filter out
-     * legitimate updates. See [Companion.isStaleReplay].
+     * Unix epoch seconds (UTC) when [elapsedTime] was last recomputed
+     * server-side. Drives [isBefore]. Optimistic writes bump this above
+     * the last known server stamp; see `LocalPlayerRepository`.
      */
     val elapsedTimeLastUpdated: Double?,
     val currentItem: QueueTrack?,
@@ -41,30 +28,12 @@ data class QueueInfo(
             elapsedTimeLastUpdated = elapsedTimeLastUpdated,
             currentItem = currentItem?.toQueueTrack(),
         )
-
-        /**
-         * Returns true when [incoming] is a server replay that should be dropped
-         * before it can clobber [existing] state. The comparison is per-queue
-         * (different ids never compare) and on `elapsedTimeLastUpdated` only —
-         * `elapsedTime` is legitimately null mid-pause-transition, whereas the
-         * "last updated" stamp is what we use as the monotonic signal.
-         *
-         * Returns false when:
-         *  - there is no existing state for this queue (every first event is fresh);
-         *  - ids differ (unrelated queues);
-         *  - either side's `elapsedTimeLastUpdated` is `null` — a missing stamp
-         *    on either end disables the gate rather than silently dropping a
-         *    legitimate update. The MA server emits the field on every queue
-         *    payload today, so a `null` should never appear in practice; the
-         *    short-circuit exists so a future server omission can't invert the
-         *    gate and silently filter every subsequent update;
-         *  - the incoming timestamp is at least as recent as existing.
-         */
-        fun isStaleReplay(incoming: QueueInfo, existing: QueueInfo?): Boolean {
-            if (existing == null || existing.id != incoming.id) return false
-            val incomingStamp = incoming.elapsedTimeLastUpdated ?: return false
-            val existingStamp = existing.elapsedTimeLastUpdated ?: return false
-            return incomingStamp < existingStamp
-        }
     }
+}
+
+/** Strict-older-than on [QueueInfo.elapsedTimeLastUpdated]. Callers match ids first. */
+fun QueueInfo.isBefore(other: QueueInfo): Boolean {
+    val mine = elapsedTimeLastUpdated ?: return false
+    val theirs = other.elapsedTimeLastUpdated ?: return false
+    return mine < theirs
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/QueueInfo.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/QueueInfo.kt
@@ -10,6 +10,19 @@ data class QueueInfo(
     val shuffleEnabled: Boolean,
     val repeatMode: RepeatMode?,
     val elapsedTime: Double?,
+    /**
+     * Server wall clock (Unix seconds, fractional) when [elapsedTime] was last
+     * recomputed. Used as the monotonic staleness signal — a queue event with an
+     * older value than the one currently stored for this [id] is a server replay
+     * and is dropped. Optimistic UI writes bump this to client wall clock so a
+     * subsequent stale server event can't clobber the optimistic state.
+     *
+     * Nullable to handle the (currently theoretical) case where the server
+     * omits the field. A `null` on either side disables the staleness gate
+     * for that comparison so a missing stamp can never silently filter out
+     * legitimate updates. See [Companion.isStaleReplay].
+     */
+    val elapsedTimeLastUpdated: Double?,
     val currentItem: QueueTrack?,
 ) {
     companion object Companion {
@@ -19,7 +32,33 @@ data class QueueInfo(
             shuffleEnabled = shuffleEnabled,
             repeatMode = repeatMode,
             elapsedTime = elapsedTime,
+            elapsedTimeLastUpdated = elapsedTimeLastUpdated,
             currentItem = currentItem?.toQueueTrack(),
         )
+
+        /**
+         * Returns true when [incoming] is a server replay that should be dropped
+         * before it can clobber [existing] state. The comparison is per-queue
+         * (different ids never compare) and on `elapsedTimeLastUpdated` only —
+         * `elapsedTime` is legitimately null mid-pause-transition, whereas the
+         * "last updated" stamp is what we use as the monotonic signal.
+         *
+         * Returns false when:
+         *  - there is no existing state for this queue (every first event is fresh);
+         *  - ids differ (unrelated queues);
+         *  - either side's `elapsedTimeLastUpdated` is `null` — a missing stamp
+         *    on either end disables the gate rather than silently dropping a
+         *    legitimate update. The MA server emits the field on every queue
+         *    payload today, so a `null` should never appear in practice; the
+         *    short-circuit exists so a future server omission can't invert the
+         *    gate and silently filter every subsequent update;
+         *  - the incoming timestamp is at least as recent as existing.
+         */
+        fun isStaleReplay(incoming: QueueInfo, existing: QueueInfo?): Boolean {
+            if (existing == null || existing.id != incoming.id) return false
+            val incomingStamp = incoming.elapsedTimeLastUpdated ?: return false
+            val existingStamp = existing.elapsedTimeLastUpdated ?: return false
+            return incomingStamp < existingStamp
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/QueueInfo.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/QueueInfo.kt
@@ -11,11 +11,17 @@ data class QueueInfo(
     val repeatMode: RepeatMode?,
     val elapsedTime: Double?,
     /**
-     * Server wall clock (Unix seconds, fractional) when [elapsedTime] was last
-     * recomputed. Used as the monotonic staleness signal — a queue event with an
-     * older value than the one currently stored for this [id] is a server replay
-     * and is dropped. Optimistic UI writes bump this to client wall clock so a
-     * subsequent stale server event can't clobber the optimistic state.
+     * Server wall clock (Unix epoch seconds, fractional, UTC — DST and
+     * timezone changes don't affect this value) when [elapsedTime] was last
+     * recomputed. Used as the monotonic staleness signal — a queue event with
+     * an older value than the one currently stored for this [id] is a server
+     * replay and is dropped.
+     *
+     * Optimistic UI writes (`LocalPlayerRepository.updateOptimisticQueueInfo`)
+     * bump this to a value strictly above the last known server stamp so a
+     * subsequent stale server event can't clobber the optimistic state, while
+     * any legitimate server confirmation lands far above the bump and
+     * overrides it.
      *
      * Nullable to handle the (currently theoretical) case where the server
      * omits the field. A `null` on either side disables the staleness gate

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerQueue.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerQueue.kt
@@ -22,7 +22,22 @@ data class ServerQueue(
     // @SerialName("current_index") val currentIndex: Int? = null,
     // @SerialName("index_in_buffer") val indexInBuffer: Int? = null,
     @SerialName("elapsed_time") val elapsedTime: Double? = null,
-    // @SerialName("elapsed_time_last_updated") val elapsedTimeLastUpdated: Double,
+    /**
+     * Server-side wall clock (Unix seconds, fractional) when [elapsedTime] was last
+     * recomputed. Used as the staleness signal: a queue event whose
+     * [elapsedTimeLastUpdated] is older than what we already have for the same
+     * [queueId] is a server replay and is dropped before it can clobber fresher
+     * client state.
+     *
+     * Nullable on purpose. The MA server has historically always emitted the field
+     * (verified against schema v30), but if a future server build, a downgraded
+     * server, or a transient bug ever omits it, the staleness gate must see
+     * `null` and bypass itself — treating a missing stamp as a sentinel value
+     * (e.g. `0.0`) would compare as older than every real timestamp and
+     * silently drop every subsequent legitimate event. See
+     * [io.music_assistant.client.data.model.client.QueueInfo.Companion.isStaleReplay].
+     */
+    @SerialName("elapsed_time_last_updated") val elapsedTimeLastUpdated: Double? = null,
     // @SerialName("state") val state: PlayerState,
     @SerialName("current_item") val currentItem: ServerQueueItem? = null,
     // @SerialName("next_item") val nextItem: QueueItem? = null,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerQueue.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerQueue.kt
@@ -23,20 +23,9 @@ data class ServerQueue(
     // @SerialName("index_in_buffer") val indexInBuffer: Int? = null,
     @SerialName("elapsed_time") val elapsedTime: Double? = null,
     /**
-     * Server-side wall clock (Unix epoch seconds, fractional, UTC — DST and
-     * timezone changes don't affect this value) when [elapsedTime] was last
-     * recomputed. Used as the staleness signal: a queue event whose
-     * [elapsedTimeLastUpdated] is older than what we already have for the same
-     * [queueId] is a server replay and is dropped before it can clobber fresher
-     * client state.
-     *
-     * Nullable on purpose. The MA server has historically always emitted the field
-     * (verified against schema v30), but if a future server build, a downgraded
-     * server, or a transient bug ever omits it, the staleness gate must see
-     * `null` and bypass itself — treating a missing stamp as a sentinel value
-     * (e.g. `0.0`) would compare as older than every real timestamp and
-     * silently drop every subsequent legitimate event. See
-     * [io.music_assistant.client.data.model.client.QueueInfo.Companion.isStaleReplay].
+     * Unix epoch seconds (UTC) when [elapsedTime] was last recomputed.
+     * Drives the staleness gate. Nullable so a missing field can't silently
+     * drop subsequent legitimate events.
      */
     @SerialName("elapsed_time_last_updated") val elapsedTimeLastUpdated: Double? = null,
     // @SerialName("state") val state: PlayerState,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerQueue.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerQueue.kt
@@ -23,7 +23,8 @@ data class ServerQueue(
     // @SerialName("index_in_buffer") val indexInBuffer: Int? = null,
     @SerialName("elapsed_time") val elapsedTime: Double? = null,
     /**
-     * Server-side wall clock (Unix seconds, fractional) when [elapsedTime] was last
+     * Server-side wall clock (Unix epoch seconds, fractional, UTC — DST and
+     * timezone changes don't affect this value) when [elapsedTime] was last
      * recomputed. Used as the staleness signal: a queue event whose
      * [elapsedTimeLastUpdated] is older than what we already have for the same
      * [queueId] is a server replay and is dropped before it can clobber fresher

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/events/QueueAddedEvent.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/events/QueueAddedEvent.kt
@@ -1,0 +1,22 @@
+package io.music_assistant.client.data.model.server.events
+
+import io.music_assistant.client.data.model.client.QueueInfo.Companion.toQueue
+import io.music_assistant.client.data.model.server.EventType
+import io.music_assistant.client.data.model.server.ServerQueue
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Server announces a queue (typically fired when a new player connects to
+ * MA and MA registers its queue). Payload is a full [ServerQueue]
+ * including `current_item` if any, and is the first queue signal the
+ * client receives for a newly-added queue.
+ */
+@Serializable
+data class QueueAddedEvent(
+    @SerialName("event") override val event: EventType,
+    @SerialName("object_id") override val objectId: String? = null,
+    @SerialName("data") override val data: ServerQueue,
+) : Event<ServerQueue> {
+    fun queue() = data.toQueue()
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/api/EventTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/api/EventTest.kt
@@ -2,6 +2,7 @@ package io.music_assistant.client.api
 
 import io.music_assistant.client.data.model.server.events.PlayerRemovedEvent
 import io.music_assistant.client.data.model.server.events.PlayerUpdatedEvent
+import io.music_assistant.client.data.model.server.events.QueueAddedEvent
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlin.test.Test
@@ -78,6 +79,48 @@ class EventTest {
         assertNotNull(decoded)
         assertTrue(decoded is PlayerUpdatedEvent)
         assertNull(decoded.data.type)
+    }
+
+    @Test
+    fun decodesQueueAddedEvent() {
+        // Real-shape payload (truncated from a connect-time CarPlay session
+        // capture). Required fields: queue_id (id), elapsed_time_last_updated.
+        // current_item is the field CarPlay's initial-Now-Playing decision
+        // hinges on, so it's pinned here.
+        val raw = """{
+            "event": "queue_added",
+            "object_id": "q1",
+            "data": {
+                "queue_id": "q1",
+                "active": true,
+                "display_name": "Djinni",
+                "available": true,
+                "items": 128,
+                "shuffle_enabled": false,
+                "repeat_mode": "off",
+                "dont_stop_the_music_enabled": false,
+                "current_index": 2,
+                "elapsed_time": 134.45,
+                "elapsed_time_last_updated": 1777422843.81,
+                "state": "idle",
+                "current_item": {
+                    "queue_id": "q1",
+                    "queue_item_id": "qi1",
+                    "name": "Alela Diane - About Farewell",
+                    "duration": 190,
+                    "sort_index": 2,
+                    "available": true
+                }
+            }
+        }"""
+
+        val decoded = parse(raw).event()
+
+        assertNotNull(decoded)
+        assertTrue(decoded is QueueAddedEvent)
+        assertEquals("q1", decoded.data.queueId)
+        assertNotNull(decoded.data.currentItem)
+        assertEquals("Alela Diane - About Farewell", decoded.data.currentItem.name)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/QueueInfoStalenessTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/QueueInfoStalenessTest.kt
@@ -97,16 +97,18 @@ class QueueInfoStalenessTest {
     @Test
     fun optimisticBumpedTimestampPreservesAgainstStaleServerEvent() {
         // Optimistic UI writes (e.g. ToggleShuffle) bump elapsedTimeLastUpdated
-        // to client wall clock so a server replay whose timestamp predates the
-        // user action is rejected. This documents the contract.
+        // to a value strictly above the last known server stamp (existing +
+        // tiny epsilon, see LocalPlayerRepository) so a server replay whose
+        // timestamp predates the user action is rejected. This documents the
+        // contract.
         val lastServerEvent = queueInfoOf("q1", 1000.0)
         val optimistic = lastServerEvent.copy(
             shuffleEnabled = true,
-            // Wall clock at the optimistic moment, strictly after the last
-            // server event.
-            elapsedTimeLastUpdated = 1000.500,
+            // The realistic optimistic stamp: existing + epsilon. The exact
+            // epsilon doesn't matter to the gate, only that it's > existing.
+            elapsedTimeLastUpdated = 1000.0001,
         )
-        val staleServerEvent = queueInfoOf("q1", 1000.250)
+        val staleServerEvent = queueInfoOf("q1", 999.5)
 
         assertTrue(
             isStaleReplay(incoming = staleServerEvent, existing = optimistic),
@@ -119,9 +121,11 @@ class QueueInfoStalenessTest {
         // The flip side of the optimistic case: a server confirmation that
         // arrives *after* the optimistic write must be admitted. Otherwise
         // the optimistic state would be sticky against legitimate server
-        // updates.
-        val optimistic = queueInfoOf("q1", 1000.5)
-        val freshConfirmation = queueInfoOf("q1", 1001.0)
+        // updates. Realistically the server confirmation arrives with a stamp
+        // that's the network round-trip + server processing above the last
+        // server event — orders of magnitude above the optimistic epsilon.
+        val optimistic = queueInfoOf("q1", 1000.0001)
+        val freshConfirmation = queueInfoOf("q1", 1000.5)
 
         assertFalse(
             isStaleReplay(incoming = freshConfirmation, existing = optimistic),

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/QueueInfoStalenessTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/QueueInfoStalenessTest.kt
@@ -1,20 +1,20 @@
 package io.music_assistant.client.data.model.client
 
-import io.music_assistant.client.data.model.client.QueueInfo.Companion.isStaleReplay
 import io.music_assistant.client.data.model.server.RepeatMode
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
- * Guards the staleness gate used to drop server queue replays. The MA server
- * occasionally re-emits queue events that predate fresher state we already
- * received (observed around Siri "next track" handoffs and rapid queue
- * mutations). Without the gate, a stale replay clobbers fresher state and the
- * user-visible playhead snaps backward.
+ * Pins the [QueueInfo.isBefore] comparison used by the staleness gate that
+ * drops server queue replays. The MA server occasionally re-emits queue
+ * events that predate fresher state we already received (observed around
+ * Siri "next track" handoffs and rapid queue mutations); without the gate,
+ * a stale replay clobbers fresher state and the user-visible playhead snaps
+ * backward.
  *
- * The gate is a pure comparison on `elapsedTimeLastUpdated`, deliberately not
- * `elapsedTime` (which is legitimately null mid-pause-transition).
+ * Cross-id and existing==null cases are the caller's concern (handled in
+ * `MainDataSource.takeIfNotStale` before calling [isBefore]).
  */
 class QueueInfoStalenessTest {
     private fun queueInfoOf(
@@ -32,70 +32,78 @@ class QueueInfoStalenessTest {
     )
 
     @Test
-    fun monotonicTimestampsAreNotStale() {
-        val first = queueInfoOf("q1", 1000.0)
-        val second = queueInfoOf("q1", 1001.5)
-
-        assertFalse(
-            isStaleReplay(incoming = second, existing = first),
-            "An event whose timestamp is newer than what we have must not be dropped",
-        )
-    }
-
-    @Test
-    fun decreasingTimestampIsStale() {
-        val current = queueInfoOf("q1", 1001.5)
-        val replay = queueInfoOf("q1", 1000.0)
+    fun olderIsBeforeNewer() {
+        val older = queueInfoOf("q1", 1000.0)
+        val newer = queueInfoOf("q1", 1001.5)
 
         assertTrue(
-            isStaleReplay(incoming = replay, existing = current),
-            "An event with an older timestamp than current must be dropped",
+            older.isBefore(newer),
+            "An event with an older timestamp should be flagged as before",
         )
     }
 
     @Test
-    fun equalTimestampIsNotStale() {
+    fun newerIsNotBeforeOlder() {
+        val older = queueInfoOf("q1", 1000.0)
+        val newer = queueInfoOf("q1", 1001.5)
+
+        assertFalse(
+            newer.isBefore(older),
+            "An event with a newer timestamp must not be flagged as before",
+        )
+    }
+
+    @Test
+    fun equalStampsAreNotBefore() {
         // The gate uses strict less-than, so an event with an equal timestamp
-        // is admitted. Server-replay scenarios produce strictly older stamps;
-        // a same-stamp event is more likely a benign retransmit on a freshly
+        // is admitted. Server replays produce strictly older stamps; a
+        // same-stamp event is more likely a benign retransmit on a freshly
         // re-established transport, where dropping it would lose state.
-        val current = queueInfoOf("q1", 1000.0)
-        val sameStamp = queueInfoOf("q1", 1000.0)
+        val a = queueInfoOf("q1", 1000.0)
+        val b = queueInfoOf("q1", 1000.0)
+
+        assertFalse(a.isBefore(b))
+    }
+
+    @Test
+    fun nullIncomingStampShortCircuits() {
+        // A `null` stamp on the receiver means "we have no monotonic signal"
+        // — the comparison must short-circuit to false (admit), so a future
+        // server build that omits the field can't silently drop legitimate
+        // updates.
+        val malformed = queueInfoOf("q1", elapsedTimeLastUpdated = null)
+        val real = queueInfoOf("q1", 1000.0)
 
         assertFalse(
-            isStaleReplay(incoming = sameStamp, existing = current),
-            "An event with the same timestamp as current must not be dropped",
+            malformed.isBefore(real),
+            "Null receiver stamp must short-circuit to admit",
         )
     }
 
     @Test
-    fun differentQueueIdsAreNeverStale() {
-        // The gate is per-queue. An older event for queue B is unrelated to
-        // a fresher event for queue A; comparing across ids would
-        // permanently silence one of them on a multi-queue server.
-        val queueA = queueInfoOf("queueA", 5000.0)
-        val queueB = queueInfoOf("queueB", 1000.0)
+    fun nullOtherStampShortCircuits() {
+        // Symmetric case: if the existing entry was decoded from a malformed
+        // payload (no stamp), the next event with a real stamp must still be
+        // admitted.
+        val real = queueInfoOf("q1", 1000.0)
+        val malformed = queueInfoOf("q1", elapsedTimeLastUpdated = null)
 
         assertFalse(
-            isStaleReplay(incoming = queueB, existing = queueA),
-            "Cross-queue comparisons must not flag staleness",
+            real.isBefore(malformed),
+            "Null other stamp must short-circuit to admit",
         )
     }
 
     @Test
-    fun firstEventForQueueIsNeverStale() {
-        // No existing state means we have nothing to compare against — the
-        // event is unconditionally fresh.
-        val first = queueInfoOf("q1", 1000.0)
+    fun bothNullStampsShortCircuit() {
+        val a = queueInfoOf("q1", elapsedTimeLastUpdated = null)
+        val b = queueInfoOf("q1", elapsedTimeLastUpdated = null)
 
-        assertFalse(
-            isStaleReplay(incoming = first, existing = null),
-            "An event with no prior state must always be admitted",
-        )
+        assertFalse(a.isBefore(b))
     }
 
     @Test
-    fun optimisticBumpedTimestampPreservesAgainstStaleServerEvent() {
+    fun staleServerEventIsBeforeOptimisticBump() {
         // Optimistic UI writes (e.g. ToggleShuffle) bump elapsedTimeLastUpdated
         // to a value strictly above the last known server stamp (existing +
         // tiny epsilon, see LocalPlayerRepository) so a server replay whose
@@ -104,72 +112,23 @@ class QueueInfoStalenessTest {
         val lastServerEvent = queueInfoOf("q1", 1000.0)
         val optimistic = lastServerEvent.copy(
             shuffleEnabled = true,
-            // The realistic optimistic stamp: existing + epsilon. The exact
-            // epsilon doesn't matter to the gate, only that it's > existing.
             elapsedTimeLastUpdated = 1000.0001,
         )
         val staleServerEvent = queueInfoOf("q1", 999.5)
 
         assertTrue(
-            isStaleReplay(incoming = staleServerEvent, existing = optimistic),
-            "A server event older than the optimistic bump must be dropped to preserve optimistic state",
+            staleServerEvent.isBefore(optimistic),
+            "A server event older than the optimistic bump must be flagged",
         )
     }
 
     @Test
-    fun freshServerConfirmationOverridesOptimistic() {
-        // The flip side of the optimistic case: a server confirmation that
-        // arrives *after* the optimistic write must be admitted. Otherwise
-        // the optimistic state would be sticky against legitimate server
-        // updates. Realistically the server confirmation arrives with a stamp
-        // that's the network round-trip + server processing above the last
-        // server event — orders of magnitude above the optimistic epsilon.
+    fun freshServerConfirmationIsNotBeforeOptimistic() {
+        // Pins the flip side of the optimistic contract: a confirmation
+        // arriving after the optimistic write must override.
         val optimistic = queueInfoOf("q1", 1000.0001)
         val freshConfirmation = queueInfoOf("q1", 1000.5)
 
-        assertFalse(
-            isStaleReplay(incoming = freshConfirmation, existing = optimistic),
-            "A server event newer than the optimistic bump must override",
-        )
-    }
-
-    @Test
-    fun nullIncomingTimestampDisablesGate() {
-        // A `null` incoming stamp means "we have no monotonic signal." The gate
-        // must short-circuit to admit, so a future server build that omits the
-        // field can't silently drop a legitimate update.
-        val current = queueInfoOf("q1", 1000.0)
-        val malformed = queueInfoOf(id = "q1", elapsedTimeLastUpdated = null)
-
-        assertFalse(
-            isStaleReplay(incoming = malformed, existing = current),
-            "A null incoming timestamp must bypass the gate (admit), not be treated as 0.0",
-        )
-    }
-
-    @Test
-    fun nullExistingTimestampDisablesGate() {
-        // Symmetric case: if the existing entry was decoded from a malformed
-        // payload (no stamp), the next event with a real stamp must still be
-        // admitted — otherwise we'd be permanently locked out of updating
-        // that queue.
-        val malformedExisting = queueInfoOf(id = "q1", elapsedTimeLastUpdated = null)
-        val incoming = queueInfoOf("q1", 1000.0)
-
-        assertFalse(
-            isStaleReplay(incoming = incoming, existing = malformedExisting),
-            "A null existing timestamp must bypass the gate (admit) — never permanently lock out updates",
-        )
-    }
-
-    @Test
-    fun bothNullTimestampsAdmit() {
-        val malformedCurrent = queueInfoOf(id = "q1", elapsedTimeLastUpdated = null)
-        val malformedIncoming = queueInfoOf(id = "q1", elapsedTimeLastUpdated = null)
-
-        assertFalse(
-            isStaleReplay(incoming = malformedIncoming, existing = malformedCurrent),
-            "When neither side has a stamp, the gate is fully disabled — admit",
-        )
+        assertFalse(freshConfirmation.isBefore(optimistic))
     }
 }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/QueueInfoStalenessTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/QueueInfoStalenessTest.kt
@@ -1,0 +1,171 @@
+package io.music_assistant.client.data.model.client
+
+import io.music_assistant.client.data.model.client.QueueInfo.Companion.isStaleReplay
+import io.music_assistant.client.data.model.server.RepeatMode
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Guards the staleness gate used to drop server queue replays. The MA server
+ * occasionally re-emits queue events that predate fresher state we already
+ * received (observed around Siri "next track" handoffs and rapid queue
+ * mutations). Without the gate, a stale replay clobbers fresher state and the
+ * user-visible playhead snaps backward.
+ *
+ * The gate is a pure comparison on `elapsedTimeLastUpdated`, deliberately not
+ * `elapsedTime` (which is legitimately null mid-pause-transition).
+ */
+class QueueInfoStalenessTest {
+    private fun queueInfoOf(
+        id: String,
+        elapsedTimeLastUpdated: Double?,
+        elapsedTime: Double? = elapsedTimeLastUpdated,
+    ) = QueueInfo(
+        id = id,
+        available = true,
+        shuffleEnabled = false,
+        repeatMode = RepeatMode.OFF,
+        elapsedTime = elapsedTime,
+        elapsedTimeLastUpdated = elapsedTimeLastUpdated,
+        currentItem = null,
+    )
+
+    @Test
+    fun monotonicTimestampsAreNotStale() {
+        val first = queueInfoOf("q1", 1000.0)
+        val second = queueInfoOf("q1", 1001.5)
+
+        assertFalse(
+            isStaleReplay(incoming = second, existing = first),
+            "An event whose timestamp is newer than what we have must not be dropped",
+        )
+    }
+
+    @Test
+    fun decreasingTimestampIsStale() {
+        val current = queueInfoOf("q1", 1001.5)
+        val replay = queueInfoOf("q1", 1000.0)
+
+        assertTrue(
+            isStaleReplay(incoming = replay, existing = current),
+            "An event with an older timestamp than current must be dropped",
+        )
+    }
+
+    @Test
+    fun equalTimestampIsNotStale() {
+        // The gate uses strict less-than, so an event with an equal timestamp
+        // is admitted. Server-replay scenarios produce strictly older stamps;
+        // a same-stamp event is more likely a benign retransmit on a freshly
+        // re-established transport, where dropping it would lose state.
+        val current = queueInfoOf("q1", 1000.0)
+        val sameStamp = queueInfoOf("q1", 1000.0)
+
+        assertFalse(
+            isStaleReplay(incoming = sameStamp, existing = current),
+            "An event with the same timestamp as current must not be dropped",
+        )
+    }
+
+    @Test
+    fun differentQueueIdsAreNeverStale() {
+        // The gate is per-queue. An older event for queue B is unrelated to
+        // a fresher event for queue A; comparing across ids would
+        // permanently silence one of them on a multi-queue server.
+        val queueA = queueInfoOf("queueA", 5000.0)
+        val queueB = queueInfoOf("queueB", 1000.0)
+
+        assertFalse(
+            isStaleReplay(incoming = queueB, existing = queueA),
+            "Cross-queue comparisons must not flag staleness",
+        )
+    }
+
+    @Test
+    fun firstEventForQueueIsNeverStale() {
+        // No existing state means we have nothing to compare against — the
+        // event is unconditionally fresh.
+        val first = queueInfoOf("q1", 1000.0)
+
+        assertFalse(
+            isStaleReplay(incoming = first, existing = null),
+            "An event with no prior state must always be admitted",
+        )
+    }
+
+    @Test
+    fun optimisticBumpedTimestampPreservesAgainstStaleServerEvent() {
+        // Optimistic UI writes (e.g. ToggleShuffle) bump elapsedTimeLastUpdated
+        // to client wall clock so a server replay whose timestamp predates the
+        // user action is rejected. This documents the contract.
+        val lastServerEvent = queueInfoOf("q1", 1000.0)
+        val optimistic = lastServerEvent.copy(
+            shuffleEnabled = true,
+            // Wall clock at the optimistic moment, strictly after the last
+            // server event.
+            elapsedTimeLastUpdated = 1000.500,
+        )
+        val staleServerEvent = queueInfoOf("q1", 1000.250)
+
+        assertTrue(
+            isStaleReplay(incoming = staleServerEvent, existing = optimistic),
+            "A server event older than the optimistic bump must be dropped to preserve optimistic state",
+        )
+    }
+
+    @Test
+    fun freshServerConfirmationOverridesOptimistic() {
+        // The flip side of the optimistic case: a server confirmation that
+        // arrives *after* the optimistic write must be admitted. Otherwise
+        // the optimistic state would be sticky against legitimate server
+        // updates.
+        val optimistic = queueInfoOf("q1", 1000.5)
+        val freshConfirmation = queueInfoOf("q1", 1001.0)
+
+        assertFalse(
+            isStaleReplay(incoming = freshConfirmation, existing = optimistic),
+            "A server event newer than the optimistic bump must override",
+        )
+    }
+
+    @Test
+    fun nullIncomingTimestampDisablesGate() {
+        // A `null` incoming stamp means "we have no monotonic signal." The gate
+        // must short-circuit to admit, so a future server build that omits the
+        // field can't silently drop a legitimate update.
+        val current = queueInfoOf("q1", 1000.0)
+        val malformed = queueInfoOf(id = "q1", elapsedTimeLastUpdated = null)
+
+        assertFalse(
+            isStaleReplay(incoming = malformed, existing = current),
+            "A null incoming timestamp must bypass the gate (admit), not be treated as 0.0",
+        )
+    }
+
+    @Test
+    fun nullExistingTimestampDisablesGate() {
+        // Symmetric case: if the existing entry was decoded from a malformed
+        // payload (no stamp), the next event with a real stamp must still be
+        // admitted — otherwise we'd be permanently locked out of updating
+        // that queue.
+        val malformedExisting = queueInfoOf(id = "q1", elapsedTimeLastUpdated = null)
+        val incoming = queueInfoOf("q1", 1000.0)
+
+        assertFalse(
+            isStaleReplay(incoming = incoming, existing = malformedExisting),
+            "A null existing timestamp must bypass the gate (admit) — never permanently lock out updates",
+        )
+    }
+
+    @Test
+    fun bothNullTimestampsAdmit() {
+        val malformedCurrent = queueInfoOf(id = "q1", elapsedTimeLastUpdated = null)
+        val malformedIncoming = queueInfoOf(id = "q1", elapsedTimeLastUpdated = null)
+
+        assertFalse(
+            isStaleReplay(incoming = malformedIncoming, existing = malformedCurrent),
+            "When neither side has a stamp, the gate is fully disabled — admit",
+        )
+    }
+}


### PR DESCRIPTION
I saw a lot of out-of-order and replayed Queue events when I was on cellular, and using my steering wheel buttons and Siri to control playback. It ended up with a lot of weird UI stuff, showing some track for a split second then snapping over to another one, all while playing the same song. This uses the time sent from the server as a monotonic-ish (and DST-immune) guide to what comes first so we do better at displaying what the server thinks we should be displaying.

Robot explanation:

The MA server occasionally replays QueueUpdated/QueueItemsUpdated events that predate fresher state we already received (observed around Siri "next track" handoffs and rapid queue mutations); the playhead would snap backward or a prior track would briefly return.

`QueueInfo.isStaleReplay` drops events whose `elapsedTimeLastUpdated` predates what we have for the same queue id, gated through a single `gateOrSkip` helper across `QueueUpdated`, `QueueItemsUpdated`, and `QueueAdded`. `_queueInfos` is the single source of truth: optimistic shuffle/repeat toggles bump the stamp to client wall clock and notify `MainDataSource` via `LocalPlayerRepository.onOptimisticQueueChange`, so a stale replay after a toggle can't pass the gate. `QueueTimeUpdatedEvent` carries no server stamp and isn't gated.

QueueAdded was previously dropped at `Event.fromJsonElement`; the new handler upserts into `_queueInfos` and forwards to the local-player repository, fixing an empty Now Playing on a freshly connected player.

Tests: 10 cases in `QueueInfoStalenessTest` + queue_added parse test.