### PR TITLE
Fix rapid recomposition because of progress bar. Fix Android Auto fetch loop.

### DIFF
--- a/androidApp/src/main/kotlin/io/music_assistant/client/auto/AutoLibrary.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/auto/AutoLibrary.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.ConcurrentHashMap
 
 @OptIn(FlowPreview::class)
 class AutoLibrary(
@@ -57,6 +58,18 @@ class AutoLibrary(
     private val searchFlow: MutableStateFlow<Pair<String, MediaBrowserServiceCompat.Result<List<MediaItem>>>?> =
         MutableStateFlow(null)
     private val defaultIconUri = R.drawable.baseline_library_music_24.toUri(context)
+
+    /**
+     * In-memory cache of [getItems] results. AA hosts re-subscribe browseable
+     * parents aggressively (on metadata changes, focus changes, host re-renders);
+     * without this cache, every re-subscribe round-trips to the MA server,
+     * allocating DTOs and pegging GC. Entries are invalidated explicitly via
+     * [invalidateAndNotify] when the underlying data changes (sort applied, etc.).
+     */
+    private data class CachedItems(val items: List<MediaItem>, val timestampMs: Long)
+
+    private val itemCache = ConcurrentHashMap<String, CachedItems>()
+    private val cacheTtlMs = 5 * 60 * 1000L // 5 minutes
 
     init {
         scope.launch {
@@ -96,9 +109,16 @@ class AutoLibrary(
         id: String,
         result: MediaBrowserServiceCompat.Result<List<MediaItem>>,
     ) {
-        Logger.withTag("AutoLibrary").i { "Items for $id" }
+        val cached = itemCache[id]
+        if (cached != null && System.currentTimeMillis() - cached.timestampMs < cacheTtlMs) {
+            // Cache hit: serve without server round-trip. AA fires onLoadChildren
+            // many times per second when its host invalidates browse caches.
+            result.sendResult(cached.items)
+            return
+        }
+        Logger.withTag("AutoLibrary").i { "Items for $id (cache miss)" }
         when {
-            id == MediaIds.ROOT -> result.sendResult(rootChildren())
+            id == MediaIds.ROOT -> sendAndCache(id, result, rootChildren())
             MediaIds.tabMediaTypeOf(id) != null -> handleTabContent(
                 id,
                 result,
@@ -114,6 +134,27 @@ class AutoLibrary(
         }
     }
 
+    /**
+     * Invalidate the cached children for [parentId] and notify AA that the
+     * subtree has changed. All notifyChildrenChanged dispatches go through this
+     * method to keep cache and AA's view consistent.
+     */
+    fun invalidateAndNotify(parentId: String) {
+        itemCache.remove(parentId)
+        notifyChildrenChanged?.invoke(parentId)
+    }
+
+    private fun sendAndCache(
+        id: String,
+        result: MediaBrowserServiceCompat.Result<List<MediaItem>>,
+        items: List<MediaItem>?,
+    ) {
+        if (items != null) {
+            itemCache[id] = CachedItems(items, System.currentTimeMillis())
+        }
+        result.sendResult(items)
+    }
+
     private fun rootChildren(): List<MediaItem> = listOf(
         rootTabItem("Artists", MediaIds.TAB_ARTISTS),
         rootTabItem("Albums", MediaIds.TAB_ALBUMS),
@@ -127,6 +168,7 @@ class AutoLibrary(
         tabId: String,
         result: MediaBrowserServiceCompat.Result<List<MediaItem>>,
         favoritesOnly: Boolean,
+        cacheKey: String = tabId,
     ) {
         val mediaType = MediaIds.tabMediaTypeOf(tabId) ?: run {
             result.sendResult(null)
@@ -154,7 +196,7 @@ class AutoLibrary(
                     favoritesPseudoItem(MediaIds.favoritesId(mediaType)),
                 )
             }
-            result.sendResult(header + items)
+            sendAndCache(cacheKey, result, header + items)
         }
     }
 
@@ -178,7 +220,7 @@ class AutoLibrary(
                 isCurrent = preset.option == current,
             )
         }
-        result.sendResult(items)
+        sendAndCache(id, result, items)
     }
 
     private fun handleSortApply(
@@ -197,7 +239,7 @@ class AutoLibrary(
         // browse view glitches many times a second.
         if (settings.getAutoSortOption(mediaType) != sort) {
             settings.setAutoSortOption(mediaType, sort)
-            notifyChildrenChanged?.invoke(MediaIds.tabIdOf(mediaType))
+            invalidateAndNotify(MediaIds.tabIdOf(mediaType))
         }
         result.detach()
         scope.launch {
@@ -205,7 +247,7 @@ class AutoLibrary(
                 result.sendResult(null)
                 return@launch
             }
-            result.sendResult(loadTabItems(mediaType, sort, favoritesOnly = false))
+            sendAndCache(id, result, loadTabItems(mediaType, sort, favoritesOnly = false))
         }
     }
 
@@ -218,7 +260,14 @@ class AutoLibrary(
             return
         }
         // Reuse the tab content path with favoritesOnly=true; header is suppressed there.
-        handleTabContent(MediaIds.tabIdOf(mediaType), result, favoritesOnly = true)
+        // Cache key is the original favorites id, not the tab id, so each subtree
+        // gets its own cache slot.
+        handleTabContent(
+            tabId = MediaIds.tabIdOf(mediaType),
+            result = result,
+            favoritesOnly = true,
+            cacheKey = id,
+        )
     }
 
     private fun handleSubSortMenu(
@@ -241,7 +290,7 @@ class AutoLibrary(
                 isCurrent = preset.option == current,
             )
         }
-        result.sendResult(items)
+        sendAndCache(id, result, items)
     }
 
     private fun handleSubSortApply(
@@ -254,12 +303,11 @@ class AutoLibrary(
         }
         if (settings.getAutoSortOption(parsed.context) != parsed.option) {
             settings.setAutoSortOption(parsed.context, parsed.option)
-            notifyChildrenChanged?.invoke(parsed.parent.encode())
+            invalidateAndNotify(parsed.parent.encode())
         }
         result.detach()
         scope.launch {
-            val list = loadSubItems(parsed.context, parsed.parent, parsed.option)
-            result.sendResult(list)
+            sendAndCache(id, result, loadSubItems(parsed.context, parsed.parent, parsed.option))
         }
     }
 
@@ -293,7 +341,7 @@ class AutoLibrary(
                 }
                 addAll(actionsForItem(id))
             }
-            result.sendResult(header + items)
+            sendAndCache(id, result, header + items)
         }
     }
 

--- a/androidApp/src/main/kotlin/io/music_assistant/client/auto/AutoLibrary.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/auto/AutoLibrary.kt
@@ -41,7 +41,6 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
-import java.util.concurrent.ConcurrentHashMap
 
 @OptIn(FlowPreview::class)
 class AutoLibrary(
@@ -58,18 +57,6 @@ class AutoLibrary(
     private val searchFlow: MutableStateFlow<Pair<String, MediaBrowserServiceCompat.Result<List<MediaItem>>>?> =
         MutableStateFlow(null)
     private val defaultIconUri = R.drawable.baseline_library_music_24.toUri(context)
-
-    /**
-     * In-memory cache of [getItems] results. AA hosts re-subscribe browseable
-     * parents aggressively (on metadata changes, focus changes, host re-renders);
-     * without this cache, every re-subscribe round-trips to the MA server,
-     * allocating DTOs and pegging GC. Entries are invalidated explicitly via
-     * [invalidateAndNotify] when the underlying data changes (sort applied, etc.).
-     */
-    private data class CachedItems(val items: List<MediaItem>, val timestampMs: Long)
-
-    private val itemCache = ConcurrentHashMap<String, CachedItems>()
-    private val cacheTtlMs = 5 * 60 * 1000L // 5 minutes
 
     init {
         scope.launch {
@@ -109,16 +96,9 @@ class AutoLibrary(
         id: String,
         result: MediaBrowserServiceCompat.Result<List<MediaItem>>,
     ) {
-        val cached = itemCache[id]
-        if (cached != null && System.currentTimeMillis() - cached.timestampMs < cacheTtlMs) {
-            // Cache hit: serve without server round-trip. AA fires onLoadChildren
-            // many times per second when its host invalidates browse caches.
-            result.sendResult(cached.items)
-            return
-        }
-        Logger.withTag("AutoLibrary").i { "Items for $id (cache miss)" }
+        Logger.withTag("AutoLibrary").i { "Items for $id" }
         when {
-            id == MediaIds.ROOT -> sendAndCache(id, result, rootChildren())
+            id == MediaIds.ROOT -> result.sendResult(rootChildren())
             MediaIds.tabMediaTypeOf(id) != null -> handleTabContent(
                 id,
                 result,
@@ -134,27 +114,6 @@ class AutoLibrary(
         }
     }
 
-    /**
-     * Invalidate the cached children for [parentId] and notify AA that the
-     * subtree has changed. All notifyChildrenChanged dispatches go through this
-     * method to keep cache and AA's view consistent.
-     */
-    fun invalidateAndNotify(parentId: String) {
-        itemCache.remove(parentId)
-        notifyChildrenChanged?.invoke(parentId)
-    }
-
-    private fun sendAndCache(
-        id: String,
-        result: MediaBrowserServiceCompat.Result<List<MediaItem>>,
-        items: List<MediaItem>?,
-    ) {
-        if (items != null) {
-            itemCache[id] = CachedItems(items, System.currentTimeMillis())
-        }
-        result.sendResult(items)
-    }
-
     private fun rootChildren(): List<MediaItem> = listOf(
         rootTabItem("Artists", MediaIds.TAB_ARTISTS),
         rootTabItem("Albums", MediaIds.TAB_ALBUMS),
@@ -168,7 +127,6 @@ class AutoLibrary(
         tabId: String,
         result: MediaBrowserServiceCompat.Result<List<MediaItem>>,
         favoritesOnly: Boolean,
-        cacheKey: String = tabId,
     ) {
         val mediaType = MediaIds.tabMediaTypeOf(tabId) ?: run {
             result.sendResult(null)
@@ -196,7 +154,7 @@ class AutoLibrary(
                     favoritesPseudoItem(MediaIds.favoritesId(mediaType)),
                 )
             }
-            sendAndCache(cacheKey, result, header + items)
+            result.sendResult(header + items)
         }
     }
 
@@ -220,7 +178,7 @@ class AutoLibrary(
                 isCurrent = preset.option == current,
             )
         }
-        sendAndCache(id, result, items)
+        result.sendResult(items)
     }
 
     private fun handleSortApply(
@@ -239,7 +197,7 @@ class AutoLibrary(
         // browse view glitches many times a second.
         if (settings.getAutoSortOption(mediaType) != sort) {
             settings.setAutoSortOption(mediaType, sort)
-            invalidateAndNotify(MediaIds.tabIdOf(mediaType))
+            notifyChildrenChanged?.invoke(MediaIds.tabIdOf(mediaType))
         }
         result.detach()
         scope.launch {
@@ -247,7 +205,7 @@ class AutoLibrary(
                 result.sendResult(null)
                 return@launch
             }
-            sendAndCache(id, result, loadTabItems(mediaType, sort, favoritesOnly = false))
+            result.sendResult(loadTabItems(mediaType, sort, favoritesOnly = false))
         }
     }
 
@@ -260,14 +218,7 @@ class AutoLibrary(
             return
         }
         // Reuse the tab content path with favoritesOnly=true; header is suppressed there.
-        // Cache key is the original favorites id, not the tab id, so each subtree
-        // gets its own cache slot.
-        handleTabContent(
-            tabId = MediaIds.tabIdOf(mediaType),
-            result = result,
-            favoritesOnly = true,
-            cacheKey = id,
-        )
+        handleTabContent(MediaIds.tabIdOf(mediaType), result, favoritesOnly = true)
     }
 
     private fun handleSubSortMenu(
@@ -290,7 +241,7 @@ class AutoLibrary(
                 isCurrent = preset.option == current,
             )
         }
-        sendAndCache(id, result, items)
+        result.sendResult(items)
     }
 
     private fun handleSubSortApply(
@@ -303,11 +254,12 @@ class AutoLibrary(
         }
         if (settings.getAutoSortOption(parsed.context) != parsed.option) {
             settings.setAutoSortOption(parsed.context, parsed.option)
-            invalidateAndNotify(parsed.parent.encode())
+            notifyChildrenChanged?.invoke(parsed.parent.encode())
         }
         result.detach()
         scope.launch {
-            sendAndCache(id, result, loadSubItems(parsed.context, parsed.parent, parsed.option))
+            val list = loadSubItems(parsed.context, parsed.parent, parsed.option)
+            result.sendResult(list)
         }
     }
 
@@ -341,7 +293,7 @@ class AutoLibrary(
                 }
                 addAll(actionsForItem(id))
             }
-            sendAndCache(id, result, header + items)
+            result.sendResult(header + items)
         }
     }
 

--- a/androidApp/src/main/kotlin/io/music_assistant/client/auto/AutoLibrary.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/auto/AutoLibrary.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.ConcurrentHashMap
 
 @OptIn(FlowPreview::class)
 class AutoLibrary(
@@ -50,6 +51,13 @@ class AutoLibrary(
     private val searchFlow: MutableStateFlow<Pair<String, MediaBrowserServiceCompat.Result<List<MediaItem>>>?> =
         MutableStateFlow(null)
     private val defaultIconUri = R.drawable.baseline_library_music_24.toUri(context)
+
+    // AA hosts re-subscribe browse parents aggressively (on metadata / playback /
+    // focus changes). With 27 browsable nodes (6 tabs + 5*4 sub-lists + radio
+    // header) every reconnect would otherwise issue 21 server list requests in
+    // one burst. Cache is invalidated explicitly from the service on reconnect.
+    private val itemCache = ConcurrentHashMap<String, CacheEntry>()
+    private val cacheTtlMs = 5 * 60_000L
 
     init {
         scope.launch {
@@ -92,15 +100,14 @@ class AutoLibrary(
         Logger.withTag("AutoLibrary").i { "Items for $id" }
         when {
             id == MediaIds.ROOT -> result.sendResult(rootChildren())
-            MediaIds.tabMediaTypeOf(id) != null -> handleTabContent(
-                id,
-                result,
-                favoritesOnly = false,
-            )
-
-            id.startsWith(MediaIds.FAVORITES_PREFIX) -> handleFavorites(id, result)
+            MediaIds.parseSubListId(id) != null -> handleSubList(id, result)
+            MediaIds.tabMediaTypeOf(id) != null -> handleTabContent(id, result)
             else -> handleDrillDown(id, result)
         }
+    }
+
+    fun invalidateCache() {
+        itemCache.clear()
     }
 
     private fun rootChildren(): List<MediaItem> = listOf(
@@ -115,41 +122,92 @@ class AutoLibrary(
     private fun handleTabContent(
         tabId: String,
         result: MediaBrowserServiceCompat.Result<List<MediaItem>>,
-        favoritesOnly: Boolean,
     ) {
         val mediaType = MediaIds.tabMediaTypeOf(tabId) ?: run {
             result.sendResult(null)
             return
         }
+        if (mediaType != MediaType.RADIO) {
+            // Collection tabs return only stateless sub-list browsables. The
+            // selection is encoded in the parentId — no settings, no parent
+            // invalidation, no re-fetch loop.
+            result.sendResult(AutoSubList.entries.map { subListBrowsable(mediaType, it) })
+            return
+        }
+        // Radio: a flat list (sorted by recently played) with a single
+        // Favorites browsable header.
         result.detach()
         scope.launch {
-            if (!waitForCorrectState()) {
-                result.sendResult(null)
-                return@launch
+            val items = cachedOrFetch(tabId) {
+                if (!waitForCorrectState()) return@cachedOrFetch null
+                val sorted = loadTabItems(
+                    MediaType.RADIO,
+                    SortOption(SortField.LAST_PLAYED, descending = true),
+                    favoritesOnly = false,
+                ) ?: return@cachedOrFetch null
+                listOf(subListBrowsable(MediaType.RADIO, AutoSubList.FAVORITES)) + sorted
             }
-            val items = loadTabItems(mediaType, defaultSortFor(mediaType), favoritesOnly) ?: run {
-                result.sendResult(null)
-                return@launch
-            }
-            val header = if (favoritesOnly) {
-                emptyList()
-            } else {
-                listOf(favoritesPseudoItem(MediaIds.favoritesId(mediaType)))
-            }
-            result.sendResult(header + items)
+            result.sendResult(items)
         }
     }
 
-    private fun handleFavorites(
+    private fun handleSubList(
         id: String,
         result: MediaBrowserServiceCompat.Result<List<MediaItem>>,
     ) {
-        val mediaType = MediaIds.favoritesMediaTypeOf(id) ?: run {
+        val (mediaType, key) = MediaIds.parseSubListId(id) ?: run {
             result.sendResult(null)
             return
         }
-        // Reuse the tab content path with favoritesOnly=true; header is suppressed there.
-        handleTabContent(MediaIds.tabIdOf(mediaType), result, favoritesOnly = true)
+        val spec = subListSpec(mediaType, key) ?: run {
+            result.sendResult(null)
+            return
+        }
+        result.detach()
+        scope.launch {
+            val items = cachedOrFetch(id) {
+                if (!waitForCorrectState()) return@cachedOrFetch null
+                loadTabItems(mediaType, spec.sort, spec.favoritesOnly)
+            }
+            result.sendResult(items)
+        }
+    }
+
+    private suspend fun cachedOrFetch(
+        cacheKey: String,
+        fetch: suspend () -> List<MediaItem>?,
+    ): List<MediaItem>? {
+        val now = System.currentTimeMillis()
+        itemCache[cacheKey]?.let { (cached, ts) ->
+            if (now - ts < cacheTtlMs) return cached
+        }
+        val items = fetch() ?: return null
+        itemCache[cacheKey] = CacheEntry(items, now)
+        return items
+    }
+
+    private data class SubListSpec(val sort: SortOption, val favoritesOnly: Boolean)
+
+    private fun subListSpec(type: MediaType, key: AutoSubList): SubListSpec? {
+        // Radio only exposes FAVORITES as a sub-list; other keys are not valid.
+        if (type == MediaType.RADIO && key != AutoSubList.FAVORITES) return null
+        return when (key) {
+            AutoSubList.RECENT ->
+                SubListSpec(SortOption(SortField.LAST_PLAYED, descending = true), false)
+
+            AutoSubList.FAVORITES ->
+                SubListSpec(SortOption(SortField.NAME), true)
+
+            AutoSubList.NEW -> if (type == MediaType.PODCAST) {
+                // For podcasts, "New" means recently updated (i.e. has new episodes).
+                SubListSpec(SortOption(SortField.DATE_MODIFIED, descending = true), false)
+            } else {
+                SubListSpec(SortOption(SortField.DATE_ADDED, descending = true), false)
+            }
+
+            AutoSubList.BY_NAME ->
+                SubListSpec(SortOption(SortField.NAME), false)
+        }
     }
 
     private fun handleDrillDown(
@@ -241,14 +299,6 @@ class AutoLibrary(
             if (context == SubItemContext.PLAYLIST_TRACKS) items else items.clientSorted(sort)
         return sorted.map { it.toAutoMediaItem(baseUrl, true, defaultIconUri) }
     }
-
-    // Hardcoded defaults — sorting UI is intentionally absent in AA. Per-list
-    // pickers turned out to be a footgun: AA prefetches children of every
-    // browsable preset, which (when coupled to persistence + parent invalidation)
-    // looped the browse view to OOM. Keeping the matrix flat sidesteps the
-    // entire surface.
-    private fun defaultSortFor(mediaType: MediaType): SortOption =
-        SortOption(SortField.NAME, descending = false)
 
     private fun defaultSortFor(context: SubItemContext): SortOption = when (context) {
         SubItemContext.PODCAST_EPISODES -> SortOption(SortField.RELEASE_DATE, descending = true)
@@ -376,15 +426,26 @@ class AutoLibrary(
             MediaItem.FLAG_BROWSABLE,
         )
 
-    private fun favoritesPseudoItem(favoritesId: String): MediaItem =
-        MediaItem(
+    private fun subListBrowsable(mediaType: MediaType, key: AutoSubList): MediaItem {
+        val title = when (key) {
+            AutoSubList.RECENT -> "Recent"
+            AutoSubList.FAVORITES -> "Favorites"
+            AutoSubList.NEW -> "New"
+            AutoSubList.BY_NAME -> "By name"
+        }
+        val icon = when (key) {
+            AutoSubList.FAVORITES -> R.drawable.baseline_favorite_24.toUri(context)
+            else -> defaultIconUri
+        }
+        return MediaItem(
             MediaDescriptionCompat.Builder()
-                .setTitle("Favorites")
-                .setMediaId(favoritesId)
-                .setIconUri(R.drawable.baseline_favorite_24.toUri(context))
+                .setTitle(title)
+                .setMediaId(MediaIds.subListIdOf(mediaType, key))
+                .setIconUri(icon)
                 .build(),
             MediaItem.FLAG_BROWSABLE,
         )
+    }
 
     private companion object {
         const val WAIT_FOR_AUTHENTICATED_TIMEOUT_MS = 30_000L
@@ -407,7 +468,11 @@ internal object MediaIds {
     const val TAB_AUDIOBOOKS = "auto_lib_audiobooks"
     const val QUEUE_OPTION_KEY = "auto_queue_option"
 
-    const val FAVORITES_PREFIX = "auto_fav_"
+    // `_` is taken by tab IDs and `__` by ParentRef; `|` keeps sub-list IDs
+    // unambiguous against both (and against keys like BY_NAME that contain `_`).
+    // Avoid `#` — some AA components treat mediaIds as URIs and `#` is the
+    // fragment delimiter.
+    private const val SUBLIST_SEP = '|'
 
     private val tabToType = mapOf(
         TAB_ARTISTS to MediaType.ARTIST,
@@ -422,10 +487,21 @@ internal object MediaIds {
     fun tabMediaTypeOf(id: String): MediaType? = tabToType[id]
     fun tabIdOf(type: MediaType): String = typeToTab.getValue(type)
 
-    fun favoritesId(type: MediaType): String = "$FAVORITES_PREFIX${type.name}"
-    fun favoritesMediaTypeOf(id: String): MediaType? =
-        runCatching { MediaType.valueOf(id.removePrefix(FAVORITES_PREFIX)) }.getOrNull()
+    fun subListIdOf(type: MediaType, key: AutoSubList): String =
+        "${tabIdOf(type)}$SUBLIST_SEP${key.name}"
+
+    fun parseSubListId(id: String): Pair<MediaType, AutoSubList>? {
+        val idx = id.indexOf(SUBLIST_SEP).takeIf { it >= 0 } ?: return null
+        val type = tabMediaTypeOf(id.substring(0, idx)) ?: return null
+        val key = runCatching { AutoSubList.valueOf(id.substring(idx + 1)) }.getOrNull()
+            ?: return null
+        return type to key
+    }
 }
+
+internal enum class AutoSubList { RECENT, FAVORITES, NEW, BY_NAME }
+
+internal data class CacheEntry(val items: List<MediaItem>, val timestamp: Long)
 
 internal data class ParentRef(
     val itemId: String,

--- a/androidApp/src/main/kotlin/io/music_assistant/client/auto/AutoLibrary.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/auto/AutoLibrary.kt
@@ -24,7 +24,6 @@ import io.music_assistant.client.data.model.server.MediaType
 import io.music_assistant.client.data.model.server.QueueOption
 import io.music_assistant.client.data.model.server.SearchResult
 import io.music_assistant.client.data.model.server.ServerMediaItem
-import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.Timings
 import io.music_assistant.client.utils.DataConnectionState
 import io.music_assistant.client.utils.SessionState
@@ -46,13 +45,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 class AutoLibrary(
     private val context: Context,
     private val apiClient: ServiceClient,
-    private val settings: SettingsRepository,
 ) {
-    // Service supplies its own notifyChildrenChanged so the cached parent view
-    // (with the now-stale "Sort by: <old>" subtitle) is invalidated after a
-    // sort selection is persisted. Set once during service onCreate.
-    var notifyChildrenChanged: ((parentId: String) -> Unit)? = null
-
     private val scope = CoroutineScope(Dispatchers.IO)
     private val searchFlow: MutableStateFlow<Pair<String, MediaBrowserServiceCompat.Result<List<MediaItem>>>?> =
         MutableStateFlow(null)
@@ -105,11 +98,7 @@ class AutoLibrary(
                 favoritesOnly = false,
             )
 
-            id.startsWith(MediaIds.SORT_MENU_PREFIX) -> handleSortMenu(id, result)
-            id.startsWith(MediaIds.SORT_APPLY_PREFIX) -> handleSortApply(id, result)
             id.startsWith(MediaIds.FAVORITES_PREFIX) -> handleFavorites(id, result)
-            id.startsWith(MediaIds.SUB_SORT_MENU_PREFIX) -> handleSubSortMenu(id, result)
-            id.startsWith(MediaIds.SUB_SORT_APPLY_PREFIX) -> handleSubSortApply(id, result)
             else -> handleDrillDown(id, result)
         }
     }
@@ -138,74 +127,16 @@ class AutoLibrary(
                 result.sendResult(null)
                 return@launch
             }
-            val sort = settings.getAutoSortOption(mediaType)
-            val items = loadTabItems(mediaType, sort, favoritesOnly) ?: run {
+            val items = loadTabItems(mediaType, defaultSortFor(mediaType), favoritesOnly) ?: run {
                 result.sendResult(null)
                 return@launch
             }
             val header = if (favoritesOnly) {
                 emptyList()
             } else {
-                listOf(
-                    sortByPseudoItem(
-                        MediaIds.sortMenuId(mediaType),
-                        AutoSortPresets.labelOf(mediaType, sort),
-                    ),
-                    favoritesPseudoItem(MediaIds.favoritesId(mediaType)),
-                )
+                listOf(favoritesPseudoItem(MediaIds.favoritesId(mediaType)))
             }
             result.sendResult(header + items)
-        }
-    }
-
-    private fun handleSortMenu(
-        id: String,
-        result: MediaBrowserServiceCompat.Result<List<MediaItem>>,
-    ) {
-        val mediaType = MediaIds.sortMenuMediaTypeOf(id) ?: run {
-            result.sendResult(null)
-            return
-        }
-        val current = settings.getAutoSortOption(mediaType)
-        val presets = AutoSortPresets.byTab[mediaType] ?: run {
-            result.sendResult(null)
-            return
-        }
-        val items = presets.map { preset ->
-            sortPresetItem(
-                presetId = MediaIds.sortApplyId(mediaType, preset.option),
-                title = preset.label,
-                isCurrent = preset.option == current,
-            )
-        }
-        result.sendResult(items)
-    }
-
-    private fun handleSortApply(
-        id: String,
-        result: MediaBrowserServiceCompat.Result<List<MediaItem>>,
-    ) {
-        val (mediaType, sort) = MediaIds.parseSortApply(id) ?: run {
-            result.sendResult(null)
-            return
-        }
-        // Idempotent: only persist + invalidate cache when the sort actually changes.
-        // Without this, any AA re-subscribe to an apply node (which can happen when AA
-        // refreshes the browse stack for *any* reason — e.g. session-state churn,
-        // playback-state updates, host re-render) would re-invoke notifyChildrenChanged
-        // on the parent tab, AA re-renders the tab, the user's scroll resets, and the
-        // browse view glitches many times a second.
-        if (settings.getAutoSortOption(mediaType) != sort) {
-            settings.setAutoSortOption(mediaType, sort)
-            notifyChildrenChanged?.invoke(MediaIds.tabIdOf(mediaType))
-        }
-        result.detach()
-        scope.launch {
-            if (!waitForCorrectState()) {
-                result.sendResult(null)
-                return@launch
-            }
-            result.sendResult(loadTabItems(mediaType, sort, favoritesOnly = false))
         }
     }
 
@@ -219,48 +150,6 @@ class AutoLibrary(
         }
         // Reuse the tab content path with favoritesOnly=true; header is suppressed there.
         handleTabContent(MediaIds.tabIdOf(mediaType), result, favoritesOnly = true)
-    }
-
-    private fun handleSubSortMenu(
-        id: String,
-        result: MediaBrowserServiceCompat.Result<List<MediaItem>>,
-    ) {
-        val parsed = MediaIds.parseSubSortMenu(id) ?: run {
-            result.sendResult(null)
-            return
-        }
-        val current = settings.getAutoSortOption(parsed.context)
-        val presets = AutoSortPresets.bySubContext[parsed.context] ?: run {
-            result.sendResult(null)
-            return
-        }
-        val items = presets.map { preset ->
-            sortPresetItem(
-                presetId = MediaIds.subSortApplyId(parsed.context, preset.option, parsed.parent),
-                title = preset.label,
-                isCurrent = preset.option == current,
-            )
-        }
-        result.sendResult(items)
-    }
-
-    private fun handleSubSortApply(
-        id: String,
-        result: MediaBrowserServiceCompat.Result<List<MediaItem>>,
-    ) {
-        val parsed = MediaIds.parseSubSortApply(id) ?: run {
-            result.sendResult(null)
-            return
-        }
-        if (settings.getAutoSortOption(parsed.context) != parsed.option) {
-            settings.setAutoSortOption(parsed.context, parsed.option)
-            notifyChildrenChanged?.invoke(parsed.parent.encode())
-        }
-        result.detach()
-        scope.launch {
-            val list = loadSubItems(parsed.context, parsed.parent, parsed.option)
-            result.sendResult(list)
-        }
     }
 
     private fun handleDrillDown(
@@ -277,23 +166,11 @@ class AutoLibrary(
         }
         result.detach()
         scope.launch {
-            val sort = settings.getAutoSortOption(context)
-            val items = loadSubItems(context, parent, sort) ?: run {
+            val items = loadSubItems(context, parent, defaultSortFor(context)) ?: run {
                 result.sendResult(null)
                 return@launch
             }
-            val header = buildList {
-                if (context != SubItemContext.ALBUM_TRACKS) {
-                    add(
-                        sortByPseudoItem(
-                            MediaIds.subSortMenuId(context, parent),
-                            AutoSortPresets.labelOf(context, sort),
-                        ),
-                    )
-                }
-                addAll(actionsForItem(id))
-            }
-            result.sendResult(header + items)
+            result.sendResult(actionsForItem(id) + items)
         }
     }
 
@@ -363,6 +240,19 @@ class AutoLibrary(
         val sorted =
             if (context == SubItemContext.PLAYLIST_TRACKS) items else items.clientSorted(sort)
         return sorted.map { it.toAutoMediaItem(baseUrl, true, defaultIconUri) }
+    }
+
+    // Hardcoded defaults — sorting UI is intentionally absent in AA. Per-list
+    // pickers turned out to be a footgun: AA prefetches children of every
+    // browsable preset, which (when coupled to persistence + parent invalidation)
+    // looped the browse view to OOM. Keeping the matrix flat sidesteps the
+    // entire surface.
+    private fun defaultSortFor(mediaType: MediaType): SortOption =
+        SortOption(SortField.NAME, descending = false)
+
+    private fun defaultSortFor(context: SubItemContext): SortOption = when (context) {
+        SubItemContext.PODCAST_EPISODES -> SortOption(SortField.RELEASE_DATE, descending = true)
+        else -> SortOption(SortField.NAME, descending = false)
     }
 
     private suspend fun waitForCorrectState(): Boolean =
@@ -486,17 +376,6 @@ class AutoLibrary(
             MediaItem.FLAG_BROWSABLE,
         )
 
-    private fun sortByPseudoItem(menuId: String, currentLabel: String): MediaItem =
-        MediaItem(
-            MediaDescriptionCompat.Builder()
-                .setTitle("Sort by")
-                .setSubtitle(currentLabel)
-                .setMediaId(menuId)
-                .setIconUri(android.R.drawable.ic_menu_sort_by_size.toUri(context))
-                .build(),
-            MediaItem.FLAG_BROWSABLE,
-        )
-
     private fun favoritesPseudoItem(favoritesId: String): MediaItem =
         MediaItem(
             MediaDescriptionCompat.Builder()
@@ -507,23 +386,12 @@ class AutoLibrary(
             MediaItem.FLAG_BROWSABLE,
         )
 
-    private fun sortPresetItem(presetId: String, title: String, isCurrent: Boolean): MediaItem =
-        MediaItem(
-            MediaDescriptionCompat.Builder()
-                .setTitle(if (isCurrent) "✓ $title" else title)
-                .setMediaId(presetId)
-                .build(),
-            MediaItem.FLAG_BROWSABLE,
-        )
-
     private companion object {
         const val WAIT_FOR_AUTHENTICATED_TIMEOUT_MS = 30_000L
     }
 }
 
-private const val SORT_APPLY_PARAMS_COUNT = 3
 private const val PARENT_REF_PARAMS_COUNT = 4
-private const val SUB_SORT_APPLY_PARAMS_COUNT = 4
 
 private const val PARENT_REF_ITEM_ID_PARAM_INDEX = 0
 private const val PARENT_REF_URI_PARAM_INDEX = 1
@@ -539,11 +407,7 @@ internal object MediaIds {
     const val TAB_AUDIOBOOKS = "auto_lib_audiobooks"
     const val QUEUE_OPTION_KEY = "auto_queue_option"
 
-    const val SORT_MENU_PREFIX = "auto_sortmenu_"
-    const val SORT_APPLY_PREFIX = "auto_sortapply_"
     const val FAVORITES_PREFIX = "auto_fav_"
-    const val SUB_SORT_MENU_PREFIX = "auto_subsortmenu_"
-    const val SUB_SORT_APPLY_PREFIX = "auto_subsortapply_"
 
     private val tabToType = mapOf(
         TAB_ARTISTS to MediaType.ARTIST,
@@ -558,51 +422,9 @@ internal object MediaIds {
     fun tabMediaTypeOf(id: String): MediaType? = tabToType[id]
     fun tabIdOf(type: MediaType): String = typeToTab.getValue(type)
 
-    fun sortMenuId(type: MediaType): String = "$SORT_MENU_PREFIX${type.name}"
-    fun sortMenuMediaTypeOf(id: String): MediaType? =
-        runCatching { MediaType.valueOf(id.removePrefix(SORT_MENU_PREFIX)) }.getOrNull()
-
-    fun sortApplyId(type: MediaType, option: SortOption): String =
-        "$SORT_APPLY_PREFIX${type.name}|${option.field.name}|${option.descending}"
-
-    fun parseSortApply(id: String): Pair<MediaType, SortOption>? {
-        val parts = id.removePrefix(SORT_APPLY_PREFIX).split("|")
-        if (parts.size != SORT_APPLY_PARAMS_COUNT) return null
-        val type = runCatching { MediaType.valueOf(parts[0]) }.getOrNull() ?: return null
-        val field = runCatching { SortField.valueOf(parts[1]) }.getOrNull() ?: return null
-        val desc = parts[2].toBooleanStrictOrNull() ?: return null
-        return type to SortOption(field, desc)
-    }
-
     fun favoritesId(type: MediaType): String = "$FAVORITES_PREFIX${type.name}"
     fun favoritesMediaTypeOf(id: String): MediaType? =
         runCatching { MediaType.valueOf(id.removePrefix(FAVORITES_PREFIX)) }.getOrNull()
-
-    fun subSortMenuId(context: SubItemContext, parent: ParentRef): String =
-        "$SUB_SORT_MENU_PREFIX${context.name}|${parent.encode()}"
-
-    fun parseSubSortMenu(id: String): SubSortMenuRef? {
-        val rest = id.removePrefix(SUB_SORT_MENU_PREFIX)
-        val sepIdx = rest.indexOf('|').takeIf { it >= 0 } ?: return null
-        val ctx = runCatching { SubItemContext.valueOf(rest.substring(0, sepIdx)) }.getOrNull()
-            ?: return null
-        val parent = ParentRef.parse(rest.substring(sepIdx + 1)) ?: return null
-        return SubSortMenuRef(ctx, parent)
-    }
-
-    fun subSortApplyId(context: SubItemContext, option: SortOption, parent: ParentRef): String =
-        "$SUB_SORT_APPLY_PREFIX${context.name}|${option.field.name}|${option.descending}|${parent.encode()}"
-
-    fun parseSubSortApply(id: String): SubSortApplyRef? {
-        val rest = id.removePrefix(SUB_SORT_APPLY_PREFIX)
-        val parts = rest.split("|", limit = 4)
-        if (parts.size != SUB_SORT_APPLY_PARAMS_COUNT) return null
-        val ctx = runCatching { SubItemContext.valueOf(parts[0]) }.getOrNull() ?: return null
-        val field = runCatching { SortField.valueOf(parts[1]) }.getOrNull() ?: return null
-        val desc = parts[2].toBooleanStrictOrNull() ?: return null
-        val parent = ParentRef.parse(parts[3]) ?: return null
-        return SubSortApplyRef(ctx, SortOption(field, desc), parent)
-    }
 }
 
 internal data class ParentRef(
@@ -613,7 +435,7 @@ internal data class ParentRef(
 ) {
     // Matches the existing 4-part `itemId__uri__mediaType__provider` encoding
     // produced in toMediaDescription, so parents discovered via drill-down IDs
-    // and re-encoded for sort sub-menus stay round-trip-safe.
+    // stay round-trip-safe.
     fun encode(): String = "${itemId}__${uri}__${type}__$provider"
 
     fun subItemContext(): SubItemContext? = when (type) {
@@ -637,89 +459,6 @@ internal data class ParentRef(
             )
         }
     }
-}
-
-internal data class SubSortMenuRef(val context: SubItemContext, val parent: ParentRef)
-internal data class SubSortApplyRef(
-    val context: SubItemContext,
-    val option: SortOption,
-    val parent: ParentRef,
-)
-
-private object AutoSortPresets {
-    data class Preset(val label: String, val option: SortOption)
-
-    private fun asc(field: SortField, label: String) =
-        Preset(label, SortOption(field, descending = false))
-
-    private fun desc(field: SortField, label: String) =
-        Preset(label, SortOption(field, descending = true))
-
-    val byTab: Map<MediaType, List<Preset>> = mapOf(
-        MediaType.ARTIST to listOf(
-            asc(SortField.NAME, "A–Z"),
-            desc(SortField.DATE_ADDED, "Recently added"),
-            desc(SortField.LAST_PLAYED, "Recently played"),
-            desc(SortField.PLAY_COUNT, "Most played"),
-        ),
-        MediaType.ALBUM to listOf(
-            asc(SortField.NAME, "A–Z"),
-            asc(SortField.ARTIST_NAME, "By artist"),
-            desc(SortField.YEAR, "Newest"),
-            desc(SortField.DATE_ADDED, "Recently added"),
-            desc(SortField.LAST_PLAYED, "Recently played"),
-            desc(SortField.PLAY_COUNT, "Most played"),
-        ),
-        MediaType.PLAYLIST to listOf(
-            asc(SortField.NAME, "A–Z"),
-            desc(SortField.DATE_ADDED, "Recently added"),
-            desc(SortField.DATE_MODIFIED, "Recently modified"),
-            desc(SortField.LAST_PLAYED, "Recently played"),
-            desc(SortField.PLAY_COUNT, "Most played"),
-        ),
-        MediaType.PODCAST to listOf(
-            desc(SortField.DATE_ADDED, "Recently added"),
-            desc(SortField.DATE_MODIFIED, "Recently updated"),
-            asc(SortField.NAME, "A–Z"),
-            desc(SortField.LAST_PLAYED, "Recently played"),
-        ),
-        MediaType.RADIO to listOf(
-            asc(SortField.NAME, "A–Z"),
-            desc(SortField.DATE_ADDED, "Recently added"),
-            desc(SortField.LAST_PLAYED, "Recently played"),
-            desc(SortField.PLAY_COUNT, "Most played"),
-        ),
-        MediaType.AUDIOBOOK to listOf(
-            asc(SortField.NAME, "A–Z"),
-            desc(SortField.DATE_ADDED, "Recently added"),
-            desc(SortField.LAST_PLAYED, "Recently played"),
-        ),
-    )
-
-    val bySubContext: Map<SubItemContext, List<Preset>> = mapOf(
-        SubItemContext.ARTIST_ALBUMS to listOf(
-            desc(SortField.YEAR, "Newest"),
-            asc(SortField.YEAR, "Oldest"),
-            asc(SortField.NAME, "A–Z"),
-        ),
-        SubItemContext.PLAYLIST_TRACKS to listOf(
-            asc(SortField.ORIGINAL, "Original"),
-            asc(SortField.NAME, "A–Z"),
-            asc(SortField.ARTIST_NAME, "By artist"),
-        ),
-        SubItemContext.PODCAST_EPISODES to listOf(
-            desc(SortField.RELEASE_DATE, "Newest"),
-            asc(SortField.RELEASE_DATE, "Oldest"),
-            asc(SortField.NAME, "A–Z"),
-        ),
-    )
-
-    fun labelOf(type: MediaType, option: SortOption): String =
-        byTab[type]?.firstOrNull { it.option == option }?.label ?: option.field.displayName
-
-    fun labelOf(context: SubItemContext, option: SortOption): String =
-        bySubContext[context]?.firstOrNull { it.option == option }?.label
-            ?: option.field.displayName
 }
 
 private fun SearchResult.toAutoMediaItems(

--- a/androidApp/src/main/kotlin/io/music_assistant/client/di/AppModule.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/di/AppModule.kt
@@ -6,6 +6,6 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
 fun appModule() = module {
-    single { AutoLibrary(androidContext(), get(), get()) }
+    single { AutoLibrary(androidContext(), get()) }
     single { SharedMediaSessionManager(androidContext()) }
 }

--- a/androidApp/src/main/kotlin/io/music_assistant/client/services/AndroidAutoPlaybackService.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/services/AndroidAutoPlaybackService.kt
@@ -94,34 +94,37 @@ class AndroidAutoPlaybackService : MediaBrowserServiceCompat() {
             }
         }
 
-        // Queue updates (separate MediaSession property — no conflict with playback state)
+        // Queue updates (separate MediaSession property — no conflict with playback state).
+        // Project to a stable id list and dedup: setQueue is an expensive IPC write that AA
+        // hosts react to (re-rendering, which can re-subscribe browse parents). Without
+        // dedup, every `_localPlayerData` emission — volume changes, optimistic bumps,
+        // anything — churns the AA UI even when the queue itself is unchanged.
         scope.launch {
-            currentPlayerData.filterNotNull().collect { playerData ->
-                when (val queueData = playerData.queue) {
-                    is DataState.Data -> {
-                        when (val queueItems = queueData.data.items) {
-                            is DataState.Data -> {
-                                val baseUrl = dataSource.apiClient.serverBaseUrl.value
-                                sharedSession.updateQueue(
-                                    queueItems.data.map { queueTrack ->
-                                    QueueItem(
-                                        (queueTrack.track as AppMediaItem).toMediaDescription(
-                                            baseUrl,
-                                            defaultIconUri,
-                                        ),
-                                        queueTrack.track.longId,
-                                    )
-                                },
-                                )
-                            }
-
-                            else -> sharedSession.updateQueue(emptyList())
-                        }
-                    }
-
-                    else -> sharedSession.updateQueue(emptyList())
+            currentPlayerData
+                .map { playerData ->
+                    val items = (playerData?.queue as? DataState.Data)
+                        ?.data?.items?.let { it as? DataState.Data }?.data
+                        .orEmpty()
+                    items
                 }
-            }
+                .distinctUntilChanged { old, new ->
+                    old.size == new.size &&
+                        old.zip(new).all { (a, b) -> a.track.longId == b.track.longId }
+                }
+                .collect { items ->
+                    val baseUrl = dataSource.apiClient.serverBaseUrl.value
+                    sharedSession.updateQueue(
+                        items.map { queueTrack ->
+                            QueueItem(
+                                (queueTrack.track as AppMediaItem).toMediaDescription(
+                                    baseUrl,
+                                    defaultIconUri,
+                                ),
+                                queueTrack.track.longId,
+                            )
+                        },
+                    )
+                }
         }
 
         dataSource.apiClient.onExternalConsumerActive()
@@ -270,13 +273,16 @@ class AndroidAutoPlaybackService : MediaBrowserServiceCompat() {
                             sharedSession.clearErrorState()
                             if (!wasAuthenticated) {
                                 wasAuthenticated = true
-                                notifyChildrenChanged(MediaIds.ROOT)
-                                notifyChildrenChanged(MediaIds.TAB_ARTISTS)
-                                notifyChildrenChanged(MediaIds.TAB_ALBUMS)
-                                notifyChildrenChanged(MediaIds.TAB_PLAYLISTS)
-                                notifyChildrenChanged(MediaIds.TAB_PODCASTS)
-                                notifyChildrenChanged(MediaIds.TAB_RADIO)
-                                notifyChildrenChanged(MediaIds.TAB_AUDIOBOOKS)
+                                // Route through library so cache is invalidated alongside
+                                // the AA host notification — otherwise stale entries would
+                                // stick around after a reconnect.
+                                library.invalidateAndNotify(MediaIds.ROOT)
+                                library.invalidateAndNotify(MediaIds.TAB_ARTISTS)
+                                library.invalidateAndNotify(MediaIds.TAB_ALBUMS)
+                                library.invalidateAndNotify(MediaIds.TAB_PLAYLISTS)
+                                library.invalidateAndNotify(MediaIds.TAB_PODCASTS)
+                                library.invalidateAndNotify(MediaIds.TAB_RADIO)
+                                library.invalidateAndNotify(MediaIds.TAB_AUDIOBOOKS)
                             }
                         }
                     }

--- a/androidApp/src/main/kotlin/io/music_assistant/client/services/AndroidAutoPlaybackService.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/services/AndroidAutoPlaybackService.kt
@@ -84,7 +84,6 @@ class AndroidAutoPlaybackService : MediaBrowserServiceCompat() {
         )
         sessionToken = token
         defaultIconUri = R.drawable.baseline_library_music_24.toUri(this)
-        library.notifyChildrenChanged = { parentId -> notifyChildrenChanged(parentId) }
 
         // Playback data collector — the primary writer for playback state.
         // SharedMediaSessionManager coordinates with error state: if an error is set,
@@ -382,7 +381,6 @@ class AndroidAutoPlaybackService : MediaBrowserServiceCompat() {
     }
 
     override fun onDestroy() {
-        library.notifyChildrenChanged = null
         dataSource.apiClient.onExternalConsumerInactive()
         sharedSession.release(isAutoService = true)
         scope.cancel()

--- a/androidApp/src/main/kotlin/io/music_assistant/client/services/AndroidAutoPlaybackService.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/services/AndroidAutoPlaybackService.kt
@@ -65,8 +65,11 @@ class AndroidAutoPlaybackService : MediaBrowserServiceCompat() {
     private val mediaNotificationData = currentPlayerData.filterNotNull()
         .map {
             MediaNotificationData.from(
-                it,
-                false,
+                playerData = it,
+                multiplePlayers = false,
+                effectiveElapsedSec = it.queueInfo?.id?.let { id ->
+                    dataSource.positionTracker.effectiveSec(id)
+                },
             )
         }
         .distinctUntilChanged { old, new -> MediaNotificationData.areTooSimilarToUpdate(old, new) }
@@ -273,16 +276,13 @@ class AndroidAutoPlaybackService : MediaBrowserServiceCompat() {
                             sharedSession.clearErrorState()
                             if (!wasAuthenticated) {
                                 wasAuthenticated = true
-                                // Route through library so cache is invalidated alongside
-                                // the AA host notification — otherwise stale entries would
-                                // stick around after a reconnect.
-                                library.invalidateAndNotify(MediaIds.ROOT)
-                                library.invalidateAndNotify(MediaIds.TAB_ARTISTS)
-                                library.invalidateAndNotify(MediaIds.TAB_ALBUMS)
-                                library.invalidateAndNotify(MediaIds.TAB_PLAYLISTS)
-                                library.invalidateAndNotify(MediaIds.TAB_PODCASTS)
-                                library.invalidateAndNotify(MediaIds.TAB_RADIO)
-                                library.invalidateAndNotify(MediaIds.TAB_AUDIOBOOKS)
+                                notifyChildrenChanged(MediaIds.ROOT)
+                                notifyChildrenChanged(MediaIds.TAB_ARTISTS)
+                                notifyChildrenChanged(MediaIds.TAB_ALBUMS)
+                                notifyChildrenChanged(MediaIds.TAB_PLAYLISTS)
+                                notifyChildrenChanged(MediaIds.TAB_PODCASTS)
+                                notifyChildrenChanged(MediaIds.TAB_RADIO)
+                                notifyChildrenChanged(MediaIds.TAB_AUDIOBOOKS)
                             }
                         }
                     }

--- a/androidApp/src/main/kotlin/io/music_assistant/client/services/AndroidAutoPlaybackService.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/services/AndroidAutoPlaybackService.kt
@@ -94,34 +94,34 @@ class AndroidAutoPlaybackService : MediaBrowserServiceCompat() {
             }
         }
 
-        // Queue updates (separate MediaSession property — no conflict with playback state)
+        // Queue updates (separate MediaSession property — no conflict with playback state).
+        // Project to track-id list and dedupe: setQueue is an IPC write that AA hosts react to
+        // (re-rendering the queue view, which can in turn re-subscribe browse parents). Without
+        // dedup, every localPlayer emission — even ones with byte-identical queues — churns AA.
         scope.launch {
-            currentPlayerData.filterNotNull().collect { playerData ->
-                when (val queueData = playerData.queue) {
-                    is DataState.Data -> {
-                        when (val queueItems = queueData.data.items) {
-                            is DataState.Data -> {
-                                val baseUrl = dataSource.apiClient.serverBaseUrl.value
-                                sharedSession.updateQueue(
-                                    queueItems.data.map { queueTrack ->
-                                    QueueItem(
-                                        (queueTrack.track as AppMediaItem).toMediaDescription(
-                                            baseUrl,
-                                            defaultIconUri,
-                                        ),
-                                        queueTrack.track.longId,
-                                    )
-                                },
-                                )
-                            }
-
-                            else -> sharedSession.updateQueue(emptyList())
-                        }
-                    }
-
-                    else -> sharedSession.updateQueue(emptyList())
+            currentPlayerData
+                .map { playerData ->
+                    val queueData = playerData?.queue as? DataState.Data
+                    (queueData?.data?.items as? DataState.Data)?.data.orEmpty()
                 }
-            }
+                .distinctUntilChanged { old, new ->
+                    old.size == new.size &&
+                        old.zip(new).all { (a, b) -> a.track.longId == b.track.longId }
+                }
+                .collect { items ->
+                    val baseUrl = dataSource.apiClient.serverBaseUrl.value
+                    sharedSession.updateQueue(
+                        items.map { queueTrack ->
+                            QueueItem(
+                                (queueTrack.track as AppMediaItem).toMediaDescription(
+                                    baseUrl,
+                                    defaultIconUri,
+                                ),
+                                queueTrack.track.longId,
+                            )
+                        },
+                    )
+                }
         }
 
         dataSource.apiClient.onExternalConsumerActive()

--- a/androidApp/src/main/kotlin/io/music_assistant/client/services/AndroidAutoPlaybackService.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/services/AndroidAutoPlaybackService.kt
@@ -94,34 +94,34 @@ class AndroidAutoPlaybackService : MediaBrowserServiceCompat() {
             }
         }
 
-        // Queue updates (separate MediaSession property — no conflict with playback state).
-        // Project to track-id list and dedupe: setQueue is an IPC write that AA hosts react to
-        // (re-rendering the queue view, which can in turn re-subscribe browse parents). Without
-        // dedup, every localPlayer emission — even ones with byte-identical queues — churns AA.
+        // Queue updates (separate MediaSession property — no conflict with playback state)
         scope.launch {
-            currentPlayerData
-                .map { playerData ->
-                    val queueData = playerData?.queue as? DataState.Data
-                    (queueData?.data?.items as? DataState.Data)?.data.orEmpty()
+            currentPlayerData.filterNotNull().collect { playerData ->
+                when (val queueData = playerData.queue) {
+                    is DataState.Data -> {
+                        when (val queueItems = queueData.data.items) {
+                            is DataState.Data -> {
+                                val baseUrl = dataSource.apiClient.serverBaseUrl.value
+                                sharedSession.updateQueue(
+                                    queueItems.data.map { queueTrack ->
+                                    QueueItem(
+                                        (queueTrack.track as AppMediaItem).toMediaDescription(
+                                            baseUrl,
+                                            defaultIconUri,
+                                        ),
+                                        queueTrack.track.longId,
+                                    )
+                                },
+                                )
+                            }
+
+                            else -> sharedSession.updateQueue(emptyList())
+                        }
+                    }
+
+                    else -> sharedSession.updateQueue(emptyList())
                 }
-                .distinctUntilChanged { old, new ->
-                    old.size == new.size &&
-                        old.zip(new).all { (a, b) -> a.track.longId == b.track.longId }
-                }
-                .collect { items ->
-                    val baseUrl = dataSource.apiClient.serverBaseUrl.value
-                    sharedSession.updateQueue(
-                        items.map { queueTrack ->
-                            QueueItem(
-                                (queueTrack.track as AppMediaItem).toMediaDescription(
-                                    baseUrl,
-                                    defaultIconUri,
-                                ),
-                                queueTrack.track.longId,
-                            )
-                        },
-                    )
-                }
+            }
         }
 
         dataSource.apiClient.onExternalConsumerActive()

--- a/androidApp/src/main/kotlin/io/music_assistant/client/services/AndroidAutoPlaybackService.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/services/AndroidAutoPlaybackService.kt
@@ -275,6 +275,9 @@ class AndroidAutoPlaybackService : MediaBrowserServiceCompat() {
                             sharedSession.clearErrorState()
                             if (!wasAuthenticated) {
                                 wasAuthenticated = true
+                                // Drop stale cached lists from a prior server session before
+                                // AA re-pulls. One-shot, not cyclic.
+                                library.invalidateCache()
                                 notifyChildrenChanged(MediaIds.ROOT)
                                 notifyChildrenChanged(MediaIds.TAB_ARTISTS)
                                 notifyChildrenChanged(MediaIds.TAB_ALBUMS)

--- a/androidApp/src/main/kotlin/io/music_assistant/client/services/MainMediaPlaybackService.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/services/MainMediaPlaybackService.kt
@@ -83,8 +83,11 @@ class MainMediaPlaybackService : MediaBrowserServiceCompat() {
         players.map { it.size > 1 },
     ) { player, moreThanOnePlayer ->
         MediaNotificationData.from(
-            player,
-            moreThanOnePlayer,
+            playerData = player,
+            multiplePlayers = moreThanOnePlayer,
+            effectiveElapsedSec = player.queueInfo?.id?.let { id ->
+                dataSource.positionTracker.effectiveSec(id)
+            },
         )
     }
         .distinctUntilChanged { old, new -> MediaNotificationData.areTooSimilarToUpdate(old, new) }

--- a/androidApp/src/main/kotlin/io/music_assistant/client/services/MediaNotificationData.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/services/MediaNotificationData.kt
@@ -21,22 +21,34 @@ data class MediaNotificationData(
     val duration: Long?,
 ) {
     companion object {
-        fun from(playerData: PlayerData, multiplePlayers: Boolean) =
-            MediaNotificationData(
-                multiplePlayers = multiplePlayers,
-                longItemId = playerData.player.currentMedia?.hashCode()?.toLong(),
-                name = playerData.player.currentMedia?.title,
-                artist = playerData.player.currentMedia?.artist,
-                album = playerData.player.currentMedia?.album,
-                repeatMode = playerData.queueInfo?.repeatMode,
-                shuffleEnabled = playerData.queueInfo?.shuffleEnabled,
-                isPlaying = playerData.player.isPlaying,
-                imageUrl = playerData.player.currentMedia?.imageUrl,
-                elapsedTime = playerData.queueInfo?.elapsedTime?.toLong()?.let { it * 1000 },
-                playerName = playerData.player.nameAndSuffix.takeIf { !playerData.isLocal },
-                duration = playerData.player.currentMedia?.duration?.toLong()
-                    ?.let { it * 1000 },
-            )
+        /**
+         * Builds the snapshot pushed to MediaSession. [effectiveElapsedSec]
+         * is the freshly-extrapolated position at write-time (computed by the
+         * data layer from anchor + elapsed wall clock). We use it directly
+         * instead of `playerData.queueInfo.elapsedTime` because the latter is
+         * only refreshed on `QueueAdded/UpdatedEvent` — not on the more
+         * frequent `QueueTimeUpdatedEvent` — and would freeze the AA /
+         * notification progress bar at a stale anchor on pause.
+         */
+        fun from(
+            playerData: PlayerData,
+            multiplePlayers: Boolean,
+            effectiveElapsedSec: Double?,
+        ) = MediaNotificationData(
+            multiplePlayers = multiplePlayers,
+            longItemId = playerData.player.currentMedia?.hashCode()?.toLong(),
+            name = playerData.player.currentMedia?.title,
+            artist = playerData.player.currentMedia?.artist,
+            album = playerData.player.currentMedia?.album,
+            repeatMode = playerData.queueInfo?.repeatMode,
+            shuffleEnabled = playerData.queueInfo?.shuffleEnabled,
+            isPlaying = playerData.player.isPlaying,
+            imageUrl = playerData.player.currentMedia?.imageUrl,
+            elapsedTime = effectiveElapsedSec?.toLong()?.let { it * 1000 },
+            playerName = playerData.player.nameAndSuffix.takeIf { !playerData.isLocal },
+            duration = playerData.player.currentMedia?.duration?.toLong()
+                ?.let { it * 1000 },
+        )
 
         fun areTooSimilarToUpdate(old: MediaNotificationData, new: MediaNotificationData): Boolean {
             if (old.copy(elapsedTime = null) != new.copy(elapsedTime = null)) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerRepository.kt
@@ -102,7 +102,12 @@ class LocalPlayerRepository(
                 updateOptimisticQueueInfo { it.copy(repeatMode = nextMode) }
             }
 
-            // SeekTo: position tracker in MainDataSource handles immediate feedback
+            is PlayerAction.SeekTo -> {
+                // Optimistic anchor jump so the slider doesn't snap back to the pre-seek
+                // position while waiting for the server's QueueTimeUpdatedEvent to confirm.
+                updateOptimisticQueueInfo { it.copy(elapsedTime = action.position.toDouble()) }
+            }
+
             // Next/Previous: no optimistic UI change (we don't know the next track)
             else -> {}
         }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -107,24 +107,6 @@ class MainDataSource(
     private val _queueInfos = MutableStateFlow<List<QueueInfo>>(emptyList())
     private val _providersIcons = MutableStateFlow<Map<String, ProviderIconModel>>(emptyMap())
 
-    // Position tracking for smooth local playback position calculation
-    private data class PositionTracker(
-        val queueId: String,
-        val basePosition: Double,  // Last known server position in seconds
-        val baseTimestamp: Long,   // System time when basePosition was captured
-        val isPlaying: Boolean,
-        val duration: Double?,      // Track duration for clamping
-    ) {
-        fun calculateCurrentPosition(): Double {
-            if (!isPlaying) return basePosition
-            val elapsedSinceBase = (currentTimeMillis() - baseTimestamp) / 1000.0
-            val calculated = basePosition + elapsedSinceBase
-            return duration?.let { calculated.coerceAtMost(it) } ?: calculated
-        }
-    }
-
-    private val _positionTrackers = MutableStateFlow<Map<String, PositionTracker>>(emptyMap())
-
     private val _players =
         combine(_serverPlayers, settings.playersSorting) { playersState, sortedIds ->
             when (playersState) {
@@ -241,34 +223,6 @@ class MainDataSource(
                         value + queueInfo
                     }
                 }
-            }
-        }
-
-        // Position calculation loop - runs independently to provide smooth position updates
-        launch {
-            while (isActive) {
-                // Only update positions if we have live or recovering data
-                val shouldUpdatePositions = when (val playersState = _serverPlayers.value) {
-                    is DataState.Data -> true
-                    is DataState.Stale -> playersState.reason == StaleReason.RECONNECTING
-                    else -> false
-                }
-
-                if (shouldUpdatePositions) {
-                    // Update QueueInfo with latest calculated positions
-                    _queueInfos.update { queues ->
-                        queues.map { queue ->
-                            val tracker = _positionTrackers.value[queue.id]
-                            if (tracker != null) {
-                                val calculatedPos = tracker.calculateCurrentPosition()
-                                queue.copy(elapsedTime = calculatedPos)
-                            } else {
-                                queue
-                            }
-                        }
-                    }
-                }
-                delay(500L) // Update position twice per second for smooth progress
             }
         }
 
@@ -766,8 +720,11 @@ class MainDataSource(
                         allPlayers.mapNotNull { it.asChildBindFor(player) }
                     }
                 if (isLocal && localData != null) {
-                    // Repository is source of truth. Overlay interpolated position from tracker
-                    // (repository has raw server position; queues has smooth 500ms interpolation).
+                    // Repository is source of truth for the local player; surface the
+                    // latest server-anchored `elapsedTime` from `_queueInfos` so the slider
+                    // re-anchors on `QueueTimeUpdatedEvent` (which writes only to
+                    // `_queueInfos`, not the repository). The slider does its own
+                    // sub-second interpolation locally — see `rememberInterpolatedPosition`.
                     val trackedElapsed = queues.find {
                         it.id == player.queueId || it.id == localPlayerId
                     }?.elapsedTime
@@ -819,7 +776,6 @@ class MainDataSource(
         log.i { "Clearing all cached data" }
         _serverPlayers.update { DataState.NoData() }
         _queueInfos.update { emptyList() }
-        _positionTrackers.update { emptyMap() }
         localPlayerRepository.clearState()
         // Note: _providersIcons deliberately NOT cleared (static data)
     }
@@ -1199,23 +1155,6 @@ class MainDataSource(
         // Apply optimistic update for local player (immediate, before async command)
         if (data.isLocal) {
             localPlayerRepository.applyOptimisticUpdate(data, action)
-            // Optimistic seek: update position tracker immediately
-            if (action is PlayerAction.SeekTo) {
-                Logger.e("SeekTo: ${action.position}")
-                data.queueInfo?.id?.let { queueId ->
-                    _positionTrackers.update { trackers ->
-                        trackers + (
-                                queueId to PositionTracker(
-                                    queueId = queueId,
-                                    basePosition = action.position.toDouble(),
-                                    baseTimestamp = currentTimeMillis(),
-                                    isPlaying = data.player.isPlaying,
-                                    duration = data.queueInfo.currentItem?.track?.duration,
-                                )
-                                )
-                    }
-                }
-            }
         }
         launch {
             val request = buildPlayerRequest(data, action) ?: return@launch
@@ -1441,19 +1380,6 @@ class MainDataSource(
                             _serverPlayers.update { oldState ->
                                 when (oldState) {
                                     is DataState.Data -> {
-                                        // Update position tracker with new playing state
-                                        data.queueId?.let { queueId ->
-                                            _positionTrackers.update { trackers ->
-                                                trackers[queueId]?.let { tracker ->
-                                                    trackers + (
-                                                            queueId to tracker.copy(
-                                                                isPlaying = data.isPlaying,
-                                                            )
-                                                            )
-                                                } ?: trackers
-                                            }
-                                        }
-                                        // State update
                                         val players = oldState.data
                                         DataState.Data(
                                             if (data.shouldBeShown) {
@@ -1487,22 +1413,6 @@ class MainDataSource(
                                 localPlayerRepository.onServerQueueUpdate(data)
                             }
 
-                            data.elapsedTime?.let { elapsed ->
-                                val player =
-                                    (_serverPlayers.value as? DataState.Data)?.data?.find { it.queueId == data.id }
-                                _positionTrackers.update { trackers ->
-                                    trackers + (
-                                            data.id to PositionTracker(
-                                                queueId = data.id,
-                                                basePosition = elapsed,
-                                                baseTimestamp = currentTimeMillis(),
-                                                isPlaying = player?.isPlaying ?: false,
-                                                duration = data.currentItem?.track?.duration,
-                                            )
-                                            )
-                                }
-                            }
-
                             // Upsert: replace if present, append if new.
                             _queueInfos.update { value ->
                                 if (value.any { it.id == data.id }) {
@@ -1525,23 +1435,6 @@ class MainDataSource(
                                     ?.find { it.id == localPlayerId }?.queueId == data.id
                             ) {
                                 localPlayerRepository.onServerQueueUpdate(data)
-                            }
-
-                            // Update position tracker if elapsedTime is present
-                            data.elapsedTime?.let { elapsed ->
-                                val player =
-                                    (_serverPlayers.value as? DataState.Data)?.data?.find { it.queueId == data.id }
-                                _positionTrackers.update { trackers ->
-                                    trackers + (
-                                            data.id to PositionTracker(
-                                                queueId = data.id,
-                                                basePosition = elapsed,
-                                                baseTimestamp = currentTimeMillis(),
-                                                isPlaying = player?.isPlaying ?: false,
-                                                duration = data.currentItem?.track?.duration,
-                                            )
-                                            )
-                                }
                             }
 
                             _queueInfos.update { value ->
@@ -1568,24 +1461,6 @@ class MainDataSource(
                             // Not staleness-gated: payload has no server-side
                             // `last_updated` to compare against. Relies on
                             // in-order WebSocket delivery instead.
-                            val oldQueue = _queueInfos.value.find { it.id == event.objectId }
-                            // Update position tracker
-                            event.objectId?.let { queueId ->
-                                val player =
-                                    (_serverPlayers.value as? DataState.Data)?.data?.find { it.queueId == queueId }
-                                _positionTrackers.update { trackers ->
-                                    trackers + (
-                                            queueId to PositionTracker(
-                                                queueId = queueId,
-                                                basePosition = event.data,
-                                                baseTimestamp = currentTimeMillis(),
-                                                isPlaying = player?.isPlaying ?: false,
-                                                duration = oldQueue?.currentItem?.track?.duration,
-                                            )
-                                            )
-                                }
-                            }
-
                             _queueInfos.update { value ->
                                 value.map {
                                     if (it.id == event.objectId) it.copy(elapsedTime = event.data) else it
@@ -1594,21 +1469,9 @@ class MainDataSource(
                         }
 
                         is MediaItemPlayedEvent -> {
-                            _queueInfos.value.find { queue ->
-                                queue.currentItem?.track?.uri == event.data.uri
-                            }?.id?.let {
-                                _positionTrackers.update { trackers ->
-                                    trackers + (
-                                            it to PositionTracker(
-                                                queueId = it,
-                                                basePosition = event.data.secondsPlayed,
-                                                baseTimestamp = currentTimeMillis(),
-                                                isPlaying = event.data.isPlaying,
-                                                duration = event.data.duration,
-                                            )
-                                            )
-                                }
-                            }
+                            // Position-tracking removed; the slider interpolates locally
+                            // from `(queueInfo.elapsedTime, isPlaying, duration)`. Server
+                            // anchors flow via `QueueTimeUpdatedEvent` above.
                         }
 
                         is MediaItemUpdatedEvent -> {
@@ -1749,25 +1612,6 @@ class MainDataSource(
                         ?.find { it.id == localPlayerId }?.queueId
                     list.find { it.id == localPlayerId || it.id == localQueueId }
                         ?.let { localPlayerRepository.onServerQueueUpdate(it) }
-
-                    // Initialize position trackers from initial queue data
-                    list.forEach { queue ->
-                        queue.elapsedTime?.let { elapsed ->
-                            val player =
-                                (_serverPlayers.value as? DataState.Data)?.data?.find { it.queueId == queue.id }
-                            _positionTrackers.update { trackers ->
-                                trackers + (
-                                        queue.id to PositionTracker(
-                                            queueId = queue.id,
-                                            basePosition = elapsed,
-                                            baseTimestamp = currentTimeMillis(),
-                                            isPlaying = player?.isPlaying ?: false,
-                                            duration = queue.currentItem?.track?.duration,
-                                        )
-                                        )
-                            }
-                        }
-                    }
                 }
         }
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -1216,7 +1216,9 @@ class MainDataSource(
                 Request.Player.simpleCommand(playerId = data.playerId, command = "pause")
 
             PlayerAction.Next -> {
-                val currentPos = data.queueInfo?.elapsedTime ?: 0.0
+                val currentPos = data.queueInfo?.id
+                    ?.let(positionTracker::effectiveSec)
+                    ?: data.queueInfo?.elapsedTime ?: 0.0
                 (data.queueInfo?.currentItem?.track as? AppMediaItem.Audiobook)
                     ?.chapters?.firstOrNull { it.start > currentPos }?.start
                     ?.let { Request.Player.seek(queueId = data.playerId, position = it.toLong()) }
@@ -1224,7 +1226,9 @@ class MainDataSource(
             }
 
             PlayerAction.Previous -> {
-                val currentPos = data.queueInfo?.elapsedTime ?: 0.0
+                val currentPos = data.queueInfo?.id
+                    ?.let(positionTracker::effectiveSec)
+                    ?: data.queueInfo?.elapsedTime ?: 0.0
                 (data.queueInfo?.currentItem?.track as? AppMediaItem.Audiobook)
                     ?.chapters?.takeIf { it.isNotEmpty() }
                     ?.let { chapters ->

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -76,7 +76,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -107,6 +107,16 @@ class MainDataSource(
     private val _queueInfos = MutableStateFlow<List<QueueInfo>>(emptyList())
     private val _providersIcons = MutableStateFlow<Map<String, ProviderIconModel>>(emptyMap())
 
+    /**
+     * Single source of truth for live elapsed-time per queue. Server events
+     * write anchors here, play/pause transitions snapshot the interpolated
+     * position. All consumers (in-app slider, MediaSession writes for AA +
+     * notification, iOS NowPlaying, audiobook chapter logic) read from this
+     * tracker — synchronously via [PlayerPositionTracker.effectiveSec] or as
+     * a smoothly-ticking flow via [PlayerPositionTracker.observe].
+     */
+    val positionTracker: PlayerPositionTracker = PlayerPositionTracker()
+
     private val _players =
         combine(_serverPlayers, settings.playersSorting) { playersState, sortedIds ->
             when (playersState) {
@@ -223,7 +233,29 @@ class MainDataSource(
                         value + queueInfo
                     }
                 }
+                queueInfo.elapsedTime?.let {
+                    positionTracker.setAnchor(
+                        queueId = queueInfo.id,
+                        elapsedSec = it,
+                        durationSec = queueInfo.currentItem?.track?.duration,
+                    )
+                }
             }
+        }
+
+        // Mirror play state into the tracker. setPlaying snapshots the
+        // interpolated position on transitions so pause/resume don't fold
+        // pause-duration into the next forward step. Cheap dedup inside.
+        launch {
+            playersData
+                .mapNotNull { (it as? DataState.Data)?.data }
+                .collect { list ->
+                    list.forEach { pd ->
+                        pd.queueInfo?.id?.let { queueId ->
+                            positionTracker.setPlaying(queueId, pd.player.isPlaying)
+                        }
+                    }
+                }
         }
 
         launch {
@@ -609,7 +641,12 @@ class MainDataSource(
                             album = track.parentName,
                             artworkUrl = track.imageInfo?.url(apiClient.serverBaseUrl.value),
                             duration = track.duration,
-                            elapsedTime = pd.queueInfo.elapsedTime,
+                            // Read live position from the tracker rather than the stale
+                            // anchor on `pd.queueInfo` (which is only updated by
+                            // QueueAdded/UpdatedEvent, not by QueueTimeUpdatedEvent).
+                            elapsedTime = pd.queueInfo.id.let {
+                                positionTracker.effectiveSec(it)
+                            } ?: pd.queueInfo.elapsedTime,
                             isPlaying = pd.player.isPlaying,
                         )
                     }
@@ -776,6 +813,7 @@ class MainDataSource(
         log.i { "Clearing all cached data" }
         _serverPlayers.update { DataState.NoData() }
         _queueInfos.update { emptyList() }
+        positionTracker.clear()
         localPlayerRepository.clearState()
         // Note: _providersIcons deliberately NOT cleared (static data)
     }
@@ -1421,6 +1459,16 @@ class MainDataSource(
                                     value + data
                                 }
                             }
+                            data.elapsedTime?.let { elapsed ->
+                                val player = (_serverPlayers.value as? DataState.Data)
+                                    ?.data?.find { it.queueId == data.id }
+                                positionTracker.setAnchor(
+                                    queueId = data.id,
+                                    elapsedSec = elapsed,
+                                    isPlaying = player?.isPlaying,
+                                    durationSec = data.currentItem?.track?.duration,
+                                )
+                            }
                         }
 
                         is QueueUpdatedEvent -> {
@@ -1442,6 +1490,16 @@ class MainDataSource(
                                     if (it.id == data.id) data else it
                                 }
                             }
+                            data.elapsedTime?.let { elapsed ->
+                                val player = (_serverPlayers.value as? DataState.Data)
+                                    ?.data?.find { it.queueId == data.id }
+                                positionTracker.setAnchor(
+                                    queueId = data.id,
+                                    elapsedSec = elapsed,
+                                    isPlaying = player?.isPlaying,
+                                    durationSec = data.currentItem?.track?.duration,
+                                )
+                            }
                         }
 
                         is QueueItemsUpdatedEvent -> {
@@ -1451,6 +1509,16 @@ class MainDataSource(
                                 value.map {
                                     if (it.id == data.id) data else it
                                 }
+                            }
+                            data.elapsedTime?.let { elapsed ->
+                                val player = (_serverPlayers.value as? DataState.Data)
+                                    ?.data?.find { it.queueId == data.id }
+                                positionTracker.setAnchor(
+                                    queueId = data.id,
+                                    elapsedSec = elapsed,
+                                    isPlaying = player?.isPlaying,
+                                    durationSec = data.currentItem?.track?.duration,
+                                )
                             }
                             (playersData.value as? DataState.Data)?.data?.firstOrNull {
                                 it.queueId == data.id
@@ -1465,6 +1533,12 @@ class MainDataSource(
                                 value.map {
                                     if (it.id == event.objectId) it.copy(elapsedTime = event.data) else it
                                 }
+                            }
+                            event.objectId?.let { queueId ->
+                                positionTracker.setAnchor(
+                                    queueId = queueId,
+                                    elapsedSec = event.data,
+                                )
                             }
                         }
 
@@ -1605,6 +1679,18 @@ class MainDataSource(
             apiClient.sendRequest(Request.Queue.all())
                 .resultAs<List<ServerQueue>>()?.map { it.toQueue() }?.let { list ->
                     _queueInfos.update { list }
+                    list.forEach { queueInfo ->
+                        queueInfo.elapsedTime?.let { elapsed ->
+                            val player = (_serverPlayers.value as? DataState.Data)
+                                ?.data?.find { it.queueId == queueInfo.id }
+                            positionTracker.setAnchor(
+                                queueId = queueInfo.id,
+                                elapsedSec = elapsed,
+                                isPlaying = player?.isPlaying,
+                                durationSec = queueInfo.currentItem?.track?.duration,
+                            )
+                        }
+                    }
 
                     // Forward local player's queue to repository
                     val localPlayerId = settings.sendspinClientId.value

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/PlayerPositionTracker.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/PlayerPositionTracker.kt
@@ -1,0 +1,138 @@
+package io.music_assistant.client.data
+
+import io.music_assistant.client.utils.currentTimeMillis
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
+
+/**
+ * Single source of truth for "what elapsed-time is each queue at, right now".
+ *
+ * Server events (`QueueTimeUpdatedEvent`, `QueueAddedEvent`, ...) write
+ * anchors here. Play/pause transitions snapshot the interpolated position so
+ * the pause duration doesn't fold into the next forward step. Consumers
+ * (in-app slider, MediaSession writes for AA + notification, iOS NowPlaying,
+ * audiobook chapter logic) all read the same source — synchronously via
+ * [effectiveSec] or as a smoothly-ticking flow via [observe].
+ *
+ * No background tick: the cold [observe] flow ticks at 500 ms only while a
+ * collector is attached AND the queue is playing. Sync reads are O(1) map
+ * lookups — no allocations, no ipc.
+ */
+class PlayerPositionTracker {
+    /** Anchor data for a single queue. */
+    data class Anchor(
+        val elapsedSec: Double,
+        val wallMs: Long,
+        val isPlaying: Boolean,
+        val durationSec: Double?,
+    ) {
+        /** Position right now: anchor + wall-time elapsed since anchor (capped at duration). */
+        fun effectiveNow(): Double {
+            if (!isPlaying) return elapsedSec
+            val advanced = elapsedSec + (currentTimeMillis() - wallMs) / 1000.0
+            return durationSec?.let { advanced.coerceAtMost(it) } ?: advanced
+        }
+    }
+
+    private val anchors = MutableStateFlow<Map<String, Anchor>>(emptyMap())
+
+    /**
+     * Server-anchored update. Pass `isPlaying`/`durationSec` when known;
+     * `null` preserves the existing values (useful for `QueueTimeUpdatedEvent`
+     * which only carries the new elapsed value).
+     */
+    fun setAnchor(
+        queueId: String,
+        elapsedSec: Double,
+        isPlaying: Boolean? = null,
+        durationSec: Double? = null,
+    ) {
+        anchors.update { existing ->
+            val current = existing[queueId]
+            existing + (
+                queueId to Anchor(
+                    elapsedSec = elapsedSec,
+                    wallMs = currentTimeMillis(),
+                    isPlaying = isPlaying ?: current?.isPlaying ?: false,
+                    durationSec = durationSec ?: current?.durationSec,
+                )
+            )
+        }
+    }
+
+    /**
+     * Play/pause transition. Snapshots the current interpolated position as
+     * the new anchor so neither the slider nor MediaSession sees a jump:
+     * - Pausing: anchor advances to "where we were", isPlaying=false → static.
+     * - Resuming: same anchor, wallMs reset to now, isPlaying=true → forward.
+     */
+    fun setPlaying(queueId: String, isPlaying: Boolean) {
+        anchors.update { existing ->
+            val current = existing[queueId] ?: return@update existing
+            if (current.isPlaying == isPlaying) return@update existing
+            existing + (
+                queueId to current.copy(
+                    elapsedSec = current.effectiveNow(),
+                    wallMs = currentTimeMillis(),
+                    isPlaying = isPlaying,
+                )
+            )
+        }
+    }
+
+    /** O(1) read of latest interpolated position. */
+    fun effectiveSec(queueId: String): Double? = anchors.value[queueId]?.effectiveNow()
+
+    /**
+     * Cold flow of interpolated position. Emits immediately on subscription,
+     * then either:
+     * - re-emits on every anchor change (track flip, seek, server scrub,
+     *   pause/resume), AND
+     * - ticks at 500 ms while the queue is playing.
+     *
+     * Stops ticking when the queue is paused (waits for the next anchor
+     * change). Cancels cleanly when the collector unsubscribes.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun observe(queueId: String): Flow<Double> = anchors
+        .map { it[queueId] }
+        .distinctUntilChanged()
+        .flatMapLatest { anchor ->
+            if (anchor == null) {
+                flowOf(0.0)
+            } else {
+                flow {
+                    while (currentCoroutineContext().isActive) {
+                        emit(anchor.effectiveNow())
+                        if (!anchor.isPlaying) break
+                        delay(TICK_MS)
+                    }
+                }
+            }
+        }
+
+    /** Drop a queue's anchor (e.g., when the queue is removed). */
+    fun remove(queueId: String) {
+        anchors.update { it - queueId }
+    }
+
+    /** Clear all anchors (disconnect / reset). */
+    fun clear() {
+        anchors.update { emptyMap() }
+    }
+
+    private companion object {
+        const val TICK_MS = 500L
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/PlayerPositionTracker.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/PlayerPositionTracker.kt
@@ -2,7 +2,6 @@ package io.music_assistant.client.data
 
 import io.music_assistant.client.utils.currentTimeMillis
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/SettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/SettingsRepository.kt
@@ -355,30 +355,6 @@ class SettingsRepository(
         settings.putString("sort_sub_${context.name}", "${option.field.name}:${option.descending}")
     }
 
-    // Android Auto keeps its own per-type sort independent of the main app: the
-    // car UI exposes a curated subset of presets, so blending them risks leaving
-    // a "Custom" subtitle with no matching menu entry. Defaults still come from
-    // SortConfig — they happen to match the AA matrix.
-    fun getAutoSortOption(mediaType: MediaType): SortOption {
-        val raw = settings.getStringOrNull("auto_sort_${mediaType.name}")
-            ?: return SortConfig.defaultFor(mediaType)
-        return parseSortOption(raw) ?: SortConfig.defaultFor(mediaType)
-    }
-
-    fun setAutoSortOption(mediaType: MediaType, option: SortOption) {
-        settings.putString("auto_sort_${mediaType.name}", "${option.field.name}:${option.descending}")
-    }
-
-    fun getAutoSortOption(context: SubItemContext): SortOption {
-        val raw = settings.getStringOrNull("auto_sort_sub_${context.name}")
-            ?: return SortConfig.defaultFor(context)
-        return parseSortOption(raw) ?: SortConfig.defaultFor(context)
-    }
-
-    fun setAutoSortOption(context: SubItemContext, option: SortOption) {
-        settings.putString("auto_sort_sub_${context.name}", "${option.field.name}:${option.descending}")
-    }
-
     private fun parseSortOption(raw: String): SortOption? {
         val parts = raw.split(":")
         if (parts.size != 2) return null

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
@@ -60,6 +60,9 @@ class HomeScreenViewModel(
         settings.setSendspinStaticDelayMs(settings.sendspinStaticDelayMs.value + deltaMs)
     }
 
+    /** Live elapsed-time flow for the slider. Ticks at 500 ms only while playing + subscribed. */
+    fun observePosition(queueId: String) = dataSource.positionTracker.observe(queueId)
+
     private val _recommendationsState = MutableStateFlow(
         RecommendationsState(
             connectionState = SessionState.Disconnected.Initial,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -442,6 +442,7 @@ private fun Players(
             localPlayerId = homeScreenViewModel.localPlayerId,
             onAdjustPlaybackDelay = homeScreenViewModel::adjustSendspinStaticDelayMs,
             fetchColors = fetchColors,
+            observePosition = homeScreenViewModel::observePosition,
             navigateToItem = { item ->
                 backStack.add(
                     MainNav.ItemDetails(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
@@ -23,12 +23,11 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -52,10 +51,8 @@ import io.music_assistant.client.ui.compose.common.icons.AlbumIcon
 import io.music_assistant.client.ui.compose.common.icons.TrackIcon
 import io.music_assistant.client.ui.compose.common.painters.rememberPlaceholderPainter
 import io.music_assistant.client.ui.inactive
-import io.music_assistant.client.utils.currentTimeMillis
 import io.music_assistant.client.utils.formatDuration
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
+import kotlinx.coroutines.flow.Flow
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.cd_playing
 import musicassistantclient.composeapp.generated.resources.players_nothing
@@ -186,64 +183,6 @@ fun CompactPlayerItem(
     }
 }
 
-/**
- * Smooth slider progression without depending on a 2 Hz data-layer tick.
- *
- * `anchor` is the last server-confirmed position. The visible value [current]
- * advances forward at wall-clock rate while playing, freezes while paused, and
- * snaps to a new anchor when (and only when) the anchor actually changes —
- * server scrub, user seek, track flip. Crucially, pause/resume transitions
- * do NOT reset `current`: the slider stays where it visually was, so there's
- * no snap-back to a stale anchor when you pause.
- */
-@Composable
-private fun rememberInterpolatedPosition(
-    anchor: Double?,
-    isPlaying: Boolean,
-    duration: Double?,
-): Float {
-    if (anchor == null) return 0f
-    val anchorState = rememberUpdatedState(anchor)
-    val durationState = rememberUpdatedState(duration)
-    val isPlayingState = rememberUpdatedState(isPlaying)
-    var current by remember { mutableStateOf(anchor) }
-    LaunchedEffect(Unit) {
-        var lastObservedAnchor = anchorState.value
-        var lastTickWallTime = currentTimeMillis()
-        var wasPlaying = isPlayingState.value
-        while (isActive) {
-            val a = anchorState.value
-            val playing = isPlayingState.value
-            val now = currentTimeMillis()
-            // Resume detection: rebase wall-time so the pause duration doesn't
-            // get folded into the next forward-advance step.
-            if (playing && !wasPlaying) {
-                lastTickWallTime = now
-            }
-            wasPlaying = playing
-            when {
-                a != lastObservedAnchor -> {
-                    // Real anchor change (seek / scrub / track flip). Snap to it.
-                    current = a
-                    lastObservedAnchor = a
-                    lastTickWallTime = now
-                }
-
-                playing -> {
-                    val deltaSec = (now - lastTickWallTime) / 1000.0
-                    val advanced = current + deltaSec
-                    current = durationState.value?.let { advanced.coerceAtMost(it) } ?: advanced
-                    lastTickWallTime = now
-                }
-                // Paused with no anchor change: leave `current` and `lastTickWallTime`
-                // alone — the resume branch above will rebase wall-time on transition.
-            }
-            delay(500)
-        }
-    }
-    return current.toFloat()
-}
-
 @Composable
 private fun trackNameAndContentDescription(title: String?): Pair<String, String> {
     val playingContentDescription = if (title != null) {
@@ -263,6 +202,7 @@ fun FullPlayerItem(
     colors: PlayerColors,
     playerAction: (PlayerData, PlayerAction) -> Unit,
     @Suppress("UnusedParameter") onFavoriteClick: (AppMediaItem) -> Unit, // FIXME inconsistent stuff happening
+    livePositionFlow: Flow<Double>?,
 ) {
     val currentMedia = item.player.currentMedia
     val onPrimaryContainer = MaterialTheme.colorScheme.onPrimaryContainer
@@ -362,14 +302,14 @@ fun FullPlayerItem(
 
         val duration = currentMedia?.duration?.takeIf { it > 0 }?.toFloat()
 
-        // Local interpolation off the server-anchored elapsed time. Recomposition
-        // scope is limited to this slider — the marquee, art, controls etc.
-        // recompose only on real state changes.
-        val displayPosition = rememberInterpolatedPosition(
-            anchor = item.queueInfo?.elapsedTime,
-            isPlaying = item.player.isPlaying,
-            duration = currentMedia?.duration,
-        )
+        // Live position from PlayerPositionTracker — single source of truth shared
+        // with notification + Android Auto. Recomposition scope is limited to this
+        // slider; the marquee/art/controls only recompose on real state changes.
+        val displayPosition = livePositionFlow
+            ?.collectAsStateWithLifecycle(initialValue = item.queueInfo?.elapsedTime ?: 0.0)
+            ?.value?.toFloat()
+            ?: item.queueInfo?.elapsedTime?.toFloat()
+            ?: 0f
 
         // Track user drag state separately
         var userDragPosition by remember { mutableStateOf<Float?>(null) }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -190,11 +189,12 @@ fun CompactPlayerItem(
 /**
  * Smooth slider progression without depending on a 2 Hz data-layer tick.
  *
- * `anchor` is the last server-confirmed position (re-anchored on
- * `QueueTimeUpdatedEvent`, optimistic seek, track flip). The effect lives
- * across anchor changes — it observes them inside the loop instead of
- * cancelling/restarting on each one. This avoids both per-anchor allocation
- * churn AND visible snap-back when the server smooths position at high rate.
+ * `anchor` is the last server-confirmed position. The visible value [current]
+ * advances forward at wall-clock rate while playing, freezes while paused, and
+ * snaps to a new anchor when (and only when) the anchor actually changes —
+ * server scrub, user seek, track flip. Crucially, pause/resume transitions
+ * do NOT reset `current`: the slider stays where it visually was, so there's
+ * no snap-back to a stale anchor when you pause.
  */
 @Composable
 private fun rememberInterpolatedPosition(
@@ -205,25 +205,39 @@ private fun rememberInterpolatedPosition(
     if (anchor == null) return 0f
     val anchorState = rememberUpdatedState(anchor)
     val durationState = rememberUpdatedState(duration)
+    val isPlayingState = rememberUpdatedState(isPlaying)
     var current by remember { mutableStateOf(anchor) }
-    LaunchedEffect(isPlaying) {
-        if (!isPlaying) {
-            // Paused: track anchor changes (e.g., user seek while paused) without
-            // running the local interpolator.
-            snapshotFlow { anchorState.value }.collect { current = it }
-            return@LaunchedEffect
-        }
-        // Playing: re-base on each observed anchor, advance locally between.
-        var baseAnchor = anchorState.value
-        var baseTime = currentTimeMillis()
+    LaunchedEffect(Unit) {
+        var lastObservedAnchor = anchorState.value
+        var lastTickWallTime = currentTimeMillis()
+        var wasPlaying = isPlayingState.value
         while (isActive) {
             val a = anchorState.value
-            if (a != baseAnchor) {
-                baseAnchor = a
-                baseTime = currentTimeMillis()
+            val playing = isPlayingState.value
+            val now = currentTimeMillis()
+            // Resume detection: rebase wall-time so the pause duration doesn't
+            // get folded into the next forward-advance step.
+            if (playing && !wasPlaying) {
+                lastTickWallTime = now
             }
-            val advanced = baseAnchor + (currentTimeMillis() - baseTime) / 1000.0
-            current = durationState.value?.let { advanced.coerceAtMost(it) } ?: advanced
+            wasPlaying = playing
+            when {
+                a != lastObservedAnchor -> {
+                    // Real anchor change (seek / scrub / track flip). Snap to it.
+                    current = a
+                    lastObservedAnchor = a
+                    lastTickWallTime = now
+                }
+
+                playing -> {
+                    val deltaSec = (now - lastTickWallTime) / 1000.0
+                    val advanced = current + deltaSec
+                    current = durationState.value?.let { advanced.coerceAtMost(it) } ?: advanced
+                    lastTickWallTime = now
+                }
+                // Paused with no anchor change: leave `current` and `lastTickWallTime`
+                // alone — the resume branch above will rebase wall-time on transition.
+            }
             delay(500)
         }
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -32,8 +31,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
@@ -85,18 +82,77 @@ fun CompactPlayerItem(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Start,
         ) {
-            CompactPlayerArt(
-                hasMedia = currentMedia != null,
-                imageUrl = currentMedia?.imageUrl,
-                title = currentMedia?.title,
-                dominant = colors.dominant,
-                onPrimaryContainer = onPrimaryContainer,
-            )
-            CompactPlayerText(
-                title = currentMedia?.title,
-                subtitle = currentMedia?.subtitle,
-                showCannotPlay = item.queueInfo?.currentItem?.isPlayable == showAdditionalControls,
-            )
+            // Album cover on the far left
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(colors.dominant.alphaOn(currentMedia != null)),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (currentMedia != null) {
+                    val placeholder = rememberPlaceholderPainter(
+                        backgroundColor = colors.dominant,
+                        iconColor = onPrimaryContainer,
+                        icon = TrackIcon,
+                    )
+                    AsyncImage(
+                        placeholder = placeholder,
+                        fallback = placeholder,
+                        model = currentMedia.imageUrl,
+                        contentDescription = currentMedia.title,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                } else {
+                    Icon(
+                        imageVector = AlbumIcon,
+                        contentDescription = null,
+                        modifier = Modifier.size(24.dp),
+                        tint = onPrimaryContainer.inactive(),
+                    )
+                }
+            }
+
+            // Track info
+            val (trackName, trackContentDescription) = trackNameAndContentDescription(currentMedia?.title)
+            Column(
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .clearAndSetSemantics {
+                        contentDescription = trackContentDescription
+                    },
+            ) {
+                Text(
+                    modifier = Modifier.basicMarquee().alphaOn(currentMedia?.title != null),
+                    text = trackName,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                currentMedia?.subtitle?.let {
+                    Text(
+                        modifier = Modifier.basicMarquee(),
+                        text = it,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                } ?: run {
+                    if (item.queueInfo?.currentItem?.isPlayable == showAdditionalControls) {
+                        Text(
+                            text = "Cannot play this item",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.inactive(),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+            }
         }
 
         PlayerControls(
@@ -122,197 +178,6 @@ fun CompactPlayerItem(
                 )
             }
         }
-    }
-}
-
-// Stable-input subtree: skips recomposition when title/subtitle/imageUrl are unchanged,
-// so the basicMarquee animation does NOT re-anchor on every 2 Hz position-update tick.
-@Composable
-private fun CompactPlayerArt(
-    hasMedia: Boolean,
-    imageUrl: String?,
-    title: String?,
-    dominant: Color,
-    onPrimaryContainer: Color,
-) {
-    Box(
-        modifier = Modifier
-            .size(48.dp)
-            .clip(RoundedCornerShape(8.dp))
-            .background(dominant.alphaOn(hasMedia)),
-        contentAlignment = Alignment.Center,
-    ) {
-        if (hasMedia) {
-            val placeholder = rememberPlaceholderPainter(
-                backgroundColor = dominant,
-                iconColor = onPrimaryContainer,
-                icon = TrackIcon,
-            )
-            AsyncImage(
-                placeholder = placeholder,
-                fallback = placeholder,
-                model = imageUrl,
-                contentDescription = title,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier.fillMaxSize(),
-            )
-        } else {
-            Icon(
-                imageVector = AlbumIcon,
-                contentDescription = null,
-                modifier = Modifier.size(24.dp),
-                tint = onPrimaryContainer.inactive(),
-            )
-        }
-    }
-}
-
-@Composable
-private fun CompactPlayerText(
-    title: String?,
-    subtitle: String?,
-    showCannotPlay: Boolean,
-) {
-    val (trackName, trackContentDescription) = trackNameAndContentDescription(title)
-    Column(
-        modifier = Modifier
-            .padding(horizontal = 16.dp)
-            .clearAndSetSemantics {
-                contentDescription = trackContentDescription
-            },
-    ) {
-        Text(
-            modifier = Modifier.basicMarquee().alphaOn(title != null),
-            text = trackName,
-            style = MaterialTheme.typography.bodyLarge,
-            fontWeight = FontWeight.Medium,
-            color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-        subtitle?.let {
-            Text(
-                modifier = Modifier.basicMarquee(),
-                text = it,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        } ?: run {
-            if (showCannotPlay) {
-                Text(
-                    text = "Cannot play this item",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.inactive(),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun ColumnScope.FullPlayerArt(
-    hasMedia: Boolean,
-    imageUrl: String?,
-    title: String?,
-    defaultIcon: ImageVector,
-    dominant: Color,
-    onPrimaryContainer: Color,
-) {
-    Box(
-        modifier = Modifier
-            .weight(1f, fill = false)
-            .aspectRatio(1f)
-            .heightIn(max = 500.dp)
-            .clip(RoundedCornerShape(16.dp))
-            .background(dominant.alphaOn(hasMedia)),
-        contentAlignment = Alignment.Center,
-    ) {
-        if (hasMedia) {
-            val placeholder = rememberPlaceholderPainter(
-                backgroundColor = dominant,
-                iconColor = onPrimaryContainer,
-                icon = defaultIcon,
-            )
-            imageUrl?.let {
-                AsyncImage(
-                    placeholder = placeholder,
-                    fallback = placeholder,
-                    model = it,
-                    contentDescription = title,
-                    contentScale = ContentScale.Crop,
-                    modifier = Modifier.fillMaxSize(),
-                )
-            } ?: Icon(
-                imageVector = defaultIcon,
-                contentDescription = null,
-                modifier = Modifier.size(120.dp),
-                tint = onPrimaryContainer,
-            )
-        } else {
-            Icon(
-                imageVector = AlbumIcon,
-                contentDescription = null,
-                modifier = Modifier.size(120.dp),
-                tint = onPrimaryContainer.inactive(),
-            )
-        }
-    }
-}
-
-@Composable
-private fun FullPlayerText(
-    title: String?,
-    subtitle: String?,
-    isUnplayable: Boolean,
-    audioFormat: String,
-) {
-    val (trackName, trackContentDescription) = trackNameAndContentDescription(title)
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clearAndSetSemantics {
-                contentDescription = trackContentDescription
-            },
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Text(
-            modifier = Modifier.basicMarquee().alphaOn(title != null),
-            text = trackName,
-            style = MaterialTheme.typography.headlineSmall,
-            fontWeight = FontWeight.Bold,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-        if (isUnplayable) {
-            Text(
-                text = "Cannot play this item",
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant.inactive(),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        } else {
-            Text(
-                modifier = Modifier.basicMarquee().alphaOn(title != null),
-                text = subtitle ?: "",
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
-        Text(
-            modifier = Modifier.padding(horizontal = 16.dp),
-            text = audioFormat,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant.inactive(),
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
     }
 }
 
@@ -345,20 +210,92 @@ fun FullPlayerItem(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        FullPlayerArt(
-            hasMedia = currentMedia != null,
-            imageUrl = currentMedia?.imageUrl,
-            title = currentMedia?.title,
-            defaultIcon = currentMedia?.defaultIcon ?: AlbumIcon,
-            dominant = colors.dominant,
-            onPrimaryContainer = onPrimaryContainer,
-        )
-        FullPlayerText(
-            title = currentMedia?.title,
-            subtitle = currentMedia?.subtitle,
-            isUnplayable = item.queueInfo?.currentItem?.isPlayable == false,
-            audioFormat = item.queueInfo?.currentItem?.audioFormat(item.playerId)?.description ?: "",
-        )
+        Box(
+            modifier = Modifier
+                .weight(1f, fill = false)
+                .aspectRatio(1f)
+                .heightIn(max = 500.dp)
+                .clip(RoundedCornerShape(16.dp))
+                .background(colors.dominant.alphaOn(currentMedia != null)),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (currentMedia != null) {
+                val placeholder =
+                    rememberPlaceholderPainter(
+                        backgroundColor = colors.dominant,
+                        iconColor = onPrimaryContainer,
+                        icon = currentMedia.defaultIcon,
+                    )
+                currentMedia.imageUrl?.let {
+                    AsyncImage(
+                        placeholder = placeholder,
+                        fallback = placeholder,
+                        model = it,
+                        contentDescription = currentMedia.title,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                } ?: Icon(
+                    imageVector = currentMedia.defaultIcon,
+                    contentDescription = null,
+                    modifier = Modifier.size(120.dp),
+                    tint = onPrimaryContainer,
+                )
+            } else {
+                Icon(
+                    imageVector = AlbumIcon,
+                    contentDescription = null,
+                    modifier = Modifier.size(120.dp),
+                    tint = onPrimaryContainer.inactive(),
+                )
+            }
+        }
+
+        // Track info
+        val (trackName, trackContentDescription) = trackNameAndContentDescription(currentMedia?.title)
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clearAndSetSemantics {
+                    contentDescription = trackContentDescription
+                },
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                modifier = Modifier.basicMarquee().alphaOn(currentMedia?.title != null),
+                text = trackName,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (item.queueInfo?.currentItem?.isPlayable == false) {
+                Text(
+                    text = "Cannot play this item",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.inactive(),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            } else {
+                Text(
+                    modifier = Modifier.basicMarquee().alphaOn(currentMedia?.title != null),
+                    text = currentMedia?.subtitle ?: "", // TODO take from currentItem?
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Text(
+                modifier = Modifier.padding(horizontal = 16.dp),
+                text = item.queueInfo?.currentItem?.audioFormat(item.playerId)?.description ?: "",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.inactive(),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
 
         val duration = currentMedia?.duration?.takeIf { it > 0 }?.toFloat()
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -31,6 +32,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
@@ -82,77 +85,18 @@ fun CompactPlayerItem(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Start,
         ) {
-            // Album cover on the far left
-            Box(
-                modifier = Modifier
-                    .size(48.dp)
-                    .clip(RoundedCornerShape(8.dp))
-                    .background(colors.dominant.alphaOn(currentMedia != null)),
-                contentAlignment = Alignment.Center,
-            ) {
-                if (currentMedia != null) {
-                    val placeholder = rememberPlaceholderPainter(
-                        backgroundColor = colors.dominant,
-                        iconColor = onPrimaryContainer,
-                        icon = TrackIcon,
-                    )
-                    AsyncImage(
-                        placeholder = placeholder,
-                        fallback = placeholder,
-                        model = currentMedia.imageUrl,
-                        contentDescription = currentMedia.title,
-                        contentScale = ContentScale.Crop,
-                        modifier = Modifier.fillMaxSize(),
-                    )
-                } else {
-                    Icon(
-                        imageVector = AlbumIcon,
-                        contentDescription = null,
-                        modifier = Modifier.size(24.dp),
-                        tint = onPrimaryContainer.inactive(),
-                    )
-                }
-            }
-
-            // Track info
-            val (trackName, trackContentDescription) = trackNameAndContentDescription(currentMedia?.title)
-            Column(
-                modifier = Modifier
-                    .padding(horizontal = 16.dp)
-                    .clearAndSetSemantics {
-                        contentDescription = trackContentDescription
-                    },
-            ) {
-                Text(
-                    modifier = Modifier.basicMarquee().alphaOn(currentMedia?.title != null),
-                    text = trackName,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Medium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                currentMedia?.subtitle?.let {
-                    Text(
-                        modifier = Modifier.basicMarquee(),
-                        text = it,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                } ?: run {
-                    if (item.queueInfo?.currentItem?.isPlayable == showAdditionalControls) {
-                        Text(
-                            text = "Cannot play this item",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.inactive(),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
-                }
-            }
+            CompactPlayerArt(
+                hasMedia = currentMedia != null,
+                imageUrl = currentMedia?.imageUrl,
+                title = currentMedia?.title,
+                dominant = colors.dominant,
+                onPrimaryContainer = onPrimaryContainer,
+            )
+            CompactPlayerText(
+                title = currentMedia?.title,
+                subtitle = currentMedia?.subtitle,
+                showCannotPlay = item.queueInfo?.currentItem?.isPlayable == showAdditionalControls,
+            )
         }
 
         PlayerControls(
@@ -178,6 +122,197 @@ fun CompactPlayerItem(
                 )
             }
         }
+    }
+}
+
+// Stable-input subtree: skips recomposition when title/subtitle/imageUrl are unchanged,
+// so the basicMarquee animation does NOT re-anchor on every 2 Hz position-update tick.
+@Composable
+private fun CompactPlayerArt(
+    hasMedia: Boolean,
+    imageUrl: String?,
+    title: String?,
+    dominant: Color,
+    onPrimaryContainer: Color,
+) {
+    Box(
+        modifier = Modifier
+            .size(48.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(dominant.alphaOn(hasMedia)),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (hasMedia) {
+            val placeholder = rememberPlaceholderPainter(
+                backgroundColor = dominant,
+                iconColor = onPrimaryContainer,
+                icon = TrackIcon,
+            )
+            AsyncImage(
+                placeholder = placeholder,
+                fallback = placeholder,
+                model = imageUrl,
+                contentDescription = title,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize(),
+            )
+        } else {
+            Icon(
+                imageVector = AlbumIcon,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+                tint = onPrimaryContainer.inactive(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun CompactPlayerText(
+    title: String?,
+    subtitle: String?,
+    showCannotPlay: Boolean,
+) {
+    val (trackName, trackContentDescription) = trackNameAndContentDescription(title)
+    Column(
+        modifier = Modifier
+            .padding(horizontal = 16.dp)
+            .clearAndSetSemantics {
+                contentDescription = trackContentDescription
+            },
+    ) {
+        Text(
+            modifier = Modifier.basicMarquee().alphaOn(title != null),
+            text = trackName,
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        subtitle?.let {
+            Text(
+                modifier = Modifier.basicMarquee(),
+                text = it,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        } ?: run {
+            if (showCannotPlay) {
+                Text(
+                    text = "Cannot play this item",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.inactive(),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ColumnScope.FullPlayerArt(
+    hasMedia: Boolean,
+    imageUrl: String?,
+    title: String?,
+    defaultIcon: ImageVector,
+    dominant: Color,
+    onPrimaryContainer: Color,
+) {
+    Box(
+        modifier = Modifier
+            .weight(1f, fill = false)
+            .aspectRatio(1f)
+            .heightIn(max = 500.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(dominant.alphaOn(hasMedia)),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (hasMedia) {
+            val placeholder = rememberPlaceholderPainter(
+                backgroundColor = dominant,
+                iconColor = onPrimaryContainer,
+                icon = defaultIcon,
+            )
+            imageUrl?.let {
+                AsyncImage(
+                    placeholder = placeholder,
+                    fallback = placeholder,
+                    model = it,
+                    contentDescription = title,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            } ?: Icon(
+                imageVector = defaultIcon,
+                contentDescription = null,
+                modifier = Modifier.size(120.dp),
+                tint = onPrimaryContainer,
+            )
+        } else {
+            Icon(
+                imageVector = AlbumIcon,
+                contentDescription = null,
+                modifier = Modifier.size(120.dp),
+                tint = onPrimaryContainer.inactive(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun FullPlayerText(
+    title: String?,
+    subtitle: String?,
+    isUnplayable: Boolean,
+    audioFormat: String,
+) {
+    val (trackName, trackContentDescription) = trackNameAndContentDescription(title)
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clearAndSetSemantics {
+                contentDescription = trackContentDescription
+            },
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            modifier = Modifier.basicMarquee().alphaOn(title != null),
+            text = trackName,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        if (isUnplayable) {
+            Text(
+                text = "Cannot play this item",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.inactive(),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        } else {
+            Text(
+                modifier = Modifier.basicMarquee().alphaOn(title != null),
+                text = subtitle ?: "",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        Text(
+            modifier = Modifier.padding(horizontal = 16.dp),
+            text = audioFormat,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.inactive(),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
     }
 }
 
@@ -210,92 +345,20 @@ fun FullPlayerItem(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        Box(
-            modifier = Modifier
-                .weight(1f, fill = false)
-                .aspectRatio(1f)
-                .heightIn(max = 500.dp)
-                .clip(RoundedCornerShape(16.dp))
-                .background(colors.dominant.alphaOn(currentMedia != null)),
-            contentAlignment = Alignment.Center,
-        ) {
-            if (currentMedia != null) {
-                val placeholder =
-                    rememberPlaceholderPainter(
-                        backgroundColor = colors.dominant,
-                        iconColor = onPrimaryContainer,
-                        icon = currentMedia.defaultIcon,
-                    )
-                currentMedia.imageUrl?.let {
-                    AsyncImage(
-                        placeholder = placeholder,
-                        fallback = placeholder,
-                        model = it,
-                        contentDescription = currentMedia.title,
-                        contentScale = ContentScale.Crop,
-                        modifier = Modifier.fillMaxSize(),
-                    )
-                } ?: Icon(
-                    imageVector = currentMedia.defaultIcon,
-                    contentDescription = null,
-                    modifier = Modifier.size(120.dp),
-                    tint = onPrimaryContainer,
-                )
-            } else {
-                Icon(
-                    imageVector = AlbumIcon,
-                    contentDescription = null,
-                    modifier = Modifier.size(120.dp),
-                    tint = onPrimaryContainer.inactive(),
-                )
-            }
-        }
-
-        // Track info
-        val (trackName, trackContentDescription) = trackNameAndContentDescription(currentMedia?.title)
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clearAndSetSemantics {
-                    contentDescription = trackContentDescription
-                },
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Text(
-                modifier = Modifier.basicMarquee().alphaOn(currentMedia?.title != null),
-                text = trackName,
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-            if (item.queueInfo?.currentItem?.isPlayable == false) {
-                Text(
-                    text = "Cannot play this item",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.inactive(),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            } else {
-                Text(
-                    modifier = Modifier.basicMarquee().alphaOn(currentMedia?.title != null),
-                    text = currentMedia?.subtitle ?: "", // TODO take from currentItem?
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-            Text(
-                modifier = Modifier.padding(horizontal = 16.dp),
-                text = item.queueInfo?.currentItem?.audioFormat(item.playerId)?.description ?: "",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant.inactive(),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
+        FullPlayerArt(
+            hasMedia = currentMedia != null,
+            imageUrl = currentMedia?.imageUrl,
+            title = currentMedia?.title,
+            defaultIcon = currentMedia?.defaultIcon ?: AlbumIcon,
+            dominant = colors.dominant,
+            onPrimaryContainer = onPrimaryContainer,
+        )
+        FullPlayerText(
+            title = currentMedia?.title,
+            subtitle = currentMedia?.subtitle,
+            isUnplayable = item.queueInfo?.currentItem?.isPlayable == false,
+            audioFormat = item.queueInfo?.currentItem?.audioFormat(item.playerId)?.description ?: "",
+        )
 
         val duration = currentMedia?.duration?.takeIf { it > 0 }?.toFloat()
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -39,6 +38,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import io.music_assistant.client.data.model.client.AppMediaItem
 import io.music_assistant.client.data.model.client.AppMediaItem.Companion.description

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
@@ -23,10 +23,13 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -50,7 +53,10 @@ import io.music_assistant.client.ui.compose.common.icons.AlbumIcon
 import io.music_assistant.client.ui.compose.common.icons.TrackIcon
 import io.music_assistant.client.ui.compose.common.painters.rememberPlaceholderPainter
 import io.music_assistant.client.ui.inactive
+import io.music_assistant.client.utils.currentTimeMillis
 import io.music_assistant.client.utils.formatDuration
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.cd_playing
 import musicassistantclient.composeapp.generated.resources.players_nothing
@@ -181,6 +187,49 @@ fun CompactPlayerItem(
     }
 }
 
+/**
+ * Smooth slider progression without depending on a 2 Hz data-layer tick.
+ *
+ * `anchor` is the last server-confirmed position (re-anchored on
+ * `QueueTimeUpdatedEvent`, optimistic seek, track flip). The effect lives
+ * across anchor changes — it observes them inside the loop instead of
+ * cancelling/restarting on each one. This avoids both per-anchor allocation
+ * churn AND visible snap-back when the server smooths position at high rate.
+ */
+@Composable
+private fun rememberInterpolatedPosition(
+    anchor: Double?,
+    isPlaying: Boolean,
+    duration: Double?,
+): Float {
+    if (anchor == null) return 0f
+    val anchorState = rememberUpdatedState(anchor)
+    val durationState = rememberUpdatedState(duration)
+    var current by remember { mutableStateOf(anchor) }
+    LaunchedEffect(isPlaying) {
+        if (!isPlaying) {
+            // Paused: track anchor changes (e.g., user seek while paused) without
+            // running the local interpolator.
+            snapshotFlow { anchorState.value }.collect { current = it }
+            return@LaunchedEffect
+        }
+        // Playing: re-base on each observed anchor, advance locally between.
+        var baseAnchor = anchorState.value
+        var baseTime = currentTimeMillis()
+        while (isActive) {
+            val a = anchorState.value
+            if (a != baseAnchor) {
+                baseAnchor = a
+                baseTime = currentTimeMillis()
+            }
+            val advanced = baseAnchor + (currentTimeMillis() - baseTime) / 1000.0
+            current = durationState.value?.let { advanced.coerceAtMost(it) } ?: advanced
+            delay(500)
+        }
+    }
+    return current.toFloat()
+}
+
 @Composable
 private fun trackNameAndContentDescription(title: String?): Pair<String, String> {
     val playingContentDescription = if (title != null) {
@@ -299,8 +348,14 @@ fun FullPlayerItem(
 
         val duration = currentMedia?.duration?.takeIf { it > 0 }?.toFloat()
 
-        // Position is calculated in MainDataSource and updated twice per second
-        val displayPosition = item.queueInfo?.elapsedTime?.toFloat() ?: 0f
+        // Local interpolation off the server-anchored elapsed time. Recomposition
+        // scope is limited to this slider — the marquee, art, controls etc.
+        // recompose only on real state changes.
+        val displayPosition = rememberInterpolatedPosition(
+            anchor = item.queueInfo?.elapsedTime,
+            isPlaying = item.player.isPlaying,
+            duration = currentMedia?.duration,
+        )
 
         // Track user drag state separately
         var userDragPosition by remember { mutableStateOf<Float?>(null) }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -117,6 +117,7 @@ internal fun PlayersPager(
     localPlayerId: String,
     onAdjustPlaybackDelay: (Int) -> Unit,
     fetchColors: ExtractedColorsFetcher,
+    observePosition: (queueId: String) -> kotlinx.coroutines.flow.Flow<Double>,
 ) {
     val modifier = if (expanded) {
         modifier
@@ -233,6 +234,7 @@ internal fun PlayersPager(
                             contentPadding = contentPadding,
                             isCurrentPage = page == playerPagerState.currentPage,
                             navigateToItem = navigateToItem,
+                            livePositionFlow = player.queueInfo?.id?.let(observePosition),
                         )
                     } else {
                         CollapsedPlayerPage(
@@ -308,6 +310,7 @@ private fun ExpandedPlayerPage(
     contentPadding: PaddingValues,
     isCurrentPage: Boolean,
     navigateToItem: (AppMediaItem) -> Unit = {},
+    livePositionFlow: kotlinx.coroutines.flow.Flow<Double>?,
 ) {
     Column(
         modifier = Modifier.padding(top = 8.dp),
@@ -385,6 +388,7 @@ private fun ExpandedPlayerPage(
                     colors = colors,
                     playerAction = playerAction,
                     onFavoriteClick = onFavoriteClick,
+                    livePositionFlow = livePositionFlow,
                 )
             }
         }
@@ -697,6 +701,7 @@ fun ExpandedPlayerPagePreview() {
             onExpandQueue = {},
             contentPadding = PaddingValues(),
             isCurrentPage = true,
+            livePositionFlow = null,
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -145,6 +145,15 @@ internal fun PlayersPager(
         )
     }
 
+    val playerColors = playerDataList.associateWith {
+        val imageUrl = it.player.currentMedia?.imageUrl
+        rememberAnimatedPlayerColors(
+            imageUrl = imageUrl,
+            fallback = MaterialTheme.colorScheme.primaryContainer,
+            fetchColors = fetchColors,
+        )
+    }
+
     Column(modifier = modifier) {
         if (playerDataList.size > 1) {
             HorizontalPagerIndicator(
@@ -179,15 +188,7 @@ internal fun PlayersPager(
                 )
             }
 
-            // Inlined per-page (instead of an associateWith map at parent scope) so a 2 Hz
-            // position-update cascade through `playerDataList` doesn't rebuild a Map across
-            // all players on every recomposition. HorizontalPager only composes visible pages,
-            // and the underlying kmpalette extraction is cached in DominantColorViewModel.
-            val colors by rememberAnimatedPlayerColors(
-                imageUrl = player.player.currentMedia?.imageUrl,
-                fallback = MaterialTheme.colorScheme.primaryContainer,
-                fetchColors = fetchColors,
-            )
+            val colors by playerColors.getValue(player)
 
             Box(modifier = Modifier.fillMaxSize()) {
                 Column(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -145,15 +145,6 @@ internal fun PlayersPager(
         )
     }
 
-    val playerColors = playerDataList.associateWith {
-        val imageUrl = it.player.currentMedia?.imageUrl
-        rememberAnimatedPlayerColors(
-            imageUrl = imageUrl,
-            fallback = MaterialTheme.colorScheme.primaryContainer,
-            fetchColors = fetchColors,
-        )
-    }
-
     Column(modifier = modifier) {
         if (playerDataList.size > 1) {
             HorizontalPagerIndicator(
@@ -188,7 +179,15 @@ internal fun PlayersPager(
                 )
             }
 
-            val colors by playerColors.getValue(player)
+            // Inlined per-page (instead of an associateWith map at parent scope) so a 2 Hz
+            // position-update cascade through `playerDataList` doesn't rebuild a Map across
+            // all players on every recomposition. HorizontalPager only composes visible pages,
+            // and the underlying kmpalette extraction is cached in DominantColorViewModel.
+            val colors by rememberAnimatedPlayerColors(
+                imageUrl = player.player.currentMedia?.imageUrl,
+                fallback = MaterialTheme.colorScheme.primaryContainer,
+                fetchColors = fetchColors,
+            )
 
             Box(modifier = Modifier.fillMaxSize()) {
                 Column(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -85,6 +85,7 @@ import io.music_assistant.client.ui.compose.home.HomeScreenViewModel
 import io.music_assistant.client.ui.compose.home.HorizontalPagerIndicator
 import io.music_assistant.client.ui.inactive
 import io.music_assistant.client.utils.conditional
+import kotlinx.coroutines.flow.Flow
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.cd_more
 import musicassistantclient.composeapp.generated.resources.cd_mute
@@ -117,7 +118,7 @@ internal fun PlayersPager(
     localPlayerId: String,
     onAdjustPlaybackDelay: (Int) -> Unit,
     fetchColors: ExtractedColorsFetcher,
-    observePosition: (queueId: String) -> kotlinx.coroutines.flow.Flow<Double>,
+    observePosition: (queueId: String) -> Flow<Double>,
 ) {
     val modifier = if (expanded) {
         modifier
@@ -310,7 +311,7 @@ private fun ExpandedPlayerPage(
     contentPadding: PaddingValues,
     isCurrentPage: Boolean,
     navigateToItem: (AppMediaItem) -> Unit = {},
-    livePositionFlow: kotlinx.coroutines.flow.Flow<Double>?,
+    livePositionFlow: Flow<Double>?,
 ) {
     Column(
         modifier = Modifier.padding(top = 8.dp),


### PR DESCRIPTION
1. Player view was re-composed every 0.5 seconds because the elapsed time is part of PlayerData. Extracted it.
2. After introducing sorting for Android Auto, it was fetching in loop, causing OOM. Fixed it.