### PR TITLE
Fix the WebRTC+Opus crash

### DIFF
--- a/.github/workflows/check-pr-ios.yml
+++ b/.github/workflows/check-pr-ios.yml
@@ -35,22 +35,23 @@ jobs:
           restore-keys: |
             gradle-${{ runner.os }}-
 
-      # WebRTC.xcframework is gitignored (~99MB). Cache keyed to the pinned
-      # version string so version bumps trigger a redownload automatically.
-      # Keep in sync with ios-release.yml and ios_build_instructions.md.
+      # WebRTC.xcframework is gitignored (~32 MB extracted, dSYMs shipped
+      # separately). Cache keyed to the patched-binary release tag so
+      # version/patch bumps trigger a redownload automatically. Keep in
+      # sync with ios-release.yml and ios_build_instructions.md.
       - name: Cache WebRTC.xcframework
         id: cache-webrtc
         uses: actions/cache@v4
         with:
           path: iosApp/Frameworks/WebRTC.xcframework
-          key: webrtc-xcframework-125.6422.02
+          key: webrtc-xcframework-m125-cow-bloat-fix.1
 
       - name: Download WebRTC.xcframework
         if: steps.cache-webrtc.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           curl -L --fail \
-            "https://github.com/webrtc-sdk/Specs/releases/download/125.6422.02/WebRTC.xcframework.zip" \
+            "https://github.com/teancom/webrtc/releases/download/m125-cow-bloat-fix.1/WebRTC.xcframework.m125-cow-bloat-fix.1.zip" \
             -o /tmp/WebRTC.xcframework.zip
           mkdir -p iosApp/Frameworks
           unzip -q /tmp/WebRTC.xcframework.zip -d iosApp/Frameworks/

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -39,22 +39,23 @@ jobs:
           restore-keys: |
             gradle-${{ runner.os }}-
 
-      # WebRTC.xcframework is gitignored (99MB) and downloaded per
-      # ios_build_instructions.md. If the version ever bumps, update both
-      # places — it's only referenced here and in that doc.
+      # WebRTC.xcframework is gitignored (~32 MB extracted, dSYMs shipped
+      # separately) and downloaded per ios_build_instructions.md. If the
+      # version/patch ever bumps, update both places — it's only referenced
+      # here and in that doc.
       - name: Cache WebRTC.xcframework
         id: cache-webrtc
         uses: actions/cache@v4
         with:
           path: iosApp/Frameworks/WebRTC.xcframework
-          key: webrtc-xcframework-125.6422.02
+          key: webrtc-xcframework-m125-cow-bloat-fix.1
 
       - name: Download WebRTC.xcframework
         if: steps.cache-webrtc.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           curl -L --fail \
-            "https://github.com/webrtc-sdk/Specs/releases/download/125.6422.02/WebRTC.xcframework.zip" \
+            "https://github.com/teancom/webrtc/releases/download/m125-cow-bloat-fix.1/WebRTC.xcframework.m125-cow-bloat-fix.1.zip" \
             -o /tmp/WebRTC.xcframework.zip
           mkdir -p iosApp/Frameworks
           unzip -q /tmp/WebRTC.xcframework.zip -d iosApp/Frameworks/

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>15</string>
+	<string>17</string>
 	<key>INIntentsSupported</key>
 	<array>
 		<string>INPlayMediaIntent</string>

--- a/ios_build_instructions.md
+++ b/ios_build_instructions.md
@@ -73,8 +73,13 @@ The app uses `webrtc-kmp` which requires the `WebRTC.xcframework` binary to be p
 The framework is already included in the repository at that path. If it's missing, download it:
 
 ```bash
-# Download WebRTC.xcframework (M125 build, ~41 MB)
-curl -L "https://github.com/webrtc-sdk/Specs/releases/download/125.6422.02/WebRTC.xcframework.zip" \
+# Download WebRTC.xcframework (M125 build + dcsctp COW-bloat fix,
+# ~15 MB compressed / ~32 MB extracted).
+# Patched build from teancom/webrtc — same M125 binary upstream ships
+# (125.6422.02), with the DcSctpTransport receive_buffer fix from
+# webrtc-sdk/webrtc#234 backported. Replace with an upstream
+# webrtc-sdk/Specs release once the fix lands in a stock release.
+curl -L "https://github.com/teancom/webrtc/releases/download/m125-cow-bloat-fix.1/WebRTC.xcframework.m125-cow-bloat-fix.1.zip" \
   -o /tmp/WebRTC.xcframework.zip
 
 # Extract into iosApp/Frameworks/
@@ -85,6 +90,10 @@ cd iosApp/Frameworks && unzip /tmp/WebRTC.xcframework.zip
 Expected result: `iosApp/Frameworks/WebRTC.xcframework/` containing slices for:
 - `ios-arm64` (physical device)
 - `ios-arm64_x86_64-simulator` (simulator)
+
+The xcframework binary ships **without dSYMs** — they live as a separate
+`*-dsyms.zip` asset on the same release for opt-in download when you need
+to symbolicate a WebRTC frame in a crash report.
 
 The Xcode build phase script (`Compile Kotlin Framework`) automatically:
 1. Copies the correct slice into the KMP output directory (so the linker can find it)


### PR DESCRIPTION
The actual fix is in the WebRTC SDK, an open PR (as of this writing) is here: https://github.com/webrtc-sdk/webrtc/pull/234

This PR switches to a build of the WebRTC.xcframework with the patch, hopefully it gets merged upstream and we can just swap it out & revert all of the things that point to my repo.

Full description of the bug and what I did below:


OPUS playback through the iOS Sendspin data channel triggered SIGABRT
in cricket::Connection::OnReadPacket → rtc::CopyOnWriteBuffer::Clear()
within ~1 second of starting. Root cause: WebRTC's DcSctpTransport
reused a CopyOnWriteBuffer member whose capacity stayed at the last
high-water mark, so subsequent small messages forced COW detach against
retained references and re-allocated at the prior capacity — OOM on
sustained small-message receives after a single large one (album art).

Fix is upstream in WebRTC C++ (PR webrtc-sdk/webrtc#234, served from
teancom/webrtc tag m125-cow-bloat-fix.1 until that ships in a stock
release). Same upstream version (125.6422.02), one-line patch
backported to webrtc-sdk/m125_release.

This commit wires mobile-app to consume the patched binary:

- ios_build_instructions.md: download URL + expected-result block
  point at teancom/webrtc release. Doc note explains the patch will
  be replaced with upstream once the fix ships in a stock M125 build.
- .github/workflows/check-pr-ios.yml + ios-release.yml: cache key
  bumped to webrtc-xcframework-m125-cow-bloat-fix.1 so the new
  asset is fetched (old key would silently serve unpatched cache),
  download URL updated to teancom release.

The vendored WebRTC.xcframework is gitignored, so the patched binary
ships out-of-band per ios_build_instructions.md.

Follow-up: delete the teancom/webrtc release and revert these URLs to
upstream webrtc-sdk/Specs once webrtc-sdk/webrtc#234 lands in a stock
M125 release.