### PR TITLE
Don't display version twice on item details page

### DIFF
--- a/androidApp/src/main/kotlin/io/music_assistant/client/auto/AutoLibrary.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/auto/AutoLibrary.kt
@@ -618,7 +618,7 @@ fun AppMediaItem.toMediaDescription(
 ): MediaDescriptionCompat {
     return MediaDescriptionCompat.Builder()
         .setMediaId("${itemId}__${uri}__${mediaType}__$provider")
-        .setTitle((if (favorite == true) "♥ " else "") + title)
+        .setTitle((if (favorite == true) "♥ " else "") + displayName)
         .setSubtitle(subtitle)
         .setMediaUri(uri?.let { Uri.parse(it) })
         .setIconUri(imageInfo?.url(serverUrl)?.let { Uri.parse(it) } ?: defaultIconUri)

--- a/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTest.kt
@@ -50,10 +50,10 @@ class ItemDetailsTest {
             )
         }
 
-        composeTestRule.onAllNodes(hasText(artist.title)).onFirst().assertIsDisplayed()
+        composeTestRule.onAllNodes(hasText(artist.displayName)).onFirst().assertIsDisplayed()
         composeTestRule.inScrollable("LazyVerticalGrid") {
-            onNode(hasText(albums[0].title)).assertIsDisplayed()
-            onNode(hasText(albums[1].title)).assertIsDisplayed()
+            onNode(hasText(albums[0].displayName)).assertIsDisplayed()
+            onNode(hasText(albums[1].displayName)).assertIsDisplayed()
         }
     }
 
@@ -74,11 +74,11 @@ class ItemDetailsTest {
             )
         }
 
-        composeTestRule.onAllNodes(hasText(album.title)).onFirst().assertIsDisplayed()
-        composeTestRule.onAllNodes(hasText(artist.title)).onFirst().assertIsDisplayed()
+        composeTestRule.onAllNodes(hasText(album.displayName)).onFirst().assertIsDisplayed()
+        composeTestRule.onAllNodes(hasText(artist.displayName)).onFirst().assertIsDisplayed()
         composeTestRule.inScrollable("LazyVerticalGrid") {
-            onNode(hasText(tracks[0].title)).assertIsDisplayed()
-            onNode(hasText(tracks[1].title)).assertIsDisplayed()
+            onNode(hasText(tracks[0].displayName)).assertIsDisplayed()
+            onNode(hasText(tracks[1].displayName)).assertIsDisplayed()
         }
     }
 
@@ -136,12 +136,12 @@ class ItemDetailsTest {
             )
         }
 
-        composeTestRule.onAllNodes(hasText(playlist.title)).onFirst().assertIsDisplayed()
+        composeTestRule.onAllNodes(hasText(playlist.displayName)).onFirst().assertIsDisplayed()
         composeTestRule.inScrollable("LazyVerticalGrid") {
-            onNode(hasText(tracks[0].title)).assertIsDisplayed()
-            onNode(hasText(tracks[0].artists!![0].title)).assertIsDisplayed()
-            onNode(hasText(tracks[1].title)).assertIsDisplayed()
-            onNode(hasText(tracks[1].artists!![0].title)).assertIsDisplayed()
+            onNode(hasText(tracks[0].displayName)).assertIsDisplayed()
+            onNode(hasText(tracks[0].artists!![0].displayName)).assertIsDisplayed()
+            onNode(hasText(tracks[1].displayName)).assertIsDisplayed()
+            onNode(hasText(tracks[1].artists!![0].displayName)).assertIsDisplayed()
         }
     }
 
@@ -162,10 +162,10 @@ class ItemDetailsTest {
             )
         }
 
-        composeTestRule.onAllNodes(hasText(podcast.title)).onFirst().assertIsDisplayed()
+        composeTestRule.onAllNodes(hasText(podcast.displayName)).onFirst().assertIsDisplayed()
         composeTestRule.inScrollable("LazyVerticalGrid") {
-            onNode(hasText(episodes[0].title)).assertIsDisplayed()
-            onNode(hasText(episodes[1].title)).assertIsDisplayed()
+            onNode(hasText(episodes[0].displayName)).assertIsDisplayed()
+            onNode(hasText(episodes[1].displayName)).assertIsDisplayed()
         }
     }
 
@@ -184,7 +184,7 @@ class ItemDetailsTest {
             )
         }
 
-        composeTestRule.onAllNodes(hasText(audiobook.title)).onFirst().assertIsDisplayed()
+        composeTestRule.onAllNodes(hasText(audiobook.displayName)).onFirst().assertIsDisplayed()
         val chapters = audiobook.chapters!!
         composeTestRule.inScrollable("LazyVerticalGrid") {
             onNode(hasText(chapters[0].name)).assertIsDisplayed()

--- a/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTest.kt
@@ -98,6 +98,7 @@ class ItemDetailsTest {
             )
         }
 
+        composeTestRule.onAllNodes(hasText(album.name)).onFirst().assertIsDisplayed()
         composeTestRule.onAllNodes(hasText(album.version!!)).onFirst().assertIsDisplayed()
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -635,7 +635,7 @@ class MainDataSource(
                         NowPlayingSnapshot.Cleared
                     } else {
                         NowPlayingSnapshot.Active(
-                            title = track.title,
+                            title = track.displayName,
                             artist = track.subtitle,
                             album = track.parentName,
                             artworkUrl = track.imageInfo?.url(apiClient.serverBaseUrl.value),

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/AppMediaItem.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/AppMediaItem.kt
@@ -40,7 +40,7 @@ interface PlayableItem {
 abstract class AppMediaItem(
     val itemId: String,
     val provider: String,
-    private val name: String,
+    val name: String,
     val providerMappings: List<ProviderMapping>?,
     metadata: Metadata?,
     val favorite: Boolean?,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/AppMediaItem.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/AppMediaItem.kt
@@ -23,7 +23,7 @@ interface PlayableItem {
     val defaultIcon: ImageVector
     val parentName: String?
     val itemId: String
-    val title: String
+    val displayName: String
     val version: String?
     val duration: Double?
     val uri: String?
@@ -53,7 +53,7 @@ abstract class AppMediaItem(
     // val timestampModified: Long?,
     val canStartRadio: Boolean = false,
 ) {
-    open val title: String = name
+    open val displayName: String = name
     open val subtitle: String? = null
 
     val isInLibrary = provider == "library"
@@ -249,9 +249,9 @@ abstract class AppMediaItem(
         image = image,
         canStartRadio = true,
     ) {
-        override val title =
+        override val displayName =
             "${name}${version?.trim()?.takeIf { it.isNotBlank() }?.let { " ($it)" } ?: ""}"
-        override val subtitle = artists.joinToString(separator = ", ") { it.title }
+        override val subtitle = artists.joinToString(separator = ", ") { it.displayName }
     }
 
     class Track(
@@ -294,10 +294,10 @@ abstract class AppMediaItem(
         canStartRadio = true,
     ),
         PlayableItem {
-        override val title =
+        override val displayName =
             "${name}${version?.trim()?.takeIf { it.isNotBlank() }?.let { " ($it)" } ?: ""}"
-        override val subtitle = artists.joinToString(separator = ", ") { it.title }
-        override val parentName: String? = album?.title
+        override val subtitle = artists.joinToString(separator = ", ") { it.displayName }
+        override val parentName: String? = album?.displayName
         override val defaultIcon = TrackIcon
     }
 
@@ -388,7 +388,7 @@ abstract class AppMediaItem(
     ),
         PlayableItem {
         override val subtitle = metadata?.releaseDate?.let(::formatIsoDate)
-        override val parentName: String? = podcast?.title
+        override val parentName: String? = podcast?.displayName
         override val defaultIcon = Icons.Default.Podcasts
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/SortOption.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/SortOption.kt
@@ -104,8 +104,8 @@ fun <T> List<T>.clientSorted(option: SortOption): List<T> {
             (it as? AppMediaItem.Track)?.trackNumber
         }
         SortField.NAME -> compareBy(String.CASE_INSENSITIVE_ORDER) {
-            (it as? AppMediaItem)?.sortName ?: (it as? AppMediaItem)?.title
-                ?: (it as? PlayableItem)?.title ?: ""
+            (it as? AppMediaItem)?.sortName ?: (it as? AppMediaItem)?.displayName
+                ?: (it as? PlayableItem)?.displayName ?: ""
         }
         SortField.DURATION -> compareBy { (it as? PlayableItem)?.duration ?: 0.0 }
         SortField.YEAR -> compareBy { (it as? AppMediaItem.Album)?.year ?: 0 }
@@ -113,13 +113,13 @@ fun <T> List<T>.clientSorted(option: SortOption): List<T> {
             (it as? AppMediaItem.PodcastEpisode)?.releaseDate ?: ""
         }
         SortField.ARTIST_NAME -> compareBy(String.CASE_INSENSITIVE_ORDER) {
-            (it as? AppMediaItem.Track)?.artists?.firstOrNull()?.title
-                ?: (it as? AppMediaItem.Album)?.artists?.firstOrNull()?.title
+            (it as? AppMediaItem.Track)?.artists?.firstOrNull()?.displayName
+                ?: (it as? AppMediaItem.Album)?.artists?.firstOrNull()?.displayName
                 ?: ""
         }
         else -> compareBy(String.CASE_INSENSITIVE_ORDER) {
-            (it as? AppMediaItem)?.sortName ?: (it as? AppMediaItem)?.title
-                ?: (it as? PlayableItem)?.title ?: ""
+            (it as? AppMediaItem)?.sortName ?: (it as? AppMediaItem)?.displayName
+                ?: (it as? PlayableItem)?.displayName ?: ""
         }
     }
     return if (option.descending) sortedWith(comparator.reversed()) else sortedWith(comparator)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/BrowsableItemWithMenu.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/BrowsableItemWithMenu.kt
@@ -558,7 +558,7 @@ private fun <T : AppMediaItem> BrowsableItemWithMenu(
                                     modifier = Modifier.fillMaxWidth(),
                                 ) {
                                     Text(
-                                        text = playlist.title,
+                                        text = playlist.displayName,
                                         modifier = Modifier.fillMaxWidth(),
                                     )
                                 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/MediaItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/MediaItems.kt
@@ -96,7 +96,7 @@ fun ArtistGridItem(
         Spacer(Modifier.height(4.dp))
         Text(
             modifier = Modifier.fillMaxWidth(),
-            text = item.title,
+            text = item.displayName,
             style = MaterialTheme.typography.bodyMedium,
             textAlign = TextAlign.Center,
             maxLines = 1,
@@ -137,7 +137,7 @@ private fun ArtistImage(
             placeholder = placeholder,
             fallback = placeholder,
             model = item.imageInfo?.url(serverUrl),
-            contentDescription = item.title,
+            contentDescription = item.displayName,
             contentScale = ContentScale.Crop,
             modifier = Modifier.fillMaxSize(),
         )
@@ -175,7 +175,7 @@ fun AlbumGridItem(
         Spacer(Modifier.height(4.dp))
         Text(
             modifier = Modifier.fillMaxWidth(),
-            text = item.title,
+            text = item.displayName,
             style = MaterialTheme.typography.bodyMedium,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
@@ -224,7 +224,7 @@ private fun AlbumImage(
             placeholder = vinylRecord,
             fallback = vinylRecord,
             model = item.imageInfo?.url(serverUrl),
-            contentDescription = item.title,
+            contentDescription = item.displayName,
             contentScale = ContentScale.Crop,
             modifier = Modifier
                 .fillMaxSize()
@@ -266,7 +266,7 @@ fun PlaylistGridItem(
         Spacer(Modifier.height(4.dp))
         Text(
             modifier = Modifier.fillMaxWidth(),
-            text = item.title,
+            text = item.displayName,
             style = MaterialTheme.typography.bodyMedium,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
@@ -346,7 +346,7 @@ private fun PlaylistImage(
             placeholder = placeholder,
             fallback = placeholder,
             model = item.imageInfo?.url(serverUrl),
-            contentDescription = item.title,
+            contentDescription = item.displayName,
             contentScale = ContentScale.Crop,
             modifier = Modifier
                 .fillMaxSize()
@@ -379,7 +379,7 @@ fun PodcastGridItem(
         Spacer(Modifier.height(4.dp))
         Text(
             modifier = Modifier.fillMaxWidth(),
-            text = item.title,
+            text = item.displayName,
             style = MaterialTheme.typography.bodyMedium,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
@@ -449,7 +449,7 @@ private fun PodcastImage(
             placeholder = placeholder,
             fallback = placeholder,
             model = item.imageInfo?.url(serverUrl),
-            contentDescription = item.title,
+            contentDescription = item.displayName,
             contentScale = ContentScale.Crop,
             modifier = Modifier
                 .fillMaxSize()
@@ -515,7 +515,7 @@ private fun TrackImage(
             placeholder = placeholder,
             fallback = placeholder,
             model = item.imageInfo?.url(serverUrl),
-            contentDescription = item.title,
+            contentDescription = item.displayName,
             contentScale = ContentScale.Crop,
             modifier = Modifier.fillMaxSize(),
         )
@@ -588,7 +588,7 @@ private fun PodcastEpisodeImage(
             placeholder = placeholder,
             fallback = placeholder,
             model = item.imageInfo?.url(serverUrl),
-            contentDescription = item.title,
+            contentDescription = item.displayName,
             contentScale = ContentScale.Crop,
             modifier = Modifier.fillMaxSize(),
         )
@@ -673,7 +673,7 @@ private fun RadioImage(
             placeholder = placeholder,
             fallback = placeholder,
             model = item.imageInfo?.url(serverUrl),
-            contentDescription = item.title,
+            contentDescription = item.displayName,
             contentScale = ContentScale.Crop,
             modifier = Modifier.fillMaxSize(),
         )
@@ -716,7 +716,7 @@ internal fun AudiobookGridItem(
         Spacer(Modifier.height(4.dp))
         Text(
             modifier = Modifier.fillMaxWidth(),
-            text = item.title,
+            text = item.displayName,
             style = MaterialTheme.typography.bodyMedium,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
@@ -777,7 +777,7 @@ private fun AudiobookImage(
             placeholder = placeholder,
             fallback = placeholder,
             model = item.imageInfo?.url(serverUrl),
-            contentDescription = item.title,
+            contentDescription = item.displayName,
             contentScale = ContentScale.Crop,
             modifier = Modifier
                 .fillMaxSize()
@@ -790,7 +790,7 @@ private fun AudiobookImage(
 private fun GridPlayableItemLabels(item: PlayableItem) {
     Spacer(Modifier.height(4.dp))
     Text(
-        text = "${item.title}${
+        text = "${item.displayName}${
             item.version
                 ?.trim()?.takeIf { it.isNotBlank() }?.let { " ($it)" } ?: ""
         }",
@@ -927,7 +927,7 @@ internal fun TrackRowItem(
 ) {
     RowItem(
         modifier = modifier,
-        name = item.title,
+        name = item.displayName,
         subtitle = item.subtitle,
         imageContent = {
             TrackImage(item, serverUrl)
@@ -952,7 +952,7 @@ internal fun AlbumRowItem(
 ) {
     RowItem(
         modifier = modifier,
-        name = item.title,
+        name = item.displayName,
         subtitle = item.subtitle,
         imageContent = {
             AlbumImage(item, serverUrl)
@@ -977,7 +977,7 @@ internal fun ArtistRowItem(
 ) {
     RowItem(
         modifier = modifier,
-        name = item.title,
+        name = item.displayName,
         subtitle = item.subtitle,
         imageContent = {
             ArtistImage(item, serverUrl)
@@ -1002,7 +1002,7 @@ internal fun PlaylistRowItem(
 ) {
     RowItem(
         modifier = modifier,
-        name = item.title,
+        name = item.displayName,
         subtitle = item.subtitle,
         imageContent = {
             PlaylistImage(item, serverUrl)
@@ -1027,7 +1027,7 @@ internal fun PodcastRowItem(
 ) {
     RowItem(
         modifier = modifier,
-        name = item.title,
+        name = item.displayName,
         subtitle = item.subtitle,
         imageContent = {
             PodcastImage(item, serverUrl)
@@ -1052,7 +1052,7 @@ internal fun PodcastEpisodeRowItem(
 ) {
     RowItem(
         modifier = modifier,
-        name = item.title,
+        name = item.displayName,
         subtitle = item.subtitle,
         imageContent = {
             PodcastEpisodeImage(item, serverUrl)
@@ -1081,7 +1081,7 @@ internal fun RadioRowItem(
 ) {
     RowItem(
         modifier = modifier,
-        name = item.title,
+        name = item.displayName,
         subtitle = item.subtitle,
         imageContent = {
             RadioImage(item, serverUrl)
@@ -1119,7 +1119,7 @@ fun GenreGridItem(
         Spacer(Modifier.height(4.dp))
         Text(
             modifier = Modifier.fillMaxWidth(),
-            text = item.title,
+            text = item.displayName,
             style = MaterialTheme.typography.bodyMedium,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
@@ -1160,7 +1160,7 @@ private fun GenreImage(
             placeholder = placeholder,
             fallback = placeholder,
             model = item.imageInfo?.url(serverUrl),
-            contentDescription = item.title,
+            contentDescription = item.displayName,
             contentScale = ContentScale.Crop,
             modifier = Modifier.fillMaxSize(),
         )
@@ -1178,7 +1178,7 @@ internal fun GenreRowItem(
 ) {
     RowItem(
         modifier = modifier,
-        name = item.title,
+        name = item.displayName,
         subtitle = item.subtitle,
         imageContent = {
             GenreImage(item, serverUrl)
@@ -1203,7 +1203,7 @@ internal fun AudiobookRowItem(
 ) {
     RowItem(
         modifier = modifier,
-        name = item.title,
+        name = item.displayName,
         subtitle = item.subtitle,
         imageContent = {
             AudiobookImage(item, serverUrl)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/PlayableItemWithMenu.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/PlayableItemWithMenu.kt
@@ -469,7 +469,7 @@ private fun <T : PlayableItem> PlayableItemWithMenu(
                                     modifier = Modifier.fillMaxWidth(),
                                 ) {
                                     Text(
-                                        text = playlist.title,
+                                        text = playlist.displayName,
                                         modifier = Modifier.fillMaxWidth(),
                                     )
                                 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/viewmodel/ActionsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/viewmodel/ActionsViewModel.kt
@@ -84,7 +84,7 @@ class ActionsViewModel(
                     trackUris = listOf(itemUri),
                 ),
             )
-                .map { "Added to ${playlist.title}" }
+                .map { "Added to ${playlist.displayName}" }
                 .onSuccess { message ->
                     _toasts.emit(message)
                 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/CollapsibleQueue.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/CollapsibleQueue.kt
@@ -329,7 +329,7 @@ fun CollapsibleQueue(
                                             ) {
                                                 Text(
                                                     modifier = Modifier.fillMaxWidth(),
-                                                    text = item.track.title,
+                                                    text = item.track.displayName,
                                                     maxLines = 1,
                                                     overflow = TextOverflow.Ellipsis,
                                                     color = MaterialTheme.colorScheme.secondary,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -113,7 +113,7 @@ fun HomeScreen(
                 ) { row ->
                     CategoryRow(
                         serverUrl = serverUrl,
-                        title = row.title,
+                        title = row.displayName,
                         rowItemType = row.rowItemType,
                         onNavigateClick = onNavigateClick,
                         onPlayClick = onPlayClick,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
@@ -228,7 +228,7 @@ class HomeScreenViewModel(
                     AppMediaItem.RecommendationFolder(
                         itemId = row.itemId,
                         provider = row.provider,
-                        name = row.title,
+                        name = row.displayName,
                         providerMappings = row.providerMappings,
                         uri = row.uri,
                         image = row.image,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
@@ -286,7 +286,7 @@ private fun ItemOverflow(
                                 modifier = Modifier.fillMaxWidth(),
                             ) {
                                 Text(
-                                    text = playlist.title,
+                                    text = playlist.displayName,
                                     modifier = Modifier.fillMaxWidth(),
                                 )
                             }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
@@ -327,7 +327,7 @@ private fun ItemText(
     ) {
         Text(
             modifier = Modifier.basicMarquee(),
-            text = item.title,
+            text = item.name,
             textAlign = textAlign,
             style = MaterialTheme.typography.titleLarge,
         )

--- a/iosApp/iosApp/CarPlay/CarPlayContentManager.swift
+++ b/iosApp/iosApp/CarPlay/CarPlayContentManager.swift
@@ -149,7 +149,7 @@ class CarPlayContentManager {
     // MARK: - Helpers
     
     private func mapToCPListItem(_ item: AppMediaItem) -> CPListItem? {
-        let title = item.title
+        let title = item.displayName
         let subtitle = item.subtitle
 
         let listItem = CPListItem(text: title, detailText: subtitle)

--- a/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
+++ b/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
@@ -317,7 +317,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
                 let displayItems = Array(folderItems.prefix(maxImages))
                 var images = Array(repeating: placeholder, count: displayItems.count)
 
-                let row = CPListImageRowItem(text: folder.title, images: images)
+                let row = CPListImageRowItem(text: folder.displayName, images: images)
                 row.listImageRowHandler = { [weak self] _, index, completion in
                     guard let self = self else { completion(); return }
                     // Recommendation rows retain "tap to play" for every type;
@@ -463,8 +463,8 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
 
     private func pushAlbumsForArtist(_ artist: AppMediaItem.Artist) {
         pushDrilldown(
-            title: "Albums by \(artist.title)",
-            emptyText: "No albums for \(artist.title)"
+            title: "Albums by \(artist.displayName)",
+            emptyText: "No albums for \(artist.displayName)"
         ) { completion in
             CarPlayContentManager.shared.fetchAlbumsForArtist(artist, completion: completion)
         }
@@ -472,7 +472,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
 
     private func pushTracksForAlbum(_ album: AppMediaItem.Album) {
         pushDrilldown(
-            title: album.title,
+            title: album.displayName,
             emptyText: "No tracks in this album"
         ) { completion in
             CarPlayContentManager.shared.fetchTracksForAlbum(album, completion: completion)
@@ -481,7 +481,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
 
     private func pushTracksForPlaylist(_ playlist: AppMediaItem.Playlist) {
         pushDrilldown(
-            title: playlist.title,
+            title: playlist.displayName,
             emptyText: "No tracks in this playlist"
         ) { completion in
             CarPlayContentManager.shared.fetchTracksForPlaylist(playlist, completion: completion)

--- a/iosApp/iosApp/CarPlay/SiriIntentHandler.swift
+++ b/iosApp/iosApp/CarPlay/SiriIntentHandler.swift
@@ -60,7 +60,7 @@ class SiriIntentHandler: NSObject {
             os_log("donatePlayed: skipping non-mappable item kind=%{public}@ name=%{public}@",
                    log: log, type: .info,
                    String(describing: Swift.type(of: item)),
-                   item.title)
+                   item.displayName)
             return
         }
         // Server id is the namespace for `itemId`, which is server-relative.
@@ -83,7 +83,7 @@ class SiriIntentHandler: NSObject {
             playbackSpeed: nil,
             mediaSearch: nil
         )
-        intent.suggestedInvocationPhrase = "Play \(item.title)"
+        intent.suggestedInvocationPhrase = "Play \(item.displayName)"
 
         let interaction = INInteraction(
             intent: intent,
@@ -155,7 +155,7 @@ class SiriIntentHandler: NSObject {
 
         return INMediaItem(
             identifier: item.itemId,
-            title: item.title,
+            title: item.displayName,
             type: type,
             artwork: nil,
             artist: item.subtitle
@@ -289,7 +289,7 @@ class SiriIntentHandler: NSObject {
             // tracks/albums, descriptive labels otherwise). This lets an
             // artist token in the query lift the album that names that
             // artist, without dragging unrelated items down.
-            let itemTokens = Self.tokens(item.title)
+            let itemTokens = Self.tokens(item.displayName)
                 .union(Self.tokens(item.subtitle ?? ""))
             let overlap = queryTokens.intersection(itemTokens).count
             let score = Double(overlap) / Double(queryTokens.count)
@@ -307,7 +307,7 @@ class SiriIntentHandler: NSObject {
         if let best = best {
             os_log("bestMatch: picked name=%{public}@ kind=%{public}@ score=%{public}.2f from %d candidates (type-filtered=%d, mappable=%d)",
                    log: log, type: .info,
-                   best.item.title,
+                   best.item.displayName,
                    String(describing: Swift.type(of: best.item)),
                    best.score,
                    candidates.count,
@@ -400,7 +400,7 @@ extension SiriIntentHandler: INPlayMediaIntentHandling {
                 return
             }
             os_log("PlayMedia.resolveMediaItems: best match name=%{public}@ kind=%{public}@ — .success",
-                   log: log, type: .info, best.title, String(describing: type(of: best)))
+                   log: log, type: .info, best.displayName, String(describing: type(of: best)))
             completion([.success(with: resolved)])
         }
     }
@@ -466,7 +466,7 @@ extension SiriIntentHandler: INPlayMediaIntentHandling {
                 return
             }
             os_log("PlayMedia.handle: matched name=%{public}@ kind=%{public}@",
-                   log: log, type: .info, match.title, String(describing: type(of: match)))
+                   log: log, type: .info, match.displayName, String(describing: type(of: match)))
             Self.dispatchPlay(match, completion: completion)
         }
     }
@@ -480,7 +480,7 @@ extension SiriIntentHandler: INPlayMediaIntentHandling {
         let dispatched = KmpHelper.shared.playOnLocalPlayer(item: item)
         os_log("PlayMedia.dispatchPlay: name=%{public}@ dispatched=%{public}@",
                log: log, type: .info,
-               item.title,
+               item.displayName,
                dispatched ? "true" : "false")
         if dispatched {
             donatePlayed(item)
@@ -684,7 +684,7 @@ extension SiriIntentHandler: INUpdateMediaAffinityIntentHandling {
             os_log("Affinity.handle: applying favorite=%{public}@ to name=%{public}@ kind=%{public}@ dispatched=%{public}@",
                    log: log, type: .info,
                    favorite ? "true" : "false",
-                   match.title,
+                   match.displayName,
                    String(describing: Swift.type(of: match)),
                    dispatched ? "true" : "false")
             // setFavorite returns false synchronously when the request can't


### PR DESCRIPTION
We display item versions underneath the name, so we don't need to add the suffix.