### PR TITLE
fix: Remove invalid sample phrase

### DIFF
--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>15</string>
 	<key>INIntentsSupported</key>
 	<array>
 		<string>INPlayMediaIntent</string>

--- a/iosApp/iosApp/en.lproj/AppIntentVocabulary.plist
+++ b/iosApp/iosApp/en.lproj/AppIntentVocabulary.plist
@@ -15,7 +15,6 @@
 				<string>Play my favorites in Music Assistant</string>
 				<string>In Music Assistant, play Alela Diane</string>
 				<string>In Music Assistant, play my workout playlist</string>
-				<string>Hey Siri, play radio in Music Assistant</string>
 			</array>
 		</dict>
 		<dict>


### PR DESCRIPTION
Apparently you cannot have Hey Siri in your example phrase, discovered upon uploading.