### PR TITLE
fix(build): link WebRTC.xcframework into iOS Kotlin/Native test binaries

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -41,6 +41,32 @@ kotlin {
             isStatic = true
             binaryOption("bundleId", "io.music_assistant.client.composeapp")
         }
+
+        // Test binaries need to fully resolve WebRTC at link time. The main
+        // framework is static and defers WebRTC resolution to the iOS app's
+        // final Xcode link, where `iosApp/Frameworks/WebRTC.xcframework` is on
+        // the framework search path. Kotlin/Native test executables don't go
+        // through that wiring, so we point them at the matching slice of the
+        // bundled XCFramework directly. Without this, `:composeApp:*Test*`
+        // tasks fail at `linkDebugTest*` with `framework 'WebRTC' not found`.
+        val webrtcSlice = when (iosTarget.targetName) {
+            "iosArm64" -> "ios-arm64"
+            "iosSimulatorArm64", "iosX64" -> "ios-arm64_x86_64-simulator"
+            else -> error("Unexpected iOS target: ${iosTarget.targetName}")
+        }
+        val webrtcSliceDir = rootProject.layout.projectDirectory
+            .dir("iosApp/Frameworks/WebRTC.xcframework/$webrtcSlice")
+            .asFile
+            .absolutePath
+        listOf(
+            org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG,
+            org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.RELEASE,
+        ).forEach { buildType ->
+            iosTarget.binaries.findTest(buildType)?.linkerOpts(
+                "-F", webrtcSliceDir,
+                "-rpath", webrtcSliceDir,
+            )
+        }
     }
 
     sourceSets {


### PR DESCRIPTION
I left the comment long on this one, because it's non-obvious why we have to do this even though none of the iOS tests actually test WebRTC (at least, as of now). I can trim it down if you want.

Without this, `:composeApp:linkDebugTest*` (and every iOS test target downstream of it — `iosArm64Test`, `iosSimulatorArm64Test`, `iosX64Test`) fails with `ld: framework 'WebRTC' not found`, blocking iOS test execution entirely.

The main framework is built static and defers WebRTC resolution to the iOS app's final Xcode link, where `iosApp/Frameworks/WebRTC.xcframework` is on the framework search path. K/N test executables are standalone binaries linked by `ld` directly and don't go through that wiring, so we point them at the matching slice of the bundled XCFramework:

- Device (iosArm64) → `ios-arm64`
- Simulator (iosSimulatorArm64, iosX64) → `ios-arm64_x86_64-simulator`

Verified: `linkDebugTestIosArm64`, `linkDebugTestIosSimulatorArm64`, and `iosSimulatorArm64Test` all succeed against the failure reproduced on clean origin/dev.