### PR TITLE
Fixed music delay when was in background not playing.

### DIFF
--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -252,7 +253,7 @@ class FakeServiceClient(private val settingsRepository: SettingsRepository) : Se
 
             APICommands.PLAYER_QUEUES_CLEAR -> {
                 val queueId = (request.args!!["queue_id"] as JsonPrimitive).content
-                updateQueue(queueId, emptyList<ServerQueueItem>())
+                updateQueue(queueId, emptyList())
                 updatePlayer({ it.activeSource == queueId }) {
                     it.copy(
                         state = PlayerState.IDLE,
@@ -392,7 +393,7 @@ class FakeServiceClient(private val settingsRepository: SettingsRepository) : Se
 
     private val _events = MutableSharedFlow<Event<out Any>>()
     override val events: Flow<Event<out Any>> = _events
-    override val webrtcSendspinChannel: DataChannelWrapper?
+    override val webrtcSendspinChannel: DataChannelWrapper
         get() = TODO("Not yet implemented")
 
     override fun onAppForeground() {
@@ -400,6 +401,8 @@ class FakeServiceClient(private val settingsRepository: SettingsRepository) : Se
 
     override fun onAppBackground() {
     }
+
+    override val foregroundEvents: Flow<Unit> = emptyFlow()
 
     override fun disconnectByUser() {
         TODO("Not yet implemented")

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -101,6 +101,9 @@ class KtorServiceClient(private val settings: SettingsRepository) : ServiceClien
     private val _eventsFlow = MutableSharedFlow<Event<out Any>>(extraBufferCapacity = 10)
     override val events: Flow<Event<out Any>> = _eventsFlow.asSharedFlow()
 
+    private val _foregroundEvents = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    override val foregroundEvents: Flow<Unit> = _foregroundEvents.asSharedFlow()
+
     /**
      * WebRTC Sendspin data channel.
      * Available when connected via WebRTC, null otherwise.
@@ -202,9 +205,12 @@ class KtorServiceClient(private val settings: SettingsRepository) : ServiceClien
      * Called when the app returns to the foreground.
      */
     override fun onAppForeground() {
+        val wasInBackground = isInBackground
         isInBackground = false
         val state = _sessionState.value
         logger.i { "App foregrounded (state=${stateLabel(state)})" }
+
+        if (wasInBackground) _foregroundEvents.tryEmit(Unit)
 
         val savedInfo = backgroundedConnectionInfo
         if (savedInfo != null) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/ServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/ServiceClient.kt
@@ -22,6 +22,7 @@ interface ServiceClient {
 
     fun onAppForeground()
     fun onAppBackground()
+    val foregroundEvents: Flow<Unit>
     fun disconnectByUser()
     fun connect(connection: ConnectionInfo)
     fun connectWebRTC(remoteId: RemoteId)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -616,6 +616,21 @@ class MainDataSource(
                 }
             }
         }
+
+        // Reset clock sync on foreground unless playback held CPU awake through
+        // the background — otherwise doze-paused CLOCK_MONOTONIC strands the offset.
+        launch {
+            apiClient.foregroundEvents.collect {
+                val streaming = sendspinClient?.state?.value.let {
+                    it is SendspinState.Synchronized || it is SendspinState.Buffering
+                }
+                if (streaming) return@collect
+                sendspinClientFactory.currentClockSynchronizer()?.let {
+                    log.i { "Foreground from idle — resetting clock sync" }
+                    it.reset()
+                }
+            }
+        }
         // Keep Now Playing (iOS Control Center / Lock Screen) in sync with the
         // local player. iOS interpolates the playback bar internally from the
         // `(elapsed, timestamp, rate)` triple on every `setNowPlayingInfo`

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/SendspinClientFactory.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/SendspinClientFactory.kt
@@ -64,6 +64,8 @@ class SendspinClientFactory(
      * Returns the shared pipeline (and its clock synchronizer), creating them if needed.
      * Both are passed to new SendspinClient instances so the audio sink persists across reconnects.
      */
+    fun currentClockSynchronizer(): ClockSynchronizer? = sharedClockSynchronizer
+
     fun getOrCreatePipeline(): Pair<AudioStreamManager, ClockSynchronizer> {
         val cs = sharedClockSynchronizer ?: ClockSynchronizer().also { sharedClockSynchronizer = it }
         val pipeline = sharedPipeline ?: AudioStreamManager(cs, mediaPlayerController).also {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/Sync.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/Sync.kt
@@ -101,8 +101,15 @@ class ClockSynchronizer {
         val predictedOffset = offset + (drift * deltaTime).toLong()
         val residual = measuredOffset - predictedOffset
 
-        // Reject outliers
-        if (kotlin.math.abs(residual) > 50_000) return
+        // Residual >1s = discontinuity (doze paused CLOCK_MONOTONIC, NTP step,
+        // server reset). Smoothing can't claw that back; reset and let the next
+        // sample re-init.
+        val absResidual = kotlin.math.abs(residual)
+        if (absResidual > 1_000_000) {
+            reset()
+            return
+        }
+        if (absResidual > 50_000) return
 
         // Update offset and drift
         offset = predictedOffset + (smoothingRate * residual).toLong()

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/TopLevelNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/TopLevelNavRoot.kt
@@ -47,24 +47,28 @@ fun TopLevelNavRoot(modifier: Modifier = Modifier) {
     // user-initiated reconnects and background→foreground transitions don't bring it back.
     var splashDismissed by remember { mutableStateOf(false) }
     val splashVisible = !splashDismissed &&
-        authManager.willAutoLoginOnLaunch &&
-        when (val s = sessionState) {
-            SessionState.Disconnected.Initial -> true
-            SessionState.Connecting -> true
-            is SessionState.Connected ->
-                s.dataConnectionState != DataConnectionState.Authenticated &&
-                s.authProcessState !is AuthProcessState.Failed
-            else -> false
-        }
+            authManager.willAutoLoginOnLaunch &&
+            when (val s = sessionState) {
+                SessionState.Disconnected.Initial -> true
+                SessionState.Connecting -> true
+                is SessionState.Connected ->
+                    s.dataConnectionState != DataConnectionState.Authenticated &&
+                            s.authProcessState !is AuthProcessState.Failed
+
+                else -> false
+            }
     LaunchedEffect(sessionState) {
-        val s = sessionState
-        val terminal = when {
-            s is SessionState.Connected &&
-                s.dataConnectionState == DataConnectionState.Authenticated -> true
-            s is SessionState.Connected && s.authProcessState is AuthProcessState.Failed -> true
-            s is SessionState.Disconnected &&
-                s !is SessionState.Disconnected.Initial &&
-                s !is SessionState.Disconnected.Backgrounded -> true
+        val terminal = when (val s = sessionState) {
+            is SessionState.Connected -> {
+                s.dataConnectionState == DataConnectionState.Authenticated ||
+                        s.authProcessState is AuthProcessState.Failed
+            }
+
+            is SessionState.Disconnected.Error,
+            is SessionState.Disconnected.ByUser,
+            is SessionState.Disconnected.NoServerData,
+                -> true
+
             else -> false
         }
         if (terminal) splashDismissed = true


### PR DESCRIPTION
Bug: pause player, send app to background (or just disconnect from Android Auto), and then in a while try playing music.
Outcome: the playback is shifted in time for the time the phone was in "doze" - looks like it's not playing at all, if it was off for too long.
This is fix for that.