### PR TITLE
fix(test): wait for track-name update in assertPlayer

### DIFF
--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
@@ -113,12 +113,19 @@ fun <T : ComposePage> T.assertPlayer(
         }
     }
 
+    // waitUntil — the track-name flow update can lag the play action.
     if (item != null) {
-        composeTestRule.onNodeWithContentDescription(Res.string.cd_playing.get().format(item))
-            .assertIsDisplayed()
+        composeTestRule.waitUntil {
+            composeTestRule
+                .onNodeWithContentDescription(Res.string.cd_playing.get().format(item))
+                .isDisplayed()
+        }
     } else {
-        composeTestRule.onNodeWithContentDescription(Res.string.players_nothing.get())
-            .assertIsDisplayed()
+        composeTestRule.waitUntil {
+            composeTestRule
+                .onNodeWithContentDescription(Res.string.players_nothing.get())
+                .isDisplayed()
+        }
     }
 
     return this


### PR DESCRIPTION
A couple tests added in #314 would only intermittently pass (almost always locally, very flaky in CI). This should fix that, if my robot sidekick is right (it worked well locally, but so did the first version).