### PR TITLE
fix(carplay,siri): route plays to local Sendspin only, detach group first

### DIFF
--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
@@ -279,28 +279,40 @@ object KmpHelper : KoinComponent {
 
     // MARK: - Playback
 
-    fun playMediaItem(item: AppMediaItem) {
-        // Use selected player from MainDataSource
-        val playerId = mainDataSource.selectedPlayerIndex.value?.let { index ->
-             (mainDataSource.playersData.value as? io.music_assistant.client.ui.compose.common.DataState.Data)?.data?.get(index)?.playerId
-        } ?: return
-
-        playItem(item, playerId, QueueOption.PLAY)
-    }
-
-    private fun playItem(item: AppMediaItem, queueOrPlayerId: String, option: QueueOption) {
-        item.mediaUri?.let { mediaUri ->
-            mainScope.launch {
+    /**
+     * Play [item] on the iOS local Sendspin player only — never the group
+     * it may be synced to. Detaches from any sync group first; MA promotes
+     * `play(queueOrPlayerId = childId)` to the group queue otherwise.
+     *
+     * Returns false on no-local-player or no-URI; callers use this to skip
+     * Siri donation and respond with `.failure`.
+     */
+    fun playOnLocalPlayer(item: AppMediaItem): Boolean {
+        val localPlayerData = mainDataSource.localPlayer.value ?: return false
+        val playerId = localPlayerData.player.id
+        val mediaUri = item.mediaUri ?: return false
+        val syncedToId = localPlayerData.player.syncedTo
+        mainScope.launch {
+            if (syncedToId != null) {
+                log.i { "playOnLocalPlayer: detaching $playerId from $syncedToId" }
                 serviceClient.sendRequest(
-                    Request.Library.play(
-                        media = listOf(mediaUri),
-                        queueOrPlayerId = queueOrPlayerId,
-                        option = option,
-                        radioMode = false,
+                    Request.Player.setGroupMembers(
+                        playerId = syncedToId,
+                        playersToAdd = null,
+                        playersToRemove = listOf(playerId),
                     ),
                 )
             }
+            serviceClient.sendRequest(
+                Request.Library.play(
+                    media = listOf(mediaUri),
+                    queueOrPlayerId = playerId,
+                    option = QueueOption.PLAY,
+                    radioMode = false,
+                ),
+            )
         }
+        return true
     }
 
     // MARK: - Library Actions (Siri)

--- a/iosApp/iosApp/CarPlay/CarPlayContentManager.swift
+++ b/iosApp/iosApp/CarPlay/CarPlayContentManager.swift
@@ -140,7 +140,7 @@ class CarPlayContentManager {
     // MARK: - Action Handling
 
     func playItem(_ item: AppMediaItem) {
-        KmpHelper.shared.playMediaItem(item: item)
+        guard KmpHelper.shared.playOnLocalPlayer(item: item) else { return }
         // Donate the play so Siri learns Music Assistant is a media destination.
         // Without donations, "Hey Siri, play X" never lists this app as a candidate.
         SiriIntentHandler.donatePlayed(item)

--- a/iosApp/iosApp/CarPlay/SiriIntentHandler.swift
+++ b/iosApp/iosApp/CarPlay/SiriIntentHandler.swift
@@ -429,10 +429,8 @@ extension SiriIntentHandler: INPlayMediaIntentHandling {
         // came from Siri's catalog (different identifier namespace).
         if let identifier = selected.identifier,
            let cached = Self.cached(forIdentifier: identifier) {
-            os_log("PlayMedia.handle: cache hit for id=%{public}@ — playing", log: log, type: .info, identifier)
-            KmpHelper.shared.playMediaItem(item: cached)
-            Self.donatePlayed(cached)
-            completion(INPlayMediaIntentResponse(code: .success, userActivity: nil))
+            os_log("PlayMedia.handle: cache hit for id=%{public}@", log: log, type: .info, identifier)
+            Self.dispatchPlay(cached, completion: completion)
             return
         }
 
@@ -467,11 +465,28 @@ extension SiriIntentHandler: INPlayMediaIntentHandling {
                 completion(INPlayMediaIntentResponse(code: .failure, userActivity: nil))
                 return
             }
-            os_log("PlayMedia.handle: playing match name=%{public}@ kind=%{public}@",
+            os_log("PlayMedia.handle: matched name=%{public}@ kind=%{public}@",
                    log: log, type: .info, match.title, String(describing: type(of: match)))
-            KmpHelper.shared.playMediaItem(item: match)
-            Self.donatePlayed(match)
+            Self.dispatchPlay(match, completion: completion)
+        }
+    }
+
+    /// Don't lie to Siri: complete `.failure` (not `.success`) when dispatch
+    /// fails, and skip donation so phantom plays don't pollute the model.
+    fileprivate static func dispatchPlay(
+        _ item: AppMediaItem,
+        completion: @escaping (INPlayMediaIntentResponse) -> Void
+    ) {
+        let dispatched = KmpHelper.shared.playOnLocalPlayer(item: item)
+        os_log("PlayMedia.dispatchPlay: name=%{public}@ dispatched=%{public}@",
+               log: log, type: .info,
+               item.title,
+               dispatched ? "true" : "false")
+        if dispatched {
+            donatePlayed(item)
             completion(INPlayMediaIntentResponse(code: .success, userActivity: nil))
+        } else {
+            completion(INPlayMediaIntentResponse(code: .failure, userActivity: nil))
         }
     }
 }

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>14</string>
 	<key>INIntentsSupported</key>
 	<array>
 		<string>INPlayMediaIntent</string>


### PR DESCRIPTION
Always use the local player for CarPlay, and ungroup the phone if it is currently grouped.