### PR TITLE
CarPlay reliability

### DIFF
--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
@@ -1,5 +1,6 @@
 package io.music_assistant.client.di
 
+import co.touchlab.kermit.Logger
 import io.music_assistant.client.api.Request
 import io.music_assistant.client.api.ServiceClient
 import io.music_assistant.client.auth.AuthenticationManager
@@ -9,13 +10,25 @@ import io.music_assistant.client.data.model.client.AppMediaItem.Companion.toAppM
 import io.music_assistant.client.data.model.server.QueueOption
 import io.music_assistant.client.data.model.server.ServerMediaItem
 import io.music_assistant.client.utils.HasConnectionData
+import io.music_assistant.client.utils.currentTimeMillis
 import io.music_assistant.client.utils.resultAs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+
+private val log = Logger.withTag("KmpHelper")
+
+/** Swift-callable cancellation handle for coroutine subscriptions. */
+fun interface Cancellable { fun cancel() }
+
+/** CarPlay round-trip budget before a fetch surfaces a disconnected affordance. */
+private const val FETCH_TIMEOUT_MS = 5_000L
 
 /**
  * KmpHelper - Bridge for accessing Koin dependencies from Swift
@@ -36,10 +49,6 @@ object KmpHelper : KoinComponent {
      * The connected MA server's stable identifier (UUID-style, e.g.
      * "70e548..."). Available once the server has sent its handshake;
      * null while the connection is still being established.
-     *
-     * Stable across the server's lifetime regardless of how the client
-     * reaches it (mDNS, IP, port forward, network change), which makes it
-     * the right key for namespacing donations and other per-server state.
      */
     fun getServerId(): String? {
         return (serviceClient.sessionState.value as? HasConnectionData)
@@ -53,84 +62,144 @@ object KmpHelper : KoinComponent {
     fun onExternalConsumerActive() = serviceClient.onExternalConsumerActive()
     fun onExternalConsumerInactive() = serviceClient.onExternalConsumerInactive()
 
+    // MARK: - Readiness observation
+
+    /**
+     * Subscribe to transport command-readiness. Fires with the current value
+     * on subscribe and on every change. Caller must `cancel()` on teardown.
+     */
+    fun observeReadiness(onChanged: (Boolean) -> Unit): Cancellable {
+        val job = mainScope.launch {
+            serviceClient.isReadyForCommands.collect { onChanged(it) }
+        }
+        return Cancellable { job.cancel() }
+    }
+
+    /**
+     * Subscribe to "local player has a current track" transitions. Fires
+     * with the current value on subscribe, then on every distinct change.
+     */
+    fun observeLocalPlayerPresence(onChanged: (Boolean) -> Unit): Cancellable {
+        val job = mainScope.launch {
+            mainDataSource.localPlayer
+                .map { it?.queueInfo?.currentItem != null }
+                .distinctUntilChanged()
+                .collect { onChanged(it) }
+        }
+        return Cancellable { job.cancel() }
+    }
+
     // MARK: - Swift Helpers for Data Fetching
+    //
+    // Every fetcher returns a nullable list. `null` means the round trip
+    // exceeded FETCH_TIMEOUT_MS — Swift renders a disconnected affordance.
+    // An empty list means the server answered with nothing.
 
-    fun fetchRecommendations(completion: (List<AppMediaItem>) -> Unit) {
+    private inline fun <T> launchFetch(
+        label: String,
+        crossinline completion: (List<T>?) -> Unit,
+        crossinline fetch: suspend () -> List<T>,
+    ) {
+        val startMs = currentTimeMillis()
+        log.i { "fetch[$label] start" }
         mainScope.launch {
-            val result = serviceClient.sendRequest(Request.Library.recommendations())
-            val serverItems = result.resultAs<List<ServerMediaItem>>() ?: emptyList()
-            val appItems = serverItems.toAppMediaItemList()
-            completion(appItems)
-        }
-    }
-
-    fun fetchRecommendationFolders(completion: (List<AppMediaItem.RecommendationFolder>) -> Unit) {
-        mainScope.launch {
-            val result = serviceClient.sendRequest(Request.Library.recommendations())
-            val serverItems = result.resultAs<List<ServerMediaItem>>() ?: emptyList()
-            val folders = serverItems.toAppMediaItemList().filterIsInstance<AppMediaItem.RecommendationFolder>()
-            completion(folders)
-        }
-    }
-
-    fun fetchPlaylists(completion: (List<AppMediaItem>) -> Unit) {
-        mainScope.launch {
-             val result = serviceClient.sendRequest(Request.Playlist.listLibrary())
-             val items = result.resultAs<List<ServerMediaItem>>()?.toAppMediaItemList() ?: emptyList()
-             completion(items)
-        }
-    }
-
-    fun fetchAlbums(completion: (List<AppMediaItem>) -> Unit) {
-        mainScope.launch {
-            val result = serviceClient.sendRequest(Request.Album.listLibrary())
-            val items = result.resultAs<List<ServerMediaItem>>()?.toAppMediaItemList() ?: emptyList()
+            val items: List<T>? = withTimeoutOrNull(FETCH_TIMEOUT_MS) { fetch() }
+            val elapsed = currentTimeMillis() - startMs
+            if (items == null) {
+                log.i { "fetch[$label] timeout after ${elapsed}ms" }
+            } else {
+                log.i { "fetch[$label] returned ${items.size} items in ${elapsed}ms" }
+            }
             completion(items)
         }
     }
 
-    fun fetchArtists(completion: (List<AppMediaItem>) -> Unit) {
-        mainScope.launch {
-            val result = serviceClient.sendRequest(Request.Artist.listLibrary())
-            val items = result.resultAs<List<ServerMediaItem>>()?.toAppMediaItemList() ?: emptyList()
-            completion(items)
+    fun fetchRecommendations(completion: (List<AppMediaItem>?) -> Unit) {
+        launchFetch("recommendations", completion) {
+            serviceClient.sendRequest(Request.Library.recommendations())
+                .resultAs<List<ServerMediaItem>>()
+                ?.toAppMediaItemList()
+                ?: emptyList()
         }
     }
 
-    fun fetchAudiobooks(completion: (List<AppMediaItem>) -> Unit) {
-        mainScope.launch {
-            val result = serviceClient.sendRequest(Request.Audiobook.listLibrary())
-            val items = result.resultAs<List<ServerMediaItem>>()?.toAppMediaItemList() ?: emptyList()
-            completion(items)
+    fun fetchRecommendationFolders(
+        completion: (List<AppMediaItem.RecommendationFolder>?) -> Unit,
+    ) {
+        launchFetch("recommendationFolders", completion) {
+            serviceClient.sendRequest(Request.Library.recommendations())
+                .resultAs<List<ServerMediaItem>>()
+                ?.toAppMediaItemList()
+                ?.filterIsInstance<AppMediaItem.RecommendationFolder>()
+                ?: emptyList()
         }
     }
 
-    fun fetchTracks(completion: (List<AppMediaItem>) -> Unit) {
-        mainScope.launch {
-            val result = serviceClient.sendRequest(Request.Track.list())
-            val items = result.resultAs<List<ServerMediaItem>>()?.toAppMediaItemList() ?: emptyList()
-            completion(items)
+    fun fetchPlaylists(completion: (List<AppMediaItem>?) -> Unit) {
+        launchFetch("playlists", completion) {
+            serviceClient.sendRequest(Request.Playlist.listLibrary())
+                .resultAs<List<ServerMediaItem>>()
+                ?.toAppMediaItemList()
+                ?: emptyList()
         }
     }
 
-    fun fetchPodcasts(completion: (List<AppMediaItem>) -> Unit) {
-        mainScope.launch {
-            val result = serviceClient.sendRequest(Request.Podcast.listLibrary())
-            val items = result.resultAs<List<ServerMediaItem>>()?.toAppMediaItemList() ?: emptyList()
-            completion(items)
+    fun fetchAlbums(completion: (List<AppMediaItem>?) -> Unit) {
+        launchFetch("albums", completion) {
+            serviceClient.sendRequest(Request.Album.listLibrary())
+                .resultAs<List<ServerMediaItem>>()
+                ?.toAppMediaItemList()
+                ?: emptyList()
         }
     }
 
-    fun fetchRadioStations(completion: (List<AppMediaItem>) -> Unit) {
-        mainScope.launch {
-            val result = serviceClient.sendRequest(Request.RadioStation.listLibrary())
-            val items = result.resultAs<List<ServerMediaItem>>()?.toAppMediaItemList() ?: emptyList()
-            completion(items)
+    fun fetchArtists(completion: (List<AppMediaItem>?) -> Unit) {
+        launchFetch("artists", completion) {
+            serviceClient.sendRequest(Request.Artist.listLibrary())
+                .resultAs<List<ServerMediaItem>>()
+                ?.toAppMediaItemList()
+                ?: emptyList()
         }
     }
 
-    fun search(query: String, completion: (List<AppMediaItem>) -> Unit) {
-        mainScope.launch {
+    fun fetchAudiobooks(completion: (List<AppMediaItem>?) -> Unit) {
+        launchFetch("audiobooks", completion) {
+            serviceClient.sendRequest(Request.Audiobook.listLibrary())
+                .resultAs<List<ServerMediaItem>>()
+                ?.toAppMediaItemList()
+                ?: emptyList()
+        }
+    }
+
+    fun fetchTracks(completion: (List<AppMediaItem>?) -> Unit) {
+        launchFetch("tracks", completion) {
+            serviceClient.sendRequest(Request.Track.list())
+                .resultAs<List<ServerMediaItem>>()
+                ?.toAppMediaItemList()
+                ?: emptyList()
+        }
+    }
+
+    fun fetchPodcasts(completion: (List<AppMediaItem>?) -> Unit) {
+        launchFetch("podcasts", completion) {
+            serviceClient.sendRequest(Request.Podcast.listLibrary())
+                .resultAs<List<ServerMediaItem>>()
+                ?.toAppMediaItemList()
+                ?: emptyList()
+        }
+    }
+
+    fun fetchRadioStations(completion: (List<AppMediaItem>?) -> Unit) {
+        launchFetch("radioStations", completion) {
+            serviceClient.sendRequest(Request.RadioStation.listLibrary())
+                .resultAs<List<ServerMediaItem>>()
+                ?.toAppMediaItemList()
+                ?: emptyList()
+        }
+    }
+
+    fun search(query: String, completion: (List<AppMediaItem>?) -> Unit) {
+        launchFetch("search:$query", completion) {
             val result = serviceClient.sendRequest(
                 Request.Library.search(
                     query = query,
@@ -146,9 +215,65 @@ object KmpHelper : KoinComponent {
                     libraryOnly = false,
                 ),
             )
-            val searchResult = result.resultAs<io.music_assistant.client.data.model.server.SearchResult>()
-            val items = searchResult?.toAppMediaItemList() ?: emptyList()
-            completion(items)
+            result.resultAs<io.music_assistant.client.data.model.server.SearchResult>()
+                ?.toAppMediaItemList()
+                ?: emptyList()
+        }
+    }
+
+    // MARK: - Drilldown fetchers (same nullable-on-timeout contract)
+
+    fun fetchAlbumsByArtist(
+        artist: AppMediaItem.Artist,
+        completion: (List<AppMediaItem>?) -> Unit,
+    ) {
+        launchFetch("albumsByArtist:${artist.itemId}", completion) {
+            serviceClient.sendRequest(
+                Request.Artist.getAlbums(
+                    itemId = artist.itemId,
+                    providerInstanceIdOrDomain = artist.provider,
+                    inLibraryOnly = false,
+                ),
+            ).resultAs<List<ServerMediaItem>>()
+                ?.toAppMediaItemList()
+                ?.filterIsInstance<AppMediaItem.Album>()
+                ?: emptyList()
+        }
+    }
+
+    fun fetchTracksByAlbum(
+        album: AppMediaItem.Album,
+        completion: (List<AppMediaItem>?) -> Unit,
+    ) {
+        launchFetch("tracksByAlbum:${album.itemId}", completion) {
+            serviceClient.sendRequest(
+                Request.Album.getTracks(
+                    itemId = album.itemId,
+                    providerInstanceIdOrDomain = album.provider,
+                    inLibraryOnly = false,
+                ),
+            ).resultAs<List<ServerMediaItem>>()
+                ?.toAppMediaItemList()
+                ?.filterIsInstance<AppMediaItem.Track>()
+                ?: emptyList()
+        }
+    }
+
+    fun fetchTracksByPlaylist(
+        playlist: AppMediaItem.Playlist,
+        completion: (List<AppMediaItem>?) -> Unit,
+    ) {
+        launchFetch("tracksByPlaylist:${playlist.itemId}", completion) {
+            serviceClient.sendRequest(
+                Request.Playlist.getTracks(
+                    itemId = playlist.itemId,
+                    providerInstanceIdOrDomain = playlist.provider,
+                    forceRefresh = null,
+                ),
+            ).resultAs<List<ServerMediaItem>>()
+                ?.toAppMediaItemList()
+                ?.filterIsInstance<AppMediaItem.Track>()
+                ?: emptyList()
         }
     }
 

--- a/iosApp/iosApp/CarPlay/CarPlayContentManager.swift
+++ b/iosApp/iosApp/CarPlay/CarPlayContentManager.swift
@@ -38,67 +38,105 @@ class CarPlayContentManager {
     static let shared = CarPlayContentManager()
 
     // MARK: - API Calls
+    // Fetchers return `[CPListItem]?`: nil = timeout, [] = empty result.
 
-    func fetchRecommendations(completion: @escaping ([CPListItem]) -> Void) {
+    private func mapItems(_ items: [AppMediaItem]?) -> [CPListItem]? {
+        guard let items = items else { return nil }
+        return items.compactMap { self.mapToCPListItem($0) }
+    }
+
+    func fetchRecommendations(completion: @escaping ([CPListItem]?) -> Void) {
         KmpHelper.shared.fetchRecommendations { items in
-            completion(items.compactMap { self.mapToCPListItem($0) })
+            completion(self.mapItems(items))
         }
     }
-    
-    func fetchPlaylists(completion: @escaping ([CPListItem]) -> Void) {
+
+    func fetchPlaylists(completion: @escaping ([CPListItem]?) -> Void) {
         KmpHelper.shared.fetchPlaylists { items in
-            completion(items.compactMap { self.mapToCPListItem($0) })
+            completion(self.mapItems(items))
         }
     }
-    
-    func fetchAlbums(completion: @escaping ([CPListItem]) -> Void) {
+
+    func fetchAlbums(completion: @escaping ([CPListItem]?) -> Void) {
         KmpHelper.shared.fetchAlbums { items in
-            completion(items.compactMap { self.mapToCPListItem($0) })
+            completion(self.mapItems(items))
         }
     }
-    
-    func fetchArtists(completion: @escaping ([CPListItem]) -> Void) {
+
+    func fetchArtists(completion: @escaping ([CPListItem]?) -> Void) {
         KmpHelper.shared.fetchArtists { items in
-            completion(items.compactMap { self.mapToCPListItem($0) })
+            completion(self.mapItems(items))
         }
     }
 
-    func fetchAudiobooks(completion: @escaping ([CPListItem]) -> Void) {
+    func fetchAudiobooks(completion: @escaping ([CPListItem]?) -> Void) {
         KmpHelper.shared.fetchAudiobooks { items in
-            completion(items.compactMap { self.mapToCPListItem($0) })
+            completion(self.mapItems(items))
         }
     }
 
-    func fetchTracks(completion: @escaping ([CPListItem]) -> Void) {
+    func fetchTracks(completion: @escaping ([CPListItem]?) -> Void) {
         KmpHelper.shared.fetchTracks { items in
-            completion(items.compactMap { self.mapToCPListItem($0) })
+            completion(self.mapItems(items))
         }
     }
 
-    func fetchPodcasts(completion: @escaping ([CPListItem]) -> Void) {
+    func fetchPodcasts(completion: @escaping ([CPListItem]?) -> Void) {
         KmpHelper.shared.fetchPodcasts { items in
-            completion(items.compactMap { self.mapToCPListItem($0) })
+            completion(self.mapItems(items))
         }
     }
 
-    func fetchRadioStations(completion: @escaping ([CPListItem]) -> Void) {
+    func fetchRadioStations(completion: @escaping ([CPListItem]?) -> Void) {
         KmpHelper.shared.fetchRadioStations { items in
-            completion(items.compactMap { self.mapToCPListItem($0) })
+            completion(self.mapItems(items))
         }
     }
 
-    func fetchRecommendationFolders(completion: @escaping ([AppMediaItem.RecommendationFolder]) -> Void) {
+    /// Returns nil on timeout. Empty array means "server answered, no folders."
+    func fetchRecommendationFolders(completion: @escaping ([AppMediaItem.RecommendationFolder]?) -> Void) {
         KmpHelper.shared.fetchRecommendationFolders { folders in
+            guard let folders = folders else { completion(nil); return }
             completion(Array(folders))
         }
     }
 
-    func search(query: String, completion: @escaping ([CPListItem]) -> Void) {
+    func search(query: String, completion: @escaping ([CPListItem]?) -> Void) {
         KmpHelper.shared.search(query: query) { items in
-             completion(items.compactMap { self.mapToCPListItem($0) })
+            completion(self.mapItems(items))
         }
     }
-    
+
+    // MARK: - Drilldown fetchers
+    // Same nil-on-timeout contract as the library fetchers above.
+
+    func fetchAlbumsForArtist(
+        _ artist: AppMediaItem.Artist,
+        completion: @escaping ([CPListItem]?) -> Void
+    ) {
+        KmpHelper.shared.fetchAlbumsByArtist(artist: artist) { items in
+            completion(self.mapItems(items))
+        }
+    }
+
+    func fetchTracksForAlbum(
+        _ album: AppMediaItem.Album,
+        completion: @escaping ([CPListItem]?) -> Void
+    ) {
+        KmpHelper.shared.fetchTracksByAlbum(album: album) { items in
+            completion(self.mapItems(items))
+        }
+    }
+
+    func fetchTracksForPlaylist(
+        _ playlist: AppMediaItem.Playlist,
+        completion: @escaping ([CPListItem]?) -> Void
+    ) {
+        KmpHelper.shared.fetchTracksByPlaylist(playlist: playlist) { items in
+            completion(self.mapItems(items))
+        }
+    }
+
     // MARK: - Action Handling
 
     func playItem(_ item: AppMediaItem) {

--- a/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
+++ b/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
@@ -1,29 +1,156 @@
 import Foundation
 import CarPlay
 import ComposeApp
+import os.log
+
+/// CarPlay lifecycle markers. Logged at `.default` so they survive a
+/// post-drive sysdiagnose (`.info`/`.debug` are in-memory only).
+private let cpLog = OSLog(subsystem: "io.music-assistant.client", category: "CarPlay")
 
 class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
 
     var interfaceController: CPInterfaceController?
 
+    // MARK: - Readiness state
+    //
+    // `isReady` mirrors `serviceClient.isReadyForCommands` so synchronous
+    // tap-time checks don't have to await the StateFlow. Updated by the
+    // `readinessSubscription` callback on the main thread.
+    private var isReady: Bool = false
+    private var readinessSubscription: Cancellable?
+
+    // Weakly held so a connectivity restore can re-fire the homepage fetch
+    // without retaining the template after CarPlay disconnects.
+    private weak var libraryTemplate: CPListTemplate?
+    private weak var libraryBrowseSection: CPListSection?
+
+    // One-shot subscription that pushes Now Playing the first time
+    // local-player state becomes non-null after `setupTemplates()` runs.
+    // Cancelled either on first push or on disconnect.
+    private var initialPushSubscription: Cancellable?
+
+    /// Monotonic id for in-flight Library recommendation fetches so a slow
+    /// first attempt (fired before auth) can't overwrite a faster second
+    /// attempt (fired by `refreshLibraryOnReconnect` once readiness flipped).
+    private var recommendationsFetchGen: Int = 0
+
     // MARK: - CPTemplateApplicationSceneDelegate
 
     func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene, didConnect interfaceController: CPInterfaceController) {
         self.interfaceController = interfaceController
-        print("CP: Connected to CarPlay")
+        os_log("CP: didConnect", log: cpLog, type: .default)
+        // Reset per-session state for a clean reconnect.
+        recommendationsFetchGen = 0
+        isReady = false
         KmpHelper.shared.onExternalConsumerActive()
+        // The initial fetch is driven from handleReadinessChange's first
+        // emission, not from setupTemplates — see createLibraryTemplate.
+        // `(Boolean) -> Unit` from Kotlin exposes as `KotlinBoolean`; unbox.
+        readinessSubscription = KmpHelper.shared.observeReadiness { [weak self] ready in
+            self?.handleReadinessChange(ready.boolValue)
+        }
         setupTemplates()
     }
 
     func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene, didDisconnectInterfaceController interfaceController: CPInterfaceController) {
+        // Cancel subscriptions before tearing down state to avoid the
+        // callbacks racing with a nil interfaceController.
+        readinessSubscription?.cancel()
+        readinessSubscription = nil
+        initialPushSubscription?.cancel()
+        initialPushSubscription = nil
+        libraryTemplate = nil
+        libraryBrowseSection = nil
         self.interfaceController = nil
         KmpHelper.shared.onExternalConsumerInactive()
-        print("CP: Disconnected from CarPlay")
+        os_log("CP: didDisconnect", log: cpLog, type: .default)
     }
 
+    // MARK: - Readiness handling
+
+    /// Called from the Kotlin readiness subscription. The closure already runs
+    /// on `Dispatchers.Main` (UIKit main thread on iOS), so direct UI updates
+    /// are safe — no `DispatchQueue.main.async` hop needed.
+    private func handleReadinessChange(_ ready: Bool) {
+        let wasReady = isReady
+        isReady = ready
+        os_log("CP: handleReadinessChange wasReady=%{public}@ ready=%{public}@",
+               log: cpLog, type: .default,
+               String(wasReady), String(ready))
+        guard interfaceController != nil else {
+            os_log("CP: handleReadinessChange ignored — no interfaceController",
+                   log: cpLog, type: .default)
+            return
+        }
+
+        if !wasReady && ready {
+            // Reconnected — re-fire the Library fetch. Drilldowns re-fetch
+            // when re-entered, so only the top-level needs refreshing.
+            refreshLibraryOnReconnect()
+        }
+    }
+
+    private func refreshLibraryOnReconnect() {
+        guard
+            let template = libraryTemplate,
+            let browseSection = libraryBrowseSection
+        else {
+            os_log("CP: refreshLibraryOnReconnect skipped — template/section nil",
+                   log: cpLog, type: .default)
+            return
+        }
+        os_log("CP: refreshLibraryOnReconnect firing loadRecommendations",
+               log: cpLog, type: .default)
+        loadRecommendations(for: template, browseSection: browseSection)
+    }
+
+    /// Transient alert when the user taps while the transport is down.
+    /// Idempotent — CarPlay throws on stacked presentations.
+    private func showOfflineAlert() {
+        guard let interfaceController = interfaceController,
+              interfaceController.presentedTemplate == nil
+        else { return }
+        let alert = CPAlertTemplate(
+            titleVariants: ["Not connected — try again when reconnected"],
+            actions: [
+                CPAlertAction(title: "OK", style: .default) { [weak self] _ in
+                    self?.interfaceController?.dismissTemplate(animated: true, completion: nil)
+                }
+            ]
+        )
+        interfaceController.presentTemplate(alert, animated: true, completion: nil)
+    }
+
+    /// Pushes Library root and arms a one-shot Now Playing push for when
+    /// the local player gains a track (subscription-based because the
+    /// local-player value is cleared on backgrounded disconnect).
     private func setupTemplates() {
         let libraryTemplate = createLibraryTemplate()
-        interfaceController?.setRootTemplate(libraryTemplate, animated: true, completion: nil)
+        interfaceController?.setRootTemplate(libraryTemplate, animated: true) { [weak self] _, _ in
+            self?.subscribeToLocalPlayerForInitialPush()
+        }
+    }
+
+    private func subscribeToLocalPlayerForInitialPush() {
+        // No lock needed — KmpHelper.mainScope is pinned to Dispatchers.Main.
+        var hasPushed = false
+        initialPushSubscription = KmpHelper.shared.observeLocalPlayerPresence { [weak self] present in
+            guard let self = self, !hasPushed, present.boolValue else { return }
+            // If the user has navigated past Library root, pushing Now
+            // Playing on top of their drilldown would be jarring. Identity
+            // comparison is safe because we hold a weak reference to the
+            // same template instance set as root.
+            if self.interfaceController?.topTemplate === self.libraryTemplate {
+                self.interfaceController?.pushTemplate(
+                    CPNowPlayingTemplate.shared,
+                    animated: false,
+                    completion: nil
+                )
+            }
+            hasPushed = true
+            self.initialPushSubscription?.cancel()
+            self.initialPushSubscription = nil
+        }
     }
 
     // MARK: - UI Construction
@@ -56,12 +183,12 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     private static func renderCategoryImage(symbol symbolName: String, size: CGSize, traits: UITraitCollection) -> UIImage {
         let tintColor = iconTint.resolvedColor(with: traits)
         let symbol = UIImage(systemName: symbolName)!
-        
+
         // Use scale: 0 to automatically match the screen scale
         let format = UIGraphicsImageRendererFormat()
         format.scale = 0 // Use screen scale
         format.opaque = false
-        
+
         let renderer = UIGraphicsImageRenderer(size: size, format: format)
         return renderer.image { ctx in
             // No background - transparent
@@ -116,8 +243,11 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
 
         let libraryList = CPListTemplate(title: "Library", sections: [browseSection, loadingSection])
 
-        // Async load recommendation folders
-        loadRecommendations(for: libraryList, browseSection: browseSection)
+        // Weak refs feed `refreshLibraryOnReconnect`, which is the sole
+        // path that fires `loadRecommendations` — including the initial
+        // fetch (driven by the readiness sub's first emission).
+        self.libraryTemplate = libraryList
+        self.libraryBrowseSection = browseSection
 
         return libraryList
     }
@@ -125,13 +255,35 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     // MARK: - Data Loading Helpers
 
     private func loadRecommendations(for template: CPListTemplate, browseSection: CPListSection) {
-        CarPlayContentManager.shared.fetchRecommendationFolders { [weak self] (folders: [AppMediaItem.RecommendationFolder]) in
+        recommendationsFetchGen += 1
+        let myGen = recommendationsFetchGen
+        os_log("CP: loadRecommendations gen=%{public}d", log: cpLog, type: .default, myGen)
+        CarPlayContentManager.shared.fetchRecommendationFolders { [weak self] (folders: [AppMediaItem.RecommendationFolder]?) in
             guard let self = self else { return }
+            // Drop completions from superseded calls so a slow first attempt
+            // can't overwrite a faster second attempt's results.
+            guard myGen == self.recommendationsFetchGen else {
+                os_log("CP: loadRecommendations gen=%{public}d superseded, dropping result",
+                       log: cpLog, type: .default, myGen)
+                return
+            }
+
+            // nil means the fetch timed out. Show a disconnected affordance —
+            // `handleReadinessChange` re-fires this method when readiness
+            // flips back to true.
+            guard let folders = folders else {
+                template.updateSections([
+                    browseSection,
+                    CPListSection(items: [self.disconnectedRow()], header: nil, sectionIndexTitle: nil),
+                ])
+                return
+            }
 
             if folders.isEmpty {
-                let emptyItem = CPListItem(text: "No recommendations", detailText: nil)
-                let emptySection = CPListSection(items: [emptyItem], header: nil, sectionIndexTitle: nil)
-                template.updateSections([browseSection, emptySection])
+                template.updateSections([
+                    browseSection,
+                    self.emptyStateSection(text: "No recommendations"),
+                ])
                 return
             }
 
@@ -167,9 +319,17 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
 
                 let row = CPListImageRowItem(text: folder.title, images: images)
                 row.listImageRowHandler = { [weak self] _, index, completion in
+                    guard let self = self else { completion(); return }
+                    // Recommendation rows retain "tap to play" for every type;
+                    // gate only on connectivity, not on item type.
+                    guard self.isReady else {
+                        self.showOfflineAlert()
+                        completion()
+                        return
+                    }
                     if index < displayItems.count {
                         CarPlayContentManager.shared.playItem(displayItems[index])
-                        self?.interfaceController?.pushTemplate(CPNowPlayingTemplate.shared, animated: true, completion: nil)
+                        self.interfaceController?.pushTemplate(CPNowPlayingTemplate.shared, animated: true, completion: nil)
                     }
                     completion()
                 }
@@ -195,9 +355,12 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     // MARK: - Navigation Helpers
 
     private func pushBrowseGrid() {
+        // Gate at entry. The grid template's category fetchers would otherwise
+        // spin indefinitely on a dead transport.
+        guard isReady else { showOfflineAlert(); return }
         let imageSize = CGSize(width: 100, height: 100)
         let manager = CarPlayContentManager.shared
-        let categories: [(title: String, fetcher: (@escaping ([CPListItem]) -> Void) -> Void)] = [
+        let categories: [(title: String, fetcher: (@escaping ([CPListItem]?) -> Void) -> Void)] = [
             ("Artists",    manager.fetchArtists),
             ("Albums",     manager.fetchAlbums),
             ("Tracks",     manager.fetchTracks),
@@ -216,9 +379,11 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
         self.interfaceController?.pushTemplate(gridTemplate, animated: true, completion: nil)
     }
 
+    /// Mirrors `pushDrilldown`'s shape but targets the simpler
+    /// "list of CPListItem" fetchers used for Browse → Category.
     private func pushCategoryTemplate(
         title: String,
-        fetcher: (@escaping ([CPListItem]) -> Void) -> Void
+        fetcher: (@escaping ([CPListItem]?) -> Void) -> Void
     ) {
         let template = CPListTemplate(title: title, sections: [])
         let loadingItem = CPListItem(text: "Loading...", detailText: nil)
@@ -227,8 +392,17 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
         self.interfaceController?.pushTemplate(template, animated: true, completion: nil)
 
         fetcher { [weak self] items in
-            self?.attachHandlers(to: items)
-            template.updateSections([CPListSection(items: items)])
+            guard let self = self else { return }
+            if let items = items {
+                if items.isEmpty {
+                    template.updateSections([emptyStateSection(text: "No \(title.lowercased())")])
+                } else {
+                    self.attachHandlers(to: items)
+                    template.updateSections([CPListSection(items: items)])
+                }
+            } else {
+                template.updateSections([CPListSection(items: [disconnectedRow()])])
+            }
         }
     }
 
@@ -243,12 +417,122 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
         }
     }
 
+    /// Type-aware dispatch: container items (Artist, Album, Playlist) drill
+    /// in to their contained items; leaf items (Track, RadioStation, Podcast,
+    /// Audiobook, PodcastEpisode) play and push Now Playing.
     private func handleItemSelection(_ item: CPSelectableListItem) {
-        if let cpListItem = item as? CPListItem,
-           let mediaItem = cpListItem.userInfo as? AppMediaItem {
+        // Drop offline taps with a visible alert.
+        guard isReady else { showOfflineAlert(); return }
+        guard
+            let cpListItem = item as? CPListItem,
+            let mediaItem = cpListItem.userInfo as? AppMediaItem
+        else { return }
+
+        if let artist = mediaItem as? AppMediaItem.Artist {
+            pushAlbumsForArtist(artist)
+        } else if let album = mediaItem as? AppMediaItem.Album {
+            pushTracksForAlbum(album)
+        } else if let playlist = mediaItem as? AppMediaItem.Playlist {
+            pushTracksForPlaylist(playlist)
+        } else {
+            // Track / RadioStation / Podcast / Audiobook / PodcastEpisode —
+            // leaf-level items play immediately.
             CarPlayContentManager.shared.playItem(mediaItem)
-            self.interfaceController?.pushTemplate(CPNowPlayingTemplate.shared, animated: true, completion: nil)
+            playAndShowNowPlaying()
         }
     }
-}
 
+    /// `popToRoot` first, then push Now Playing — CarPlay caps the template
+    /// stack at 5, and Browse → Category → Artist → Albums → Tracks already
+    /// fills it. A naive push from the leaf crashes with a hierarchy-depth
+    /// exception.
+    private func playAndShowNowPlaying() {
+        guard let interfaceController = interfaceController else { return }
+        os_log("CP: playAndShowNowPlaying — popToRoot then push NowPlaying",
+               log: cpLog, type: .default)
+        interfaceController.popToRootTemplate(animated: false) { [weak self] _, _ in
+            self?.interfaceController?.pushTemplate(
+                CPNowPlayingTemplate.shared,
+                animated: true,
+                completion: nil
+            )
+        }
+    }
+
+    // MARK: - Drilldown push helpers
+
+    private func pushAlbumsForArtist(_ artist: AppMediaItem.Artist) {
+        pushDrilldown(
+            title: "Albums by \(artist.title)",
+            emptyText: "No albums for \(artist.title)"
+        ) { completion in
+            CarPlayContentManager.shared.fetchAlbumsForArtist(artist, completion: completion)
+        }
+    }
+
+    private func pushTracksForAlbum(_ album: AppMediaItem.Album) {
+        pushDrilldown(
+            title: album.title,
+            emptyText: "No tracks in this album"
+        ) { completion in
+            CarPlayContentManager.shared.fetchTracksForAlbum(album, completion: completion)
+        }
+    }
+
+    private func pushTracksForPlaylist(_ playlist: AppMediaItem.Playlist) {
+        pushDrilldown(
+            title: playlist.title,
+            emptyText: "No tracks in this playlist"
+        ) { completion in
+            CarPlayContentManager.shared.fetchTracksForPlaylist(playlist, completion: completion)
+        }
+    }
+
+    /// Push a loading template, fire `fetcher`, swap rows in on result —
+    /// empty-state on `[]`, disconnected row on `nil` (timeout).
+    private func pushDrilldown(
+        title: String,
+        emptyText: String,
+        fetcher: @escaping (@escaping ([CPListItem]?) -> Void) -> Void
+    ) {
+        let template = CPListTemplate(title: title, sections: [])
+        let loadingItem = CPListItem(text: "Loading...", detailText: nil)
+        template.updateSections([CPListSection(items: [loadingItem])])
+        self.interfaceController?.pushTemplate(template, animated: true, completion: nil)
+
+        fetcher { [weak self] items in
+            guard let self = self else { return }
+            if let items = items {
+                if items.isEmpty {
+                    template.updateSections([emptyStateSection(text: emptyText)])
+                } else {
+                    self.attachHandlers(to: items)
+                    template.updateSections([CPListSection(items: items)])
+                }
+            } else {
+                template.updateSections([CPListSection(items: [disconnectedRow()])])
+            }
+        }
+    }
+
+    // MARK: - Shared affordance rows
+
+    /// Non-tappable row — server answered, no results.
+    private func emptyStateSection(text: String) -> CPListSection {
+        let item = CPListItem(text: text, detailText: nil)
+        item.handler = nil
+        return CPListSection(items: [item], header: nil, sectionIndexTitle: nil)
+    }
+
+    /// Non-tappable row — fetcher timed out. Library auto-recovers via the
+    /// readiness sub; drilldowns require the user to back out and re-enter.
+    private func disconnectedRow() -> CPListItem {
+        let item = CPListItem(
+            text: "Disconnected — reconnecting…",
+            detailText: nil,
+            image: UIImage(systemName: "wifi.exclamationmark")
+        )
+        item.handler = nil
+        return item
+    }
+}

--- a/iosApp/iosApp/CarPlay/SiriIntentHandler.swift
+++ b/iosApp/iosApp/CarPlay/SiriIntentHandler.swift
@@ -379,7 +379,8 @@ extension SiriIntentHandler: INPlayMediaIntentHandling {
         let preferredType = Self.preferredType(from: intent)
         os_log("PlayMedia.resolveMediaItems: searching MA for query=%{public}@ preferredType=%{public}d",
                log: log, type: .info, query, preferredType.rawValue)
-        KmpHelper.shared.search(query: query) { items in
+        KmpHelper.shared.search(query: query) { maybeItems in
+            let items = maybeItems ?? []
             os_log("PlayMedia.resolveMediaItems: search returned %d items",
                    log: log, type: .info, items.count)
             // Cache everything so handle() can find any MA item by id, but
@@ -448,7 +449,8 @@ extension SiriIntentHandler: INPlayMediaIntentHandling {
         let preferredType = Self.preferredType(from: intent)
         os_log("PlayMedia.handle: cache miss; re-searching for query=%{public}@ preferredType=%{public}d",
                log: log, type: .info, query, preferredType.rawValue)
-        KmpHelper.shared.search(query: query) { items in
+        KmpHelper.shared.search(query: query) { maybeItems in
+            let items = maybeItems ?? []
             // Prefer an exact identifier match (defensive — Siri *could*
             // round-trip our id from a prior `.success(with:)`); otherwise
             // type-aware best match.
@@ -520,7 +522,8 @@ extension SiriIntentHandler: INUpdateMediaAffinityIntentHandling {
         //   - PlayMedia is the cycle that loops. Each tap re-enters resolve
         //     against MA's catalog (Siri's identifiers don't match ours)
         //     and would re-disambig forever, hence its no-disambig policy.
-        KmpHelper.shared.search(query: query) { items in
+        KmpHelper.shared.search(query: query) { maybeItems in
+            let items = maybeItems ?? []
             let mediaItems = Self.resolveAndCache(items)
             if mediaItems.isEmpty {
                 completion([.unsupported()])
@@ -644,7 +647,8 @@ extension SiriIntentHandler: INUpdateMediaAffinityIntentHandling {
 
         os_log("Affinity.handle: searching MA for query=%{public}@ preferredType=%{public}d",
                log: log, type: .info, query, preferredType.rawValue)
-        KmpHelper.shared.search(query: query) { items in
+        KmpHelper.shared.search(query: query) { maybeItems in
+            let items = maybeItems ?? []
             let match: AppMediaItem? = {
                 if let id = target?.identifier,
                    let exact = items.first(where: { $0.itemId == id }) {
@@ -702,7 +706,8 @@ extension SiriIntentHandler: INSearchForMediaIntentHandling {
             return
         }
 
-        KmpHelper.shared.search(query: query) { items in
+        KmpHelper.shared.search(query: query) { maybeItems in
+            let items = maybeItems ?? []
             let mediaItems = Self.resolveAndCache(items)
             if mediaItems.isEmpty {
                 completion([INSearchForMediaMediaItemResolutionResult(


### PR DESCRIPTION
This is the PR with the actual CarPlay reliability fixes that I've been working on. Specifically, we had some forever-hangs that now get timeouts, we add a 'Disconnected' row to the UI if we _do_ get timeouts, and we can now drill down into the actual albums of an artist, etc.


- KmpHelper: nullable-on-timeout fetcher contract (5s withTimeoutOrNull), Cancellable + observeReadiness/observeLocalPlayerPresence subscriptions, drilldown fetchers (artist→albums, album→tracks, playlist→tracks).
- CarPlay scene: readiness-gated taps with idempotent offline alert, generation counter on the recommendations fetch, type-aware drilldown dispatch, popToRoot before pushing Now Playing to dodge the depth-5 hierarchy crash, one-shot initial Now Playing push on local-player presence.
- CarPlayContentManager: drilldown wrappers + mapItems threading.
- SiriIntentHandler: nil → empty coalesce on the four search call sites.
- Lifecycle markers via OSLog at .default for post-drive sysdiagnose.