### PR TITLE
fix(androidApp, composeApp): Disconnect sendspin client on close when not playing audio.

### DIFF
--- a/androidApp/src/main/kotlin/io/music_assistant/client/services/MainMediaPlaybackService.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/services/MainMediaPlaybackService.kt
@@ -303,6 +303,18 @@ class MainMediaPlaybackService : MediaBrowserServiceCompat() {
         dataSource.selectPlayer(list[newIndex].player)
     }
 
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        // If nothing is actively playing, stop Sendspin and this service when the
+        // user closes the app from recents. Playing state is left running so
+        // background audio continues uninterrupted.
+        if (!dataSource.isAnythingPlaying.value) {
+            dataSource.onAppClosed()
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            stopSelf()
+        }
+    }
+
     override fun onDestroy() {
         if (fullyInitialized) {
             releaseWifiLock()

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -1841,6 +1841,18 @@ class MainDataSource(
         }
     }
 
+    /**
+     * Called when the app task is removed (user closed the app from recents).
+     * Stops Sendspin if nothing is actively playing — playing state is intentionally
+     * kept alive for background audio and is not affected by this call.
+     */
+    fun onAppClosed() {
+        if (!isAnythingPlaying.value) {
+            log.i { "App closed with no active playback — stopping Sendspin" }
+            launch { stopSendspin() }
+        }
+    }
+
     fun close() {
         supervisorJob.cancel()
     }


### PR DESCRIPTION
Created a function for when the app is closed, which checks for if music is playing and disconnects the sendspin client if nothing is playing.

When an android user removes the app from their recent apps, the function is triggered and checks for active playback. If no playback is active, the sendspin client is disconnected and the application stops itself and removes from the foreground.

If playback is active, it continues playing in the background to prevent accidental closures.

Fixes #302