### PR TITLE
Move queue actions and DSP into overflow menu

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -145,6 +145,7 @@
     <string name="queue_no_items">No items</string>
     <string name="queue_not_loaded">Not loaded</string>
     <string name="queue_cannot_play">Cannot play this item</string>
+    <string name="queue_clear">Clear queue</string>
 
     <!-- Players -->
     <string name="players_title">Players</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -59,7 +59,6 @@
     <string name="cd_fully_played">Fully played</string>
     <string name="cd_in_progress">In progress</string>
     <string name="cd_provider_icon">Provider Icon</string>
-    <string name="cd_dsp_settings">DSP Settings</string>
     <string name="cd_playing">Playing %1$s</string>
     <string name="cd_current_player">Current player: %1$s</string>
 
@@ -152,6 +151,7 @@
     <string name="players_group_settings">Group settings</string>
     <string name="players_group_volume">%1$s group volume</string>
     <string name="players_nothing">Nothing playing</string>
+    <string name="players_dsp_settings">DSP settings</string>
 
     <!-- DSP -->
     <string name="dsp_title">DSP settings</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -36,7 +36,6 @@
     <string name="common_delete">Delete</string>
     <string name="common_create">Create</string>
     <string name="common_done">Done</string>
-    <string name="common_transfer">Transfer</string>
 
     <!-- Content descriptions -->
     <string name="cd_play_now">Play now</string>
@@ -146,6 +145,7 @@
     <string name="queue_not_loaded">Not loaded</string>
     <string name="queue_cannot_play">Cannot play this item</string>
     <string name="queue_clear">Clear queue</string>
+    <string name="queue_transfer">Transfer queue</string>
 
     <!-- Players -->
     <string name="players_title">Players</string>

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/PlayerDataFixtures.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/PlayerDataFixtures.kt
@@ -13,13 +13,14 @@ object PlayerDataFixtures {
         queueId: String = "queue${uniqueIdGenerator.nextInt()}",
         name: String = "Player ${uniqueIdGenerator.nextInt()}",
         groupChildren: List<ChildBind> = emptyList(),
+        playerType: PlayerType = PlayerType.PLAYER,
     ): PlayerData {
         return PlayerData(
             player = Player(
                 id = "player${uniqueIdGenerator.nextInt()}",
                 name = name,
                 provider = "provider",
-                type = PlayerType.PLAYER,
+                type = playerType,
                 shouldBeShown = true,
                 canSetVolume = true,
                 volumeLevel = 50f,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/OverflowMenu.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/OverflowMenu.kt
@@ -42,33 +42,42 @@ fun OverflowMenu(expanded: Boolean, onClose: () -> Unit = {}, options: List<Over
         expanded = expanded,
         onDismissRequest = { onClose() },
     ) {
-        options.forEach { it.toDropdownMenuItem(onClose) }
+        options.forEach { it.DropdownMenuItem(onClose) }
     }
 }
 
 data class OverflowMenuOption(
     val title: String,
     val icon: ImageVector? = null,
+    val trailingIcon: ImageVector? = null,
     val onClick: () -> Unit,
 )
 
 @Composable
-fun OverflowMenuOption.toDropdownMenuItem(onClose: () -> Unit) {
-    return DropdownMenuItem(
+private fun OverflowMenuOption.DropdownMenuItem(onClose: () -> Unit) {
+    DropdownMenuItem(
         onClick = {
-            this.onClick()
+            onClick()
             onClose()
         },
-        leadingIcon = this.icon?.let {
+        leadingIcon = icon?.let {
             {
                 Icon(
                     imageVector = it,
-                    contentDescription = this.title,
+                    contentDescription = title,
+                )
+            }
+        },
+        trailingIcon = trailingIcon?.let {
+            {
+                Icon(
+                    imageVector = it,
+                    contentDescription = null,
                 )
             }
         },
         text = {
-            Text(modifier = Modifier.padding(all = 4.dp), text = this.title)
+            Text(modifier = Modifier.padding(all = 4.dp), text = title)
         },
     )
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/OverflowMenu.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/OverflowMenu.kt
@@ -42,25 +42,7 @@ fun OverflowMenu(expanded: Boolean, onClose: () -> Unit = {}, options: List<Over
         expanded = expanded,
         onDismissRequest = { onClose() },
     ) {
-        options.forEach { option ->
-            DropdownMenuItem(
-                onClick = {
-                    option.onClick()
-                    onClose()
-                },
-                leadingIcon = option.icon?.let {
-                    {
-                        Icon(
-                            imageVector = it,
-                            contentDescription = option.title,
-                        )
-                    }
-                },
-                text = {
-                    Text(modifier = Modifier.padding(all = 4.dp), text = option.title)
-                },
-            )
-        }
+        options.forEach { it.toDropdownMenuItem(onClose) }
     }
 }
 
@@ -69,3 +51,24 @@ data class OverflowMenuOption(
     val icon: ImageVector? = null,
     val onClick: () -> Unit,
 )
+
+@Composable
+fun OverflowMenuOption.toDropdownMenuItem(onClose: () -> Unit) {
+    return DropdownMenuItem(
+        onClick = {
+            this.onClick()
+            onClose()
+        },
+        leadingIcon = this.icon?.let {
+            {
+                Icon(
+                    imageVector = it,
+                    contentDescription = this.title,
+                )
+            }
+        },
+        text = {
+            Text(modifier = Modifier.padding(all = 4.dp), text = this.title)
+        },
+    )
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/CollapsibleQueue.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/CollapsibleQueue.kt
@@ -24,8 +24,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
-import androidx.compose.material.icons.filled.Smartphone
-import androidx.compose.material.icons.filled.Speaker
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenu
@@ -53,21 +51,16 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import compose.icons.TablerIcons
 import compose.icons.tablericons.GripVertical
-import io.music_assistant.client.data.model.client.PlayerData
 import io.music_assistant.client.data.model.client.Queue
 import io.music_assistant.client.ui.compose.common.DataState
-import io.music_assistant.client.ui.compose.common.OverflowMenuButton
-import io.music_assistant.client.ui.compose.common.OverflowMenuOption
 import io.music_assistant.client.ui.compose.common.action.QueueAction
 import io.music_assistant.client.ui.compose.common.icons.PlayIcon
-import io.music_assistant.client.ui.compose.common.icons.SpeakerMultipleIcon
 import io.music_assistant.client.ui.compose.common.icons.TrackIcon
 import io.music_assistant.client.ui.compose.common.painters.rememberPlaceholderPainter
 import io.music_assistant.client.utils.conditional
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.cd_toggle_queue
 import musicassistantclient.composeapp.generated.resources.common_delete
-import musicassistantclient.composeapp.generated.resources.common_transfer
 import musicassistantclient.composeapp.generated.resources.queue_browse_library
 import musicassistantclient.composeapp.generated.resources.queue_cannot_play
 import musicassistantclient.composeapp.generated.resources.queue_empty
@@ -76,7 +69,6 @@ import musicassistantclient.composeapp.generated.resources.queue_label
 import musicassistantclient.composeapp.generated.resources.queue_label_with_position
 import musicassistantclient.composeapp.generated.resources.queue_loading
 import musicassistantclient.composeapp.generated.resources.queue_no_items
-import musicassistantclient.composeapp.generated.resources.queue_no_other_players
 import musicassistantclient.composeapp.generated.resources.queue_not_loaded
 import org.jetbrains.compose.resources.stringResource
 import sh.calvin.reorderable.ReorderableItem
@@ -93,8 +85,6 @@ fun CollapsibleQueue(
     serverUrl: String?,
     queueAction: (QueueAction) -> Unit,
     tint: Color,
-    players: List<PlayerData> = emptyList(),
-    onPlayerSelected: ((String) -> Unit)? = null,
     isCurrentPage: Boolean = true,
     contentPadding: PaddingValues,
 ) {
@@ -145,52 +135,6 @@ fun CollapsibleQueue(
                 imageVector = if (isQueueExpanded) Icons.Default.ExpandMore else Icons.Default.ExpandLess,
                 contentDescription = stringResource(Res.string.cd_toggle_queue),
             )
-        }
-        val hasItems = items?.isNotEmpty() == true
-        val queueId = queueData?.data?.info?.id
-
-        if (isQueueExpanded && hasItems && queueId != null) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                // Transfer button
-                OverflowMenuButton(
-                    options = players.filter { p -> p.player.id != queueId }.map { playerData ->
-                        OverflowMenuOption(
-                            title = playerData.player.nameAndSuffix,
-                            icon = when {
-                                playerData.isLocal -> Icons.Default.Smartphone
-                                playerData.player.isGroup -> SpeakerMultipleIcon
-                                else -> Icons.Default.Speaker
-                            },
-                            onClick = {
-                                queueAction(
-                                    QueueAction.Transfer(
-                                        queueId,
-                                        playerData.player.id,
-                                        playerData.player.isPlaying,
-                                    ),
-                                )
-                                onPlayerSelected?.invoke(playerData.player.id)
-                            },
-                        )
-                    }.ifEmpty {
-                        listOf(
-                            OverflowMenuOption(
-                                title = stringResource(Res.string.queue_no_other_players),
-                                onClick = { /* No-op */ },
-                            ),
-                        )
-                    },
-                    buttonContent = {
-                        OutlinedButton(onClick = it) {
-                            Text(stringResource(Res.string.common_transfer))
-                        }
-                    },
-                )
-            }
         }
 
         if (isQueueExpanded) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/CollapsibleQueue.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/CollapsibleQueue.kt
@@ -66,7 +66,6 @@ import io.music_assistant.client.ui.compose.common.painters.rememberPlaceholderP
 import io.music_assistant.client.utils.conditional
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.cd_toggle_queue
-import musicassistantclient.composeapp.generated.resources.common_clear
 import musicassistantclient.composeapp.generated.resources.common_delete
 import musicassistantclient.composeapp.generated.resources.common_transfer
 import musicassistantclient.composeapp.generated.resources.queue_browse_library
@@ -191,13 +190,6 @@ fun CollapsibleQueue(
                         }
                     },
                 )
-
-                // Clear button
-                OutlinedButton(
-                    onClick = { queueAction(QueueAction.ClearQueue(queueId)) },
-                ) {
-                    Text(stringResource(Res.string.common_clear))
-                }
             }
         }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerControls.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerControls.kt
@@ -56,7 +56,7 @@ fun PlayerControls(
     Row(
         modifier = modifier
             .wrapContentSize(),
-        horizontalArrangement = Arrangement.Center,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (showAdditionalButtons) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerControls.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerControls.kt
@@ -79,7 +79,7 @@ fun PlayerControls(
             }
         }
 
-        if (showSkip) {
+        if (showAdditionalButtons) {
             ActionButton(
                 icon = SkipBackIcon,
                 tint = tint,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
@@ -212,12 +212,11 @@ fun FullPlayerItem(
     val controlTint = colors.controlTint
 
     Column(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth().padding(horizontal = 16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         Text(
-            modifier = Modifier.padding(horizontal = 16.dp),
             text = item.player.providerType.takeIf { !isLocal } ?: "",
             fontSize = 12.sp,
         )
@@ -226,7 +225,6 @@ fun FullPlayerItem(
                 .weight(1f, fill = false)
                 .aspectRatio(1f)
                 .heightIn(max = 500.dp)
-                .padding(16.dp)
                 .clip(RoundedCornerShape(16.dp))
                 .background(colors.dominant.alphaOn(track != null)),
             contentAlignment = Alignment.Center,
@@ -283,7 +281,6 @@ fun FullPlayerItem(
             )
             if (item.queueInfo?.currentItem?.isPlayable == false) {
                 Text(
-                    modifier = Modifier.padding(horizontal = 16.dp),
                     text = "Cannot play this item",
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant.inactive(),
@@ -292,7 +289,6 @@ fun FullPlayerItem(
                 )
             } else {
                 Text(
-                    modifier = Modifier.padding(horizontal = 16.dp),
                     text = track?.subtitle ?: "",
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -327,7 +323,7 @@ fun FullPlayerItem(
             inactiveTrackColor = controlTint.inactive(),
         )
         Column(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+            modifier = Modifier.fillMaxWidth(),
         ) { // Progress bar
             Slider(
                 value = sliderPosition,
@@ -385,27 +381,27 @@ fun FullPlayerItem(
                     }
                 },
             )
+        }
 
-            // Duration labels
-            Row(
-                modifier = Modifier.fillMaxWidth().offset(y = (-16).dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
-                Text(
-                    text = sliderPosition.takeIf { track != null }
-                        .formatDuration(DurationUnit.SECONDS)
-                        .takeIf { duration != null } ?: "",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Text(
-                    text = track
-                        ?.let { duration?.formatDuration(DurationUnit.SECONDS) ?: "\u221E" }
-                        ?: "",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
+        // Duration labels
+        Row(
+            modifier = Modifier.fillMaxWidth().offset(y = (-16).dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = sliderPosition.takeIf { track != null }
+                    .formatDuration(DurationUnit.SECONDS)
+                    .takeIf { duration != null } ?: "",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = track
+                    ?.let { duration?.formatDuration(DurationUnit.SECONDS) ?: "\u221E" }
+                    ?: "",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
 
         PlayerControls(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
@@ -173,7 +173,7 @@ fun CompactPlayerItem(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.End,
             ) {
-                PlayerSelectionLayout(
+                PlayerSelectionButton(
                     player = item,
                     sendSpinState = sendSpinState,
                     onSelectPlayer = onSelectPlayer,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerSelectionButton.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerSelectionButton.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.filled.Speaker
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SplitButtonDefaults.LeadingButton
 import androidx.compose.material3.SplitButtonDefaults.TrailingButton
 import androidx.compose.material3.SplitButtonLayout
@@ -27,8 +28,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.music_assistant.client.data.model.client.PlayerData
+import io.music_assistant.client.data.model.client.PlayerDataFixtures
+import io.music_assistant.client.data.model.server.PlayerType
 import io.music_assistant.client.player.sendspin.SendspinState
 import io.music_assistant.client.ui.compose.common.icons.SpeakerMultipleIcon
 import musicassistantclient.composeapp.generated.resources.Res
@@ -132,4 +136,68 @@ private fun SendspinState.toDotColor(): Color = when (this) {
         -> Color(0xFFFF9800) // Orange
     is SendspinState.Error -> Color(0xFFF44336) // Red
     is SendspinState.Idle -> Color(0xFFBDBDBD) // Light gray
+}
+
+@Preview
+@Composable
+private fun PlayerSelectionButtonNotGroupablePreview() {
+    MaterialTheme {
+        PlayerSelectionButton(
+            player = PlayerDataFixtures.playerData(name = "Living Room Speaker"),
+            sendSpinState = null,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PlayerSelectionButtonLocalPlayerPreview() {
+    MaterialTheme {
+        PlayerSelectionButton(
+            player = PlayerDataFixtures.playerData(name = "Local Player").copy(isLocal = true),
+            sendSpinState = SendspinState.Synchronized,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PlayerSelectionButtonPreview() {
+    MaterialTheme {
+        PlayerSelectionButton(
+            player = PlayerDataFixtures.playerData(
+                name = "Group Player",
+                groupChildren = listOf(PlayerDataFixtures.bind().copy(isBound = false)),
+            ),
+            sendSpinState = null,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PlayerSelectionButtonInGroupPreview() {
+    MaterialTheme {
+        PlayerSelectionButton(
+            player = PlayerDataFixtures.playerData(
+                name = "Group Player",
+                groupChildren = listOf(PlayerDataFixtures.bind().copy(isBound = true)),
+            ),
+            sendSpinState = null,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PlayerSelectionButtonIsGroupPreview() {
+    MaterialTheme {
+        PlayerSelectionButton(
+            player = PlayerDataFixtures.playerData(
+                name = "Group Player",
+                playerType = PlayerType.GROUP,
+            ),
+            sendSpinState = null,
+        )
+    }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerSelectionButton.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerSelectionButton.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.SplitButtonDefaults.LeadingButton
 import androidx.compose.material3.SplitButtonDefaults.TrailingButton
 import androidx.compose.material3.SplitButtonLayout
@@ -55,76 +56,93 @@ fun PlayerSelectionButton(
     val currentPlayerContentDescription =
         stringResource(Res.string.cd_current_player, player.player.name)
 
-    SplitButtonLayout(
-        modifier = Modifier.clearAndSetSemantics {
-            contentDescription = currentPlayerContentDescription
-        },
-        leadingButton = {
-            LeadingButton(
-                onClick = onSelectPlayer,
-                colors = ButtonDefaults.outlinedButtonColors(),
-                border = ButtonDefaults.outlinedButtonBorder(),
-            ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+    if (hasGroupChildren) {
+        SplitButtonLayout(
+            modifier = Modifier.clearAndSetSemantics {
+                contentDescription = currentPlayerContentDescription
+            },
+            leadingButton = {
+                LeadingButton(
+                    onClick = onSelectPlayer,
+                    colors = ButtonDefaults.outlinedButtonColors(),
+                    border = ButtonDefaults.outlinedButtonBorder(),
                 ) {
-                    Icon(
-                        imageVector = when {
-                            isLocalPlayer -> Icons.Default.Smartphone
-                            player.player.isGroup -> SpeakerMultipleIcon
-                            else -> Icons.Default.Speaker
-                        },
-                        contentDescription = null,
-                        modifier = Modifier.size(16.dp),
-                    )
-                    dotColor?.let {
-                        Box(
-                            modifier = Modifier
-                                .size(8.dp)
-                                .background(it, CircleShape),
+                    PlayerButtonContent(isLocalPlayer, player, dotColor)
+                }
+            },
+            trailingButton = {
+                if (hasGroupChildren) {
+                    val (colors, border) = if (hasBoundChildren) {
+                        Pair(ButtonDefaults.buttonColors(), null)
+                    } else {
+                        Pair(
+                            ButtonDefaults.outlinedButtonColors(),
+                            ButtonDefaults.outlinedButtonBorder(),
                         )
                     }
 
-                    val boundCount = player.childrenBinds.count { it.isBound }
-                    val playerLabel = when {
-                        player.player.isGroup -> "${player.player.name} (${player.player.groupMembers?.size ?: 0})"
-                        boundCount > 0 -> "${player.player.name} + $boundCount"
-                        else -> player.player.name
+                    TrailingButton(
+                        onClick = onGroupButton,
+                        colors = colors,
+                        border = border,
+                    ) {
+                        Icon(
+                            Icons.Default.Link,
+                            contentDescription = null,
+                        )
                     }
+                }
+            },
+        )
+    } else {
+        OutlinedButton(
+            onClick = onSelectPlayer,
+        ) {
+            PlayerButtonContent(isLocalPlayer = isLocalPlayer, player = player, dotColor = dotColor)
+        }
+    }
+}
 
-                    Text(
-                        text = playerLabel,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-            }
-        },
-        trailingButton = {
-            if (hasGroupChildren) {
-                val (colors, border) = if (hasBoundChildren) {
-                    Pair(ButtonDefaults.buttonColors(), null)
-                } else {
-                    Pair(
-                        ButtonDefaults.outlinedButtonColors(),
-                        ButtonDefaults.outlinedButtonBorder(),
-                    )
-                }
+@Composable
+private fun PlayerButtonContent(
+    isLocalPlayer: Boolean,
+    player: PlayerData,
+    dotColor: Color?,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Icon(
+            imageVector = when {
+                isLocalPlayer -> Icons.Default.Smartphone
+                player.player.isGroup -> SpeakerMultipleIcon
+                else -> Icons.Default.Speaker
+            },
+            contentDescription = null,
+            modifier = Modifier.size(16.dp),
+        )
+        dotColor?.let {
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .background(it, CircleShape),
+            )
+        }
 
-                TrailingButton(
-                    onClick = onGroupButton,
-                    colors = colors,
-                    border = border,
-                ) {
-                    Icon(
-                        Icons.Default.Link,
-                        contentDescription = null,
-                    )
-                }
-            }
-        },
-    )
+        val boundCount = player.childrenBinds.count { it.isBound }
+        val playerLabel = when {
+            player.player.isGroup -> "${player.player.name} (${player.player.groupMembers?.size ?: 0})"
+            boundCount > 0 -> "${player.player.name} + $boundCount"
+            else -> player.player.name
+        }
+
+        Text(
+            text = playerLabel,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
 }
 
 private fun SendspinState.toDotColor(): Color = when (this) {
@@ -143,7 +161,7 @@ private fun SendspinState.toDotColor(): Color = when (this) {
 private fun PlayerSelectionButtonNotGroupablePreview() {
     MaterialTheme {
         PlayerSelectionButton(
-            player = PlayerDataFixtures.playerData(name = "Living Room Speaker"),
+            player = PlayerDataFixtures.playerData(),
             sendSpinState = null,
         )
     }
@@ -154,7 +172,7 @@ private fun PlayerSelectionButtonNotGroupablePreview() {
 private fun PlayerSelectionButtonLocalPlayerPreview() {
     MaterialTheme {
         PlayerSelectionButton(
-            player = PlayerDataFixtures.playerData(name = "Local Player").copy(isLocal = true),
+            player = PlayerDataFixtures.playerData().copy(isLocal = true),
             sendSpinState = SendspinState.Synchronized,
         )
     }
@@ -166,7 +184,6 @@ private fun PlayerSelectionButtonPreview() {
     MaterialTheme {
         PlayerSelectionButton(
             player = PlayerDataFixtures.playerData(
-                name = "Group Player",
                 groupChildren = listOf(PlayerDataFixtures.bind().copy(isBound = false)),
             ),
             sendSpinState = null,
@@ -180,7 +197,6 @@ private fun PlayerSelectionButtonInGroupPreview() {
     MaterialTheme {
         PlayerSelectionButton(
             player = PlayerDataFixtures.playerData(
-                name = "Group Player",
                 groupChildren = listOf(PlayerDataFixtures.bind().copy(isBound = true)),
             ),
             sendSpinState = null,
@@ -193,10 +209,7 @@ private fun PlayerSelectionButtonInGroupPreview() {
 private fun PlayerSelectionButtonIsGroupPreview() {
     MaterialTheme {
         PlayerSelectionButton(
-            player = PlayerDataFixtures.playerData(
-                name = "Group Player",
-                playerType = PlayerType.GROUP,
-            ),
+            player = PlayerDataFixtures.playerData(playerType = PlayerType.GROUP),
             sendSpinState = null,
         )
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerSelectionButton.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerSelectionButton.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.Smartphone
 import androidx.compose.material.icons.filled.Speaker
 import androidx.compose.material3.ButtonDefaults
@@ -56,7 +57,6 @@ fun PlayerSelectionButton(
         },
         leadingButton = {
             LeadingButton(
-                enabled = true,
                 onClick = onSelectPlayer,
                 colors = ButtonDefaults.outlinedButtonColors(),
                 border = ButtonDefaults.outlinedButtonBorder(),
@@ -81,8 +81,16 @@ fun PlayerSelectionButton(
                                 .background(it, CircleShape),
                         )
                     }
+
+                    val boundCount = player.childrenBinds.count { it.isBound }
+                    val playerLabel = when {
+                        player.player.isGroup -> "${player.player.name} (${player.player.groupMembers?.size ?: 0})"
+                        boundCount > 0 -> "${player.player.name} + $boundCount"
+                        else -> player.player.name
+                    }
+
                     Text(
-                        text = player.player.name,
+                        text = playerLabel,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
@@ -91,13 +99,6 @@ fun PlayerSelectionButton(
         },
         trailingButton = {
             if (hasGroupChildren) {
-                val boundCount = player.childrenBinds.count { it.isBound }
-                val groupLabel = when {
-                    player.player.isGroup -> "${player.player.groupMembers?.size ?: 0}"
-                    boundCount > 0 -> "+$boundCount"
-                    else -> "+"
-                }
-
                 val (colors, border) = if (hasBoundChildren) {
                     Pair(ButtonDefaults.buttonColors(), null)
                 } else {
@@ -108,12 +109,14 @@ fun PlayerSelectionButton(
                 }
 
                 TrailingButton(
-                    modifier = Modifier,
                     onClick = onGroupButton,
                     colors = colors,
                     border = border,
                 ) {
-                    Text(text = groupLabel)
+                    Icon(
+                        Icons.Default.Link,
+                        contentDescription = null,
+                    )
                 }
             }
         },

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerSelectionButton.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerSelectionButton.kt
@@ -55,12 +55,13 @@ fun PlayerSelectionButton(
 
     val currentPlayerContentDescription =
         stringResource(Res.string.cd_current_player, player.player.name)
+    val modifier = Modifier.clearAndSetSemantics {
+        contentDescription = currentPlayerContentDescription
+    }
 
     if (hasGroupChildren) {
         SplitButtonLayout(
-            modifier = Modifier.clearAndSetSemantics {
-                contentDescription = currentPlayerContentDescription
-            },
+            modifier = modifier,
             leadingButton = {
                 LeadingButton(
                     onClick = onSelectPlayer,
@@ -96,6 +97,7 @@ fun PlayerSelectionButton(
         )
     } else {
         OutlinedButton(
+            modifier = modifier,
             onClick = onSelectPlayer,
         ) {
             PlayerButtonContent(isLocalPlayer = isLocalPlayer, player = player, dotColor = dotColor)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerSelectionLayout.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerSelectionLayout.kt
@@ -4,45 +4,39 @@
 package io.music_assistant.client.ui.compose.home.players
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Smartphone
 import androidx.compose.material.icons.filled.Speaker
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.SplitButtonDefaults.LeadingButton
+import androidx.compose.material3.SplitButtonDefaults.TrailingButton
+import androidx.compose.material3.SplitButtonLayout
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import io.music_assistant.client.data.model.client.PlayerData
 import io.music_assistant.client.player.sendspin.SendspinState
 import io.music_assistant.client.ui.compose.common.icons.SpeakerMultipleIcon
-import io.music_assistant.client.ui.inactive
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.cd_current_player
 import org.jetbrains.compose.resources.stringResource
 
-private val GROUP_BUTTON_SIZE = 36.dp
-
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-fun PlayerSelectionLayout(
+fun PlayerSelectionButton(
     player: PlayerData,
     sendSpinState: SendspinState?,
     onSelectPlayer: () -> Unit = {},
@@ -55,90 +49,75 @@ fun PlayerSelectionLayout(
 
     val currentPlayerContentDescription =
         stringResource(Res.string.cd_current_player, player.player.name)
-    Row(
+
+    SplitButtonLayout(
         modifier = Modifier.clearAndSetSemantics {
             contentDescription = currentPlayerContentDescription
         },
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
-        if (hasGroupChildren) {
-            Spacer(modifier = Modifier.size(GROUP_BUTTON_SIZE))
-        }
-
-        OutlinedButton(
-            enabled = true,
-            shape = RoundedCornerShape(GROUP_BUTTON_SIZE / 3),
-            onClick = onSelectPlayer,
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
+        leadingButton = {
+            LeadingButton(
+                enabled = true,
+                onClick = onSelectPlayer,
+                colors = ButtonDefaults.outlinedButtonColors(),
+                border = ButtonDefaults.outlinedButtonBorder(),
             ) {
-                Icon(
-                    imageVector = when {
-                        isLocalPlayer -> Icons.Default.Smartphone
-                        player.player.isGroup -> SpeakerMultipleIcon
-                        else -> Icons.Default.Speaker
-                    },
-                    contentDescription = null,
-                    modifier = Modifier.size(16.dp),
-                )
-                dotColor?.let {
-                    Box(
-                        modifier = Modifier
-                            .size(8.dp)
-                            .background(it, CircleShape),
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Icon(
+                        imageVector = when {
+                            isLocalPlayer -> Icons.Default.Smartphone
+                            player.player.isGroup -> SpeakerMultipleIcon
+                            else -> Icons.Default.Speaker
+                        },
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                    )
+                    dotColor?.let {
+                        Box(
+                            modifier = Modifier
+                                .size(8.dp)
+                                .background(it, CircleShape),
+                        )
+                    }
+                    Text(
+                        text = player.player.name,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
                     )
                 }
-                Text(
-                    text = player.player.name,
-                    style = MaterialTheme.typography.bodyMedium,
-                    textAlign = TextAlign.Center,
-                    fontWeight = FontWeight.Medium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
             }
-        }
+        },
+        trailingButton = {
+            if (hasGroupChildren) {
+                val boundCount = player.childrenBinds.count { it.isBound }
+                val groupLabel = when {
+                    player.player.isGroup -> "${player.player.groupMembers?.size ?: 0}"
+                    boundCount > 0 -> "+$boundCount"
+                    else -> "+"
+                }
 
-        if (hasGroupChildren) {
-            val boundCount = player.childrenBinds.count { it.isBound }
-            val groupLabel = when {
-                player.player.isGroup -> "${player.player.groupMembers?.size ?: 0}"
-                boundCount > 0 -> "+$boundCount"
-                else -> "+"
-            }
-
-            Box(
-                modifier = Modifier
-                    .size(GROUP_BUTTON_SIZE)
-                    .clip(RoundedCornerShape(GROUP_BUTTON_SIZE / 3))
-                    .background(
-                        if (hasBoundChildren) {
-                            MaterialTheme.colorScheme.primary
-                        } else {
-                            MaterialTheme.colorScheme.primary.copy(alpha = 0.15f)
-                        },
+                val (colors, border) = if (hasBoundChildren) {
+                    Pair(ButtonDefaults.buttonColors(), null)
+                } else {
+                    Pair(
+                        ButtonDefaults.outlinedButtonColors(),
+                        ButtonDefaults.outlinedButtonBorder(),
                     )
-                    .clickable(onClick = onGroupButton),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    text = groupLabel,
-                    style = MaterialTheme.typography.labelMedium,
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.Bold,
-                    color = if (hasBoundChildren) {
-                        MaterialTheme.colorScheme.onPrimary
-                    } else {
-                        MaterialTheme.colorScheme.onSurface.inactive()
-                    },
-                )
+                }
+
+                TrailingButton(
+                    modifier = Modifier,
+                    onClick = onGroupButton,
+                    colors = colors,
+                    border = border,
+                ) {
+                    Text(text = groupLabel)
+                }
             }
-        }
-    }
+        },
+    )
 }
 
 private fun SendspinState.toDotColor(): Color = when (this) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerSelectionLayout.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerSelectionLayout.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Smartphone
 import androidx.compose.material.icons.filled.Speaker
-import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -38,7 +37,6 @@ import io.music_assistant.client.ui.compose.common.icons.SpeakerMultipleIcon
 import io.music_assistant.client.ui.inactive
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.cd_current_player
-import musicassistantclient.composeapp.generated.resources.cd_dsp_settings
 import org.jetbrains.compose.resources.stringResource
 
 private val GROUP_BUTTON_SIZE = 36.dp
@@ -49,7 +47,6 @@ fun PlayerSelectionLayout(
     sendSpinState: SendspinState?,
     onSelectPlayer: () -> Unit = {},
     onGroupButton: () -> Unit = {},
-    onDspButton: (() -> Unit)? = null,
 ) {
     val isLocalPlayer = player.isLocal
     val dotColor = (if (isLocalPlayer) sendSpinState else null)?.toDotColor()
@@ -65,24 +62,7 @@ fun PlayerSelectionLayout(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
-        // Left slot: DSP button or invisible counterweight for centering
-        if (onDspButton != null) {
-            Box(
-                modifier = Modifier
-                    .size(GROUP_BUTTON_SIZE)
-                    .clip(RoundedCornerShape(GROUP_BUTTON_SIZE / 3))
-                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.15f))
-                    .clickable(onClick = onDspButton),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Tune,
-                    contentDescription = stringResource(Res.string.cd_dsp_settings),
-                    modifier = Modifier.size(18.dp),
-                    tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                )
-            }
-        } else if (hasGroupChildren) {
+        if (hasGroupChildren) {
             Spacer(modifier = Modifier.size(GROUP_BUTTON_SIZE))
         }
 
@@ -123,7 +103,6 @@ fun PlayerSelectionLayout(
             }
         }
 
-        // Right slot: group button or invisible counterweight for centering
         if (hasGroupChildren) {
             val boundCount = player.childrenBinds.count { it.isBound }
             val groupLabel = when {
@@ -158,8 +137,6 @@ fun PlayerSelectionLayout(
                     },
                 )
             }
-        } else if (onDspButton != null) {
-            Spacer(modifier = Modifier.size(GROUP_BUTTON_SIZE))
         }
     }
 }
@@ -167,10 +144,10 @@ fun PlayerSelectionLayout(
 private fun SendspinState.toDotColor(): Color = when (this) {
     is SendspinState.Synchronized, is SendspinState.Ready,
     is SendspinState.Buffering,
-    -> Color(0xFF4CAF50) // Green
+        -> Color(0xFF4CAF50) // Green
     is SendspinState.Connecting, is SendspinState.Authenticating,
     is SendspinState.Handshaking, is SendspinState.Reconnecting,
-    -> Color(0xFFFF9800) // Orange
+        -> Color(0xFFFF9800) // Orange
     is SendspinState.Error -> Color(0xFFF44336) // Red
     is SendspinState.Idle -> Color(0xFFBDBDBD) // Light gray
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DeleteSweep
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -65,6 +66,7 @@ import io.music_assistant.client.ui.alphaOn
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.ExtractedColorsFetcher
 import io.music_assistant.client.ui.compose.common.OverflowMenuButton
+import io.music_assistant.client.ui.compose.common.OverflowMenuOption
 import io.music_assistant.client.ui.compose.common.PlayerColors
 import io.music_assistant.client.ui.compose.common.action.PlayerAction
 import io.music_assistant.client.ui.compose.common.action.QueueAction
@@ -81,6 +83,7 @@ import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.cd_more
 import musicassistantclient.composeapp.generated.resources.cd_mute
 import musicassistantclient.composeapp.generated.resources.cd_unmute
+import musicassistantclient.composeapp.generated.resources.queue_clear
 import org.jetbrains.compose.resources.stringResource
 import kotlin.math.roundToInt
 
@@ -316,25 +319,7 @@ private fun ExpandedPlayerPage(
                 )
             }
 
-            val navigationOptions =
-                (player.queueInfo?.currentItem?.track as? AppMediaItem)?.navigationOptions {
-                    onClose()
-                    navigateToItem(it)
-                }
-
-            if (navigationOptions != null) {
-                OverflowMenuButton(
-                    modifier = Modifier,
-                    options = navigationOptions,
-                ) { onClick ->
-                    IconButton(onClick = onClick) {
-                        Icon(
-                            imageVector = Icons.Default.MoreVert,
-                            contentDescription = stringResource(Res.string.cd_more),
-                        )
-                    }
-                }
-            }
+            PlayerOptionsMenu(player, queueAction, onClose, navigateToItem)
         }
 
         AnimatedVisibility(
@@ -507,6 +492,50 @@ private fun ExpandedPlayerPage(
             isCurrentPage = isCurrentPage,
             contentPadding = contentPadding,
         )
+    }
+}
+
+@Composable
+private fun PlayerOptionsMenu(
+    player: PlayerData,
+    queueAction: (QueueAction) -> Unit,
+    onClose: () -> Unit,
+    navigateToItem: (AppMediaItem) -> Unit,
+) {
+    val queueData = player.queue as? DataState.Data
+    val queueId = queueData?.data?.info?.id
+    val queueHasItems = !(queueData?.data?.items as? DataState.Data)?.data.isNullOrEmpty()
+    val queueOptions = if (queueId != null && queueHasItems) {
+        listOf(
+            OverflowMenuOption(
+                title = stringResource(Res.string.queue_clear),
+                icon = Icons.Default.DeleteSweep,
+                onClick = { queueAction(QueueAction.ClearQueue(queueId)) },
+            ),
+        )
+    } else {
+        emptyList()
+    }
+
+    val navigationOptions =
+        (player.queueInfo?.currentItem?.track as? AppMediaItem)?.navigationOptions {
+            onClose()
+            navigateToItem(it)
+        } ?: emptyList()
+
+    val menuOptions = queueOptions + navigationOptions
+    if (menuOptions.isNotEmpty()) {
+        OverflowMenuButton(
+            modifier = Modifier,
+            options = menuOptions,
+        ) { onClick ->
+            IconButton(onClick = onClick) {
+                Icon(
+                    imageVector = Icons.Default.MoreVert,
+                    contentDescription = stringResource(Res.string.cd_more),
+                )
+            }
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -32,6 +32,9 @@ import androidx.compose.foundation.pager.PagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DeleteSweep
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Smartphone
+import androidx.compose.material.icons.filled.Speaker
+import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -65,11 +68,13 @@ import io.music_assistant.client.player.sendspin.SendspinState
 import io.music_assistant.client.ui.alphaOn
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.ExtractedColorsFetcher
+import io.music_assistant.client.ui.compose.common.OverflowMenu
 import io.music_assistant.client.ui.compose.common.OverflowMenuButton
 import io.music_assistant.client.ui.compose.common.OverflowMenuOption
 import io.music_assistant.client.ui.compose.common.PlayerColors
 import io.music_assistant.client.ui.compose.common.action.PlayerAction
 import io.music_assistant.client.ui.compose.common.action.QueueAction
+import io.music_assistant.client.ui.compose.common.icons.SpeakerMultipleIcon
 import io.music_assistant.client.ui.compose.common.icons.VolumeIcon
 import io.music_assistant.client.ui.compose.common.icons.VolumeMutedIcon
 import io.music_assistant.client.ui.compose.common.items.navigationOptions
@@ -84,6 +89,8 @@ import musicassistantclient.composeapp.generated.resources.cd_more
 import musicassistantclient.composeapp.generated.resources.cd_mute
 import musicassistantclient.composeapp.generated.resources.cd_unmute
 import musicassistantclient.composeapp.generated.resources.queue_clear
+import musicassistantclient.composeapp.generated.resources.queue_no_other_players
+import musicassistantclient.composeapp.generated.resources.queue_transfer
 import org.jetbrains.compose.resources.stringResource
 import kotlin.math.roundToInt
 
@@ -319,7 +326,14 @@ private fun ExpandedPlayerPage(
                 )
             }
 
-            PlayerOptionsMenu(player, queueAction, onClose, navigateToItem)
+            PlayerOverflowMenu(
+                player,
+                allPlayers,
+                queueAction,
+                onClose,
+                navigateToItem,
+                { moveToPlayer(it) },
+            )
         }
 
         AnimatedVisibility(
@@ -487,8 +501,6 @@ private fun ExpandedPlayerPage(
             serverUrl = serverUrl,
             queueAction = queueAction,
             tint = colors.controlTint,
-            players = allPlayers,
-            onPlayerSelected = { moveToPlayer(it) },
             isCurrentPage = isCurrentPage,
             contentPadding = contentPadding,
         )
@@ -496,17 +508,26 @@ private fun ExpandedPlayerPage(
 }
 
 @Composable
-private fun PlayerOptionsMenu(
+private fun PlayerOverflowMenu(
     player: PlayerData,
+    allPlayers: List<PlayerData>,
     queueAction: (QueueAction) -> Unit,
     onClose: () -> Unit,
     navigateToItem: (AppMediaItem) -> Unit,
+    onPlayerSelected: (String) -> Unit,
 ) {
+    var transferMenuExpanded by remember { mutableStateOf(false) }
+
     val queueData = player.queue as? DataState.Data
     val queueId = queueData?.data?.info?.id
     val queueHasItems = !(queueData?.data?.items as? DataState.Data)?.data.isNullOrEmpty()
     val queueOptions = if (queueId != null && queueHasItems) {
         listOf(
+            OverflowMenuOption(
+                title = stringResource(Res.string.queue_transfer),
+                icon = Icons.Default.SwapHoriz,
+                onClick = { transferMenuExpanded = true },
+            ),
             OverflowMenuOption(
                 title = stringResource(Res.string.queue_clear),
                 icon = Icons.Default.DeleteSweep,
@@ -515,6 +536,42 @@ private fun PlayerOptionsMenu(
         )
     } else {
         emptyList()
+    }
+
+    if (queueId != null) {
+        Box(modifier = Modifier.wrapContentSize(Alignment.TopStart)) {
+            OverflowMenu(
+                expanded = transferMenuExpanded,
+                onClose = { transferMenuExpanded = false },
+                options = allPlayers.filter { p -> p.player.id != queueId }.map { playerData ->
+                    OverflowMenuOption(
+                        title = playerData.player.nameAndSuffix,
+                        icon = when {
+                            playerData.isLocal -> Icons.Default.Smartphone
+                            playerData.player.isGroup -> SpeakerMultipleIcon
+                            else -> Icons.Default.Speaker
+                        },
+                        onClick = {
+                            queueAction(
+                                QueueAction.Transfer(
+                                    queueId,
+                                    playerData.player.id,
+                                    playerData.player.isPlaying,
+                                ),
+                            )
+                            onPlayerSelected.invoke(playerData.player.id)
+                        },
+                    )
+                }.ifEmpty {
+                    listOf(
+                        OverflowMenuOption(
+                            title = stringResource(Res.string.queue_no_other_players),
+                            onClick = { /* No-op */ },
+                        ),
+                    )
+                },
+            )
+        }
     }
 
     val navigationOptions =

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -311,7 +311,10 @@ private fun ExpandedPlayerPage(
     isCurrentPage: Boolean,
     navigateToItem: (AppMediaItem) -> Unit = {},
 ) {
-    Column(modifier = Modifier.padding(top = 8.dp)) {
+    Column(
+        modifier = Modifier.padding(top = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
         Box(
             modifier = Modifier.fillMaxWidth(),
             contentAlignment = Alignment.CenterEnd,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowRight
 import androidx.compose.material.icons.filled.DeleteSweep
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Smartphone
@@ -526,6 +527,7 @@ private fun PlayerOverflowMenu(
             OverflowMenuOption(
                 title = stringResource(Res.string.queue_transfer),
                 icon = Icons.Default.SwapHoriz,
+                trailingIcon = Icons.AutoMirrored.Default.ArrowRight,
                 onClick = { transferMenuExpanded = true },
             ),
             OverflowMenuOption(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Smartphone
 import androidx.compose.material.icons.filled.Speaker
 import androidx.compose.material.icons.filled.SwapHoriz
+import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -89,6 +90,7 @@ import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.cd_more
 import musicassistantclient.composeapp.generated.resources.cd_mute
 import musicassistantclient.composeapp.generated.resources.cd_unmute
+import musicassistantclient.composeapp.generated.resources.players_dsp_settings
 import musicassistantclient.composeapp.generated.resources.queue_clear
 import musicassistantclient.composeapp.generated.resources.queue_no_other_players
 import musicassistantclient.composeapp.generated.resources.queue_transfer
@@ -323,17 +325,19 @@ private fun ExpandedPlayerPage(
                     sendSpinState = sendspinState,
                     onSelectPlayer = onSelectPlayer,
                     onGroupButton = onGroupButton,
-                    onDspButton = onDspButton,
                 )
             }
 
             PlayerOverflowMenu(
-                player,
-                allPlayers,
-                queueAction,
-                onClose,
-                navigateToItem,
-                { moveToPlayer(it) },
+                player = player,
+                allPlayers = allPlayers,
+                queueAction = queueAction,
+                navigateToItem = {
+                    navigateToItem(it)
+                    onClose()
+                },
+                onPlayerSelected = { moveToPlayer(it) },
+                onOpenDsp = onDspButton,
             )
         }
 
@@ -513,9 +517,9 @@ private fun PlayerOverflowMenu(
     player: PlayerData,
     allPlayers: List<PlayerData>,
     queueAction: (QueueAction) -> Unit,
-    onClose: () -> Unit,
     navigateToItem: (AppMediaItem) -> Unit,
     onPlayerSelected: (String) -> Unit,
+    onOpenDsp: (() -> Unit)?,
 ) {
     var transferMenuExpanded by remember { mutableStateOf(false) }
 
@@ -576,13 +580,23 @@ private fun PlayerOverflowMenu(
         }
     }
 
-    val navigationOptions =
-        (player.queueInfo?.currentItem?.track as? AppMediaItem)?.navigationOptions {
-            onClose()
-            navigateToItem(it)
-        } ?: emptyList()
+    val playerOptions = if (onOpenDsp != null) {
+        listOf(
+            OverflowMenuOption(
+                title = stringResource(Res.string.players_dsp_settings),
+                icon = Icons.Default.Tune,
+                onClick = onOpenDsp,
+            ),
+        )
+    } else {
+        emptyList()
+    }
 
-    val menuOptions = queueOptions + navigationOptions
+    val navigationOptions =
+        (player.queueInfo?.currentItem?.track as? AppMediaItem)?.navigationOptions(navigateToItem)
+            ?: emptyList()
+
+    val menuOptions = queueOptions + playerOptions + navigationOptions
     if (menuOptions.isNotEmpty()) {
         OverflowMenuButton(
             modifier = Modifier,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -320,7 +320,7 @@ private fun ExpandedPlayerPage(
                 modifier = Modifier.fillMaxWidth(),
                 contentAlignment = Alignment.Center,
             ) {
-                PlayerSelectionLayout(
+                PlayerSelectionButton(
                     player = player,
                     sendSpinState = sendspinState,
                     onSelectPlayer = onSelectPlayer,
@@ -628,7 +628,7 @@ private fun CollapsedPlayerPage(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.Center,
         ) {
-            PlayerSelectionLayout(
+            PlayerSelectionButton(
                 player = player,
                 sendSpinState = sendspinState,
                 onSelectPlayer = onSelectPlayer,

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -227,9 +227,9 @@ style:
     active: true
   UnusedPrivateMember:
     active: true
-    # Allow private @Preview @Composable functions — they're unused at runtime but consumed
-    # by the IDE preview tooling. By project convention these are named `Preview*`.
-    allowedNames: '(_|ignored|expected|serialVersionUID|Preview.*)'
+    allowedNames: '(_|ignored|expected|serialVersionUID)'
+    ignoreAnnotated:
+      - 'Preview'
   UnusedParameter:
     active: true
     allowedNames: '_|ignored|expected'


### PR DESCRIPTION
Closes #285
Closes #276

<img width="270" height="600" alt="Screenshot_20260503_140653" src="https://github.com/user-attachments/assets/faef98fd-cda6-42ff-bbe1-9ac73d22b02b" />

I've also removed the skip backwards button from the compact player to increase the spacing available for other elements ([we'd discussed that button being less important](https://github.com/music-assistant/mobile-app#design-goals)):

<img width="306" height="110" alt="Screenshot 2026-05-04 at 12 02 47" src="https://github.com/user-attachments/assets/47aee51d-1c8e-4366-88b7-b1c1a54099b8" />

Just a note on testing: I haven't added any as I've mostly just moved things around that were already untested (and require bootstrapping to write tests for). Although that can of course also break things, I was happier to just get this in, and then I can follow up with backfilling tests for these features.

