### PR TITLE
Add landscape layout for player

### DIFF
--- a/androidApp/src/main/kotlin/io/music_assistant/client/MainActivity.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/MainActivity.kt
@@ -2,6 +2,7 @@ package io.music_assistant.client
 
 import android.app.ForegroundServiceStartNotAllowedException
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -24,6 +25,11 @@ class MainActivity : ComponentActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // Lock orientation on compact devices
+        if (this.resources.configuration.smallestScreenWidthDp <= COMPACT_DEVICE_WIDTH) {
+            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        }
+
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
@@ -78,5 +84,9 @@ class MainActivity : ComponentActivity() {
                 Logger.withTag("MainActivity").e("No token in OAuth callback")
             }
         }
+    }
+
+    companion object {
+        private const val COMPACT_DEVICE_WIDTH = 600
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/AppMediaItemFixtures.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/AppMediaItemFixtures.kt
@@ -59,7 +59,7 @@ object AppMediaItemFixtures {
             favorite = null,
             uri = null,
             image = null,
-            duration = null,
+            duration = 210.0,
             artists = artists,
             album = album,
             discNumber = null,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/PlayerDataFixtures.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/PlayerDataFixtures.kt
@@ -10,35 +10,13 @@ object PlayerDataFixtures {
     private val uniqueIdGenerator = UniqueIdGenerator()
 
     fun playerData(
-        queueId: String = "queue${uniqueIdGenerator.nextInt()}",
+        queueId: String = uniqueIdGenerator.nextInt().toString(),
         name: String = "Player ${uniqueIdGenerator.nextInt()}",
         groupChildren: List<ChildBind> = emptyList(),
         playerType: PlayerType = PlayerType.PLAYER,
     ): PlayerData {
         return PlayerData(
-            player = Player(
-                id = "player${uniqueIdGenerator.nextInt()}",
-                name = name,
-                provider = "provider",
-                type = playerType,
-                shouldBeShown = true,
-                canSetVolume = true,
-                volumeLevel = 50f,
-                volumeMuted = false,
-                volumeControl = "native",
-                canMute = true,
-                queueId = queueId,
-                isPlaying = true,
-                isAnnouncing = false,
-                canGroupWith = emptyList(),
-                groupVolume = null,
-                groupVolumeMuted = false,
-                groupMembers = null,
-                staticGroupMembers = null,
-                activeGroup = null,
-                syncedTo = null,
-                currentMedia = null,
-            ),
+            player = player(name = name, playerType = playerType, queueId = queueId),
             queue = DataState.Data(
                 Queue(
                     info = QueueInfo(
@@ -58,6 +36,38 @@ object PlayerDataFixtures {
         )
     }
 
+    fun player(
+        id: String = uniqueIdGenerator.nextInt().toString(),
+        name: String = "Player ${uniqueIdGenerator.nextInt()}",
+        playerType: PlayerType = PlayerType.PLAYER,
+        queueId: String = uniqueIdGenerator.nextInt().toString(),
+        currentMedia: PlayerMedia? = null,
+    ): Player {
+        return Player(
+            id = id,
+            name = name,
+            provider = "provider",
+            type = playerType,
+            shouldBeShown = true,
+            canSetVolume = true,
+            volumeLevel = 50f,
+            volumeMuted = false,
+            volumeControl = "native",
+            canMute = true,
+            queueId = queueId,
+            isPlaying = true,
+            isAnnouncing = false,
+            canGroupWith = emptyList(),
+            groupVolume = null,
+            groupVolumeMuted = false,
+            groupMembers = null,
+            staticGroupMembers = null,
+            activeGroup = null,
+            syncedTo = null,
+            currentMedia = currentMedia,
+        )
+    }
+
     fun bind(): ChildBind {
         return ChildBind(
             id = "bind${uniqueIdGenerator.nextInt()}",
@@ -68,6 +78,44 @@ object PlayerDataFixtures {
             name = "Player ${uniqueIdGenerator.nextInt()}",
             isBound = false,
             isManageable = true,
+        )
+    }
+
+    fun PlayableItem.toPlayerMedia(
+        queueId: String = uniqueIdGenerator.nextInt().toString(),
+        queueItemId: String = uniqueIdGenerator.nextInt().toString(),
+    ): PlayerMedia {
+        return PlayerMedia(
+            title = displayName,
+            artist = subtitle,
+            album = (this as? AppMediaItem.Track)?.album?.displayName,
+            imageUrl = null,
+            duration = duration,
+            queueId = queueId,
+            queueItemId = queueItemId,
+            mediaType = (this as? AppMediaItem)?.mediaType,
+            uri = null,
+        )
+    }
+
+    fun QueueTrack.toPlayerMedia(
+        queueId: String = uniqueIdGenerator.nextInt().toString(),
+    ): PlayerMedia {
+        return track.toPlayerMedia(
+            queueId = queueId,
+            queueItemId = id,
+        )
+    }
+
+    fun PlayableItem.toQueueTrack(
+        id: String = uniqueIdGenerator.nextInt().toString(),
+    ): QueueTrack {
+        return QueueTrack(
+            id = id,
+            track = this,
+            isPlayable = true,
+            format = null,
+            dsp = null,
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/PlayerDataFixtures.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/PlayerDataFixtures.kt
@@ -36,6 +36,18 @@ object PlayerDataFixtures {
         )
     }
 
+    fun playerData(queue: Queue): PlayerData {
+        val playerData = playerData()
+        return playerData.copy(
+            player = playerData.player.copy(
+                queueId = queue.info.id,
+                currentMedia = (queue.items as DataState.Data<List<QueueTrack>>).data.first()
+                    .toPlayerMedia(),
+            ),
+            queue = DataState.Data(queue),
+        )
+    }
+
     fun player(
         id: String = uniqueIdGenerator.nextInt().toString(),
         name: String = "Player ${uniqueIdGenerator.nextInt()}",
@@ -79,6 +91,21 @@ object PlayerDataFixtures {
             isBound = false,
             isManageable = true,
         )
+    }
+
+    fun List<QueueTrack>.toQueue(): Queue {
+        val queueId = uniqueIdGenerator.nextInt().toString()
+        val queueInfo = QueueInfo(
+            id = queueId,
+            available = true,
+            shuffleEnabled = false,
+            repeatMode = RepeatMode.OFF,
+            elapsedTime = 100.0,
+            elapsedTimeLastUpdated = null,
+            currentItem = first(),
+        )
+
+        return Queue(info = queueInfo, items = DataState.Data(this))
     }
 
     fun PlayableItem.toPlayerMedia(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/CollapsibleQueue.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/CollapsibleQueue.kt
@@ -139,263 +139,286 @@ fun CollapsibleQueue(
         }
 
         if (isQueueExpanded) {
-            Box(
+            Queue(
                 modifier = Modifier.fillMaxWidth().weight(1f),
-                contentAlignment = Alignment.Center,
-            ) {
-                val message: String? = when (queue) {
-                    is DataState.Error -> stringResource(Res.string.queue_error)
-                    is DataState.Loading -> stringResource(Res.string.queue_loading)
-                    is DataState.NoData -> stringResource(Res.string.queue_no_items)
-                    is DataState.Stale -> when (queue.data.items) {
-                        is DataState.Error -> stringResource(Res.string.queue_error)
-                        is DataState.Loading -> stringResource(Res.string.queue_loading)
-                        is DataState.NoData -> stringResource(Res.string.queue_not_loaded)
-                        is DataState.Data -> null
-                        is DataState.Stale -> null
-                    }
+                queue = queue,
+                onGoToLibrary = onGoToLibrary,
+                isQueueExpanded = isQueueExpanded,
+                isCurrentPage = isCurrentPage,
+                contentPadding = contentPadding,
+                queueAction = queueAction,
+                serverUrl = serverUrl,
+            )
+        }
+    }
+}
 
-                    is DataState.Data -> when (queue.data.items) {
-                        is DataState.Error -> stringResource(Res.string.queue_error)
-                        is DataState.Loading -> stringResource(Res.string.queue_loading)
-                        is DataState.NoData -> stringResource(Res.string.queue_not_loaded)
-                        is DataState.Data -> null
-                        is DataState.Stale -> null
-                    }
-                }
+@Composable
+fun Queue(
+    modifier: Modifier,
+    queue: DataState<Queue>,
+    onGoToLibrary: () -> Unit,
+    isQueueExpanded: Boolean,
+    isCurrentPage: Boolean,
+    contentPadding: PaddingValues,
+    queueAction: (QueueAction) -> Unit,
+    serverUrl: String?,
+) {
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center,
+    ) {
+        val message: String? = when (queue) {
+            is DataState.Error -> stringResource(Res.string.queue_error)
+            is DataState.Loading -> stringResource(Res.string.queue_loading)
+            is DataState.NoData -> stringResource(Res.string.queue_no_items)
+            is DataState.Stale -> when (queue.data.items) {
+                is DataState.Error -> stringResource(Res.string.queue_error)
+                is DataState.Loading -> stringResource(Res.string.queue_loading)
+                is DataState.NoData -> stringResource(Res.string.queue_not_loaded)
+                is DataState.Data -> null
+                is DataState.Stale -> null
+            }
 
-                message?.let {
+            is DataState.Data -> when (queue.data.items) {
+                is DataState.Error -> stringResource(Res.string.queue_error)
+                is DataState.Loading -> stringResource(Res.string.queue_loading)
+                is DataState.NoData -> stringResource(Res.string.queue_not_loaded)
+                is DataState.Data -> null
+                is DataState.Stale -> null
+            }
+        }
+
+        message?.let {
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } ?: run {
+            // Handle both Data and Stale states - both contain valid queue data
+            val queueData = when (queue) {
+                is DataState.Data -> queue.data
+                is DataState.Stale -> queue.data
+                else -> return@run
+            }
+            val items = when (val itemsState = queueData.items) {
+                is DataState.Data -> itemsState.data
+                is DataState.Stale -> itemsState.data
+                else -> return@run
+            }
+
+            if (items.isEmpty()) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
                     Text(
-                        text = message,
+                        text = stringResource(Res.string.queue_empty),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
-                } ?: run {
-                    // Handle both Data and Stale states - both contain valid queue data
-                    val queueData = when (queue) {
-                        is DataState.Data -> queue.data
-                        is DataState.Stale -> queue.data
-                        else -> return@run
+                    OutlinedButton(
+                        onClick = onGoToLibrary,
+                    ) {
+                        Text(stringResource(Res.string.queue_browse_library))
                     }
-                    val items = when (val itemsState = queueData.items) {
-                        is DataState.Data -> itemsState.data
-                        is DataState.Stale -> itemsState.data
-                        else -> return@run
+                }
+            } else {
+                val currentItemId = queueData.info.currentItem?.id
+                val currentItemIndex = currentItemId?.let { id ->
+                    items.indexOfFirst { it.id == id }
+                } ?: -1
+
+                var internalItems by remember(items) { mutableStateOf(items) }
+                var dragEndIndex by remember { mutableStateOf<Int?>(null) }
+                var menuItemId by remember { mutableStateOf<String?>(null) }
+                val listState = rememberLazyListState()
+                val reorderableLazyListState =
+                    rememberReorderableLazyListState(listState) { from, to ->
+                        if (to.index <= currentItemIndex) {
+                            return@rememberReorderableLazyListState
+                        }
+                        internalItems = internalItems.toMutableList().apply {
+                            add(to.index, removeAt(from.index))
+                        }
+                        dragEndIndex = to.index
                     }
 
-                    if (items.isEmpty()) {
-                        Column(
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.spacedBy(16.dp),
+                // Auto-scroll to current item when queue is shown or page becomes current
+                LaunchedEffect(isQueueExpanded, isCurrentPage, currentItemIndex) {
+                    if (isQueueExpanded && isCurrentPage && currentItemIndex >= 0) {
+                        // Scroll to show the current item with some context
+                        // Center the current item in the viewport
+                        listState.animateScrollToItem(
+                            index = currentItemIndex,
+                            scrollOffset = -100, // Offset to show some items above
+                        )
+                    }
+                }
+
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .testTag(CollapsibleQueueSemantics.QUEUE_TAG),
+                    state = listState,
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                    contentPadding = contentPadding,
+                ) {
+                    itemsIndexed(
+                        items = internalItems,
+                        key = { _, item -> item.id },
+                    ) { index, item ->
+                        val isCurrent = item.id == currentItemId
+                        val isPlayed = index < currentItemIndex
+                        val isPlayable = item.isPlayable
+
+                        ReorderableItem(
+                            state = reorderableLazyListState,
+                            key = item.id,
+                            enabled = isPlayable,  // Disable reordering for unplayable items
                         ) {
-                            Text(
-                                text = stringResource(Res.string.queue_empty),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                            OutlinedButton(
-                                onClick = onGoToLibrary,
-                            ) {
-                                Text(stringResource(Res.string.queue_browse_library))
-                            }
-                        }
-                    } else {
-                        val currentItemId = queueData.info.currentItem?.id
-                        val currentItemIndex = currentItemId?.let { id ->
-                            items.indexOfFirst { it.id == id }
-                        } ?: -1
-
-                        var internalItems by remember(items) { mutableStateOf(items) }
-                        var dragEndIndex by remember { mutableStateOf<Int?>(null) }
-                        var menuItemId by remember { mutableStateOf<String?>(null) }
-                        val listState = rememberLazyListState()
-                        val reorderableLazyListState =
-                            rememberReorderableLazyListState(listState) { from, to ->
-                                if (to.index <= currentItemIndex) {
-                                    return@rememberReorderableLazyListState
-                                }
-                                internalItems = internalItems.toMutableList().apply {
-                                    add(to.index, removeAt(from.index))
-                                }
-                                dragEndIndex = to.index
-                            }
-
-                        // Auto-scroll to current item when queue is shown or page becomes current
-                        LaunchedEffect(isQueueExpanded, isCurrentPage, currentItemIndex) {
-                            if (isQueueExpanded && isCurrentPage && currentItemIndex >= 0) {
-                                // Scroll to show the current item with some context
-                                // Center the current item in the viewport
-                                listState.animateScrollToItem(
-                                    index = currentItemIndex,
-                                    scrollOffset = -100, // Offset to show some items above
-                                )
-                            }
-                        }
-
-                        LazyColumn(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .testTag(CollapsibleQueueSemantics.QUEUE_TAG),
-                            state = listState,
-                            verticalArrangement = Arrangement.spacedBy(4.dp),
-                            contentPadding = contentPadding,
-                        ) {
-                            itemsIndexed(
-                                items = internalItems,
-                                key = { _, item -> item.id },
-                            ) { index, item ->
-                                val isCurrent = item.id == currentItemId
-                                val isPlayed = index < currentItemIndex
-                                val isPlayable = item.isPlayable
-
-                                ReorderableItem(
-                                    state = reorderableLazyListState,
-                                    key = item.id,
-                                    enabled = isPlayable,  // Disable reordering for unplayable items
-                                ) {
-                                    Box {
-                                        Row(
-                                            modifier = Modifier
-                                                .padding(vertical = 1.dp)
-                                                .alpha(
-                                                    when {
-                                                        !isPlayable -> 0.3f  // Gray out unplayable items
-                                                        isPlayed -> 0.5f
-                                                        else -> 1f
-                                                    },
-                                                )
-                                                .fillMaxWidth()
-                                                .clip(shape = RoundedCornerShape(8.dp))
-                                                .conditional(
-                                                    condition = isPlayed,  // Treat unplayable like played items
-                                                    ifTrue = {
-                                                        clickable(isPlayable) {  // Only clickable if playable
+                            Box {
+                                Row(
+                                    modifier = Modifier
+                                        .padding(vertical = 1.dp)
+                                        .alpha(
+                                            when {
+                                                !isPlayable -> 0.3f  // Gray out unplayable items
+                                                isPlayed -> 0.5f
+                                                else -> 1f
+                                            },
+                                        )
+                                        .fillMaxWidth()
+                                        .clip(shape = RoundedCornerShape(8.dp))
+                                        .conditional(
+                                            condition = isPlayed,  // Treat unplayable like played items
+                                            ifTrue = {
+                                                clickable(isPlayable) {  // Only clickable if playable
+                                                    queueAction(
+                                                        QueueAction.PlayQueueItem(
+                                                            queueData.info.id, item.id,
+                                                        ),
+                                                    )
+                                                }
+                                            },
+                                            ifFalse = {
+                                                combinedClickable(
+                                                    onClick = {
+                                                        if (!isCurrent && isPlayable) {
                                                             queueAction(
                                                                 QueueAction.PlayQueueItem(
-                                                                    queueData.info.id, item.id,
+                                                                    queueData.info.id,
+                                                                    item.id,
                                                                 ),
                                                             )
                                                         }
                                                     },
-                                                    ifFalse = {
-                                                        combinedClickable(
-                                                            onClick = {
-                                                                if (!isCurrent && isPlayable) {
-                                                                    queueAction(
-                                                                        QueueAction.PlayQueueItem(
-                                                                            queueData.info.id,
-                                                                            item.id,
-                                                                        ),
-                                                                    )
-                                                                }
-                                                            },
-                                                            onLongClick = {
-                                                                menuItemId = item.id
-                                                            },
-                                                        )
+                                                    onLongClick = {
+                                                        menuItemId = item.id
                                                     },
                                                 )
-                                                .padding(horizontal = 12.dp, vertical = 2.dp),
-                                            verticalAlignment = Alignment.CenterVertically,
-                                            horizontalArrangement = Arrangement.Start,
-                                        ) {
-                                            val placeholder = rememberPlaceholderPainter(
-                                                backgroundColor = MaterialTheme.colorScheme.background,
-                                                iconColor = MaterialTheme.colorScheme.secondary,
-                                                icon = TrackIcon,
-                                            )
-                                            AsyncImage(
-                                                modifier = Modifier
-                                                    .padding(end = 8.dp)
-                                                    .size(40.dp)
-                                                    .clip(RoundedCornerShape(size = 4.dp)),
-                                                placeholder = placeholder,
-                                                fallback = placeholder,
-                                                model = item.track.imageInfo?.url(serverUrl),
-                                                contentDescription = null,
-                                                contentScale = ContentScale.Crop,
-                                            )
-                                            if (isCurrent) {
-                                                Icon(
-                                                    modifier = Modifier.padding(end = 8.dp)
-                                                        .size(12.dp),
-                                                    imageVector = PlayIcon,
-                                                    contentDescription = null,
-                                                    tint = MaterialTheme.colorScheme.secondary,
-                                                )
-                                            }
-                                            Column(
-                                                modifier = Modifier.weight(1f).wrapContentHeight(),
-                                            ) {
-                                                Text(
-                                                    modifier = Modifier.fillMaxWidth(),
-                                                    text = item.track.displayName,
-                                                    maxLines = 1,
-                                                    overflow = TextOverflow.Ellipsis,
-                                                    color = MaterialTheme.colorScheme.secondary,
-                                                    style = MaterialTheme.typography.bodyMedium,
-                                                    fontWeight = when {
-                                                        isCurrent -> FontWeight.Bold
-                                                        else -> FontWeight.Normal
-                                                    },
-                                                )
-                                                Text(
-                                                    modifier = Modifier.fillMaxWidth().alpha(0.7f),
-                                                    text = if (isPlayable) {
-                                                        item.track.subtitle ?: "Unknown"
-                                                    } else {
-                                                        stringResource(Res.string.queue_cannot_play)
-                                                    },
-                                                    maxLines = 1,
-                                                    overflow = TextOverflow.Ellipsis,
-                                                    color = MaterialTheme.colorScheme.secondary,
-                                                    style = MaterialTheme.typography.bodySmall,
-                                                )
-                                            }
-                                            if (!isCurrent && !isPlayed && isPlayable) {
-                                                Icon(
-                                                    modifier = Modifier
-                                                        .draggableHandle(
-                                                            onDragStopped = {
-                                                                dragEndIndex?.let { to ->
-                                                                    queueAction(
-                                                                        QueueAction.MoveItem(
-                                                                            queueData.info.id,
-                                                                            item.id,
-                                                                            from = index,
-                                                                            to = to,
-                                                                        ),
-                                                                    )
-                                                                }
-                                                            },
-                                                        )
-                                                        .size(16.dp),
-                                                    imageVector = TablerIcons.GripVertical,
-                                                    contentDescription = null,
-                                                    tint = MaterialTheme.colorScheme.secondary,
-                                                )
-                                            }
-                                        }
-
-                                        // Long-click menu
-                                        DropdownMenu(
-                                            expanded = menuItemId == item.id,
-                                            onDismissRequest = { menuItemId = null },
-                                        ) {
-                                            DropdownMenuItem(
-                                                text = { Text(stringResource(Res.string.common_delete)) },
-                                                onClick = {
-                                                    queueAction(
-                                                        QueueAction.RemoveItems(
-                                                            queueData.info.id,
-                                                            listOf(item.id),
-                                                        ),
-                                                    )
-                                                    menuItemId = null
-                                                },
-                                            )
-                                        }
+                                            },
+                                        )
+                                        .padding(horizontal = 12.dp, vertical = 2.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.Start,
+                                ) {
+                                    val placeholder = rememberPlaceholderPainter(
+                                        backgroundColor = MaterialTheme.colorScheme.background,
+                                        iconColor = MaterialTheme.colorScheme.secondary,
+                                        icon = TrackIcon,
+                                    )
+                                    AsyncImage(
+                                        modifier = Modifier
+                                            .padding(end = 8.dp)
+                                            .size(40.dp)
+                                            .clip(RoundedCornerShape(size = 4.dp)),
+                                        placeholder = placeholder,
+                                        fallback = placeholder,
+                                        model = item.track.imageInfo?.url(serverUrl),
+                                        contentDescription = null,
+                                        contentScale = ContentScale.Crop,
+                                    )
+                                    if (isCurrent) {
+                                        Icon(
+                                            modifier = Modifier.padding(end = 8.dp)
+                                                .size(12.dp),
+                                            imageVector = PlayIcon,
+                                            contentDescription = null,
+                                            tint = MaterialTheme.colorScheme.secondary,
+                                        )
                                     }
+                                    Column(
+                                        modifier = Modifier.weight(1f).wrapContentHeight(),
+                                    ) {
+                                        Text(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            text = item.track.displayName,
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis,
+                                            color = MaterialTheme.colorScheme.secondary,
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            fontWeight = when {
+                                                isCurrent -> FontWeight.Bold
+                                                else -> FontWeight.Normal
+                                            },
+                                        )
+                                        Text(
+                                            modifier = Modifier.fillMaxWidth().alpha(0.7f),
+                                            text = if (isPlayable) {
+                                                item.track.subtitle ?: "Unknown"
+                                            } else {
+                                                stringResource(Res.string.queue_cannot_play)
+                                            },
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis,
+                                            color = MaterialTheme.colorScheme.secondary,
+                                            style = MaterialTheme.typography.bodySmall,
+                                        )
+                                    }
+                                    if (!isCurrent && !isPlayed && isPlayable) {
+                                        Icon(
+                                            modifier = Modifier
+                                                .draggableHandle(
+                                                    onDragStopped = {
+                                                        dragEndIndex?.let { to ->
+                                                            queueAction(
+                                                                QueueAction.MoveItem(
+                                                                    queueData.info.id,
+                                                                    item.id,
+                                                                    from = index,
+                                                                    to = to,
+                                                                ),
+                                                            )
+                                                        }
+                                                    },
+                                                )
+                                                .size(16.dp),
+                                            imageVector = TablerIcons.GripVertical,
+                                            contentDescription = null,
+                                            tint = MaterialTheme.colorScheme.secondary,
+                                        )
+                                    }
+                                }
+
+                                // Long-click menu
+                                DropdownMenu(
+                                    expanded = menuItemId == item.id,
+                                    onDismissRequest = { menuItemId = null },
+                                ) {
+                                    DropdownMenuItem(
+                                        text = { Text(stringResource(Res.string.common_delete)) },
+                                        onClick = {
+                                            queueAction(
+                                                QueueAction.RemoveItems(
+                                                    queueData.info.id,
+                                                    listOf(item.id),
+                                                ),
+                                            )
+                                            menuItemId = null
+                                        },
+                                    )
                                 }
                             }
                         }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/CollapsibleQueue.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/CollapsibleQueue.kt
@@ -155,7 +155,7 @@ fun CollapsibleQueue(
 
 @Composable
 fun Queue(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     queue: DataState<Queue>,
     onGoToLibrary: () -> Unit,
     isQueueExpanded: Boolean,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/FloatingBar.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/FloatingBar.kt
@@ -14,18 +14,11 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ExpandMore
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -68,19 +61,6 @@ fun FloatingBar(
             .background(MaterialTheme.colorScheme.surfaceContainerHigh),
     ) {
         Column {
-            if (expanded) {
-                IconButton(
-                    onClick = { onExpand(false) },
-                    modifier = Modifier.statusBarsPadding().fillMaxWidth().height(36.dp),
-                ) {
-                    Icon(
-                        Icons.Default.ExpandMore,
-                        "Collapse",
-                        modifier = Modifier.size(32.dp),
-                    )
-                }
-            }
-
             val contentPadding = if (expanded) {
                 val windowInsets = WindowInsets.systemBars.only(WindowInsetsSides.Bottom)
                 windowInsets.asPaddingValues()

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/FloatingBar.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/FloatingBar.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -18,7 +17,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.plus
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBars
@@ -32,19 +30,16 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.music_assistant.client.ui.compose.nav.BackHandler
 
 @Composable
-fun BoxScope.FloatingBar(
-    modifier: Modifier = Modifier,
-    bottomPadding: Dp = 0.dp,
+fun FloatingBar(
     expanded: Boolean = false,
     onExpand: (Boolean) -> Unit = {},
     content: @Composable (expanded: Boolean, contentPadding: PaddingValues) -> Unit,
@@ -54,14 +49,12 @@ fun BoxScope.FloatingBar(
     }
 
     val clip by animateDpAsState(if (expanded) 0.dp else 16.dp)
-    val padding by animateDpAsState(if (expanded) 0.dp else FloatingBarDefaults.padding)
-    val paddingValues =
-        PaddingValues(padding) + PaddingValues(bottom = if (expanded) 0.dp else bottomPadding)
+    val padding by animateDpAsState(if (expanded) 0.dp else 8.dp)
+    val paddingValues = PaddingValues(padding)
 
     Box(
-        modifier = modifier
+        modifier = Modifier
             .testTag(FloatingBarSemantics.TAG)
-            .align(Alignment.BottomCenter)
             .padding(paddingValues)
             .clip(RoundedCornerShape(clip))
             .fillMaxWidth()
@@ -100,8 +93,32 @@ fun BoxScope.FloatingBar(
     }
 }
 
-object FloatingBarDefaults {
-    val padding = 8.dp
+@Composable
+fun FloatingBarLayout(
+    modifier: Modifier = Modifier,
+    floatingBar: @Composable () -> Unit,
+    content: @Composable (PaddingValues) -> Unit = {},
+) {
+    SubcomposeLayout(modifier = modifier.fillMaxSize()) { constraints ->
+        val looseConstraints = constraints.copy(minWidth = 0, minHeight = 0)
+
+        val floatingBarPlaceable =
+            subcompose("floatingBar") { Box(modifier = Modifier.wrapContentHeight()) { floatingBar() } }
+                .first()
+                .measure(looseConstraints)
+
+        val contentPadding = PaddingValues(bottom = floatingBarPlaceable.height.toDp())
+        val contentPlaceable = subcompose("content") { Box { content(contentPadding) } }
+            .first()
+            .measure(looseConstraints)
+
+        val layoutWidth = constraints.maxWidth
+        val layoutHeight = constraints.maxHeight
+        layout(layoutWidth, layoutHeight) {
+            contentPlaceable.place(0, 0)
+            floatingBarPlaceable.place(0, layoutHeight - floatingBarPlaceable.height)
+        }
+    }
 }
 
 object FloatingBarSemantics {
@@ -111,41 +128,45 @@ object FloatingBarSemantics {
 @Preview
 @Composable
 private fun PreviewFloatingBarRow() {
-    Box(Modifier.fillMaxSize()) {
-        FloatingBar { _, _ ->
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
-                Text("Left")
-                Text("Right")
+    FloatingBarLayout(
+        floatingBar = {
+            FloatingBar { _, _ ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text("Left")
+                    Text("Right")
+                }
             }
-        }
-    }
+        },
+    )
 }
 
 @Preview
 @Composable
 private fun PreviewFloatingBarColumn() {
-    Box(Modifier.fillMaxSize()) {
-        FloatingBar { _, _ ->
-            Column {
-                Text("Top")
-                Text("Bottom")
+    FloatingBarLayout(
+        floatingBar = {
+            FloatingBar { _, _ ->
+                Column {
+                    Text("Top")
+                    Text("Bottom")
+                }
             }
-        }
-    }
+        },
+    )
 }
 
 @Preview
 @Composable
 private fun PreviewFloatingBarExpanded() {
-    Box(Modifier.fillMaxSize()) {
+    FloatingBarLayout(floatingBar = {
         FloatingBar(expanded = true) { _, _ ->
             Column {
                 Text("Top")
                 Text("Bottom")
             }
         }
-    }
+    })
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -61,7 +61,6 @@ import io.music_assistant.client.ui.compose.nav.NavigationItem
 import io.music_assistant.client.ui.compose.nav.createNavigationItem
 import io.music_assistant.client.ui.compose.search.SearchScreen
 import io.music_assistant.client.utils.SessionState
-import io.music_assistant.client.utils.WindowClass
 import kotlinx.coroutines.flow.collectLatest
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.nav_home
@@ -182,7 +181,6 @@ fun MainNavigationRoot(
         showNavBar = !playerExpanded,
         navigationItems = navigationItems,
     ) { scaffoldContentPadding ->
-        val isExpandedScreen = WindowClass.isAtLeastExpanded()
         val bottomPadding = scaffoldContentPadding.calculateBottomPadding()
 
         FloatingBarLayout(
@@ -200,7 +198,6 @@ fun MainNavigationRoot(
                         actionsViewModel = actionsViewModel,
                         expanded = expanded,
                         onClose = { playerExpanded = false },
-                        isExpandedScreen = isExpandedScreen,
                         contentPadding = contentPadding,
                         backStack = multiBackStack,
                     )
@@ -371,7 +368,6 @@ private fun Players(
     actionsViewModel: ActionsViewModel,
     expanded: Boolean,
     onClose: () -> Unit,
-    isExpandedScreen: Boolean,
     contentPadding: PaddingValues,
     backStack: MultiBackStack,
 ) {
@@ -435,7 +431,6 @@ private fun Players(
             onPlayersReorder = onPlayersReorder,
             queueAction = queueAction,
             moveToPlayer = moveToPlayer,
-            isExpandedScreen = isExpandedScreen,
             contentPadding = contentPadding,
             localPlayerId = homeScreenViewModel.localPlayerId,
             onAdjustPlaybackDelay = homeScreenViewModel::adjustSendspinStaticDelayMs,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -426,16 +426,7 @@ private fun Players(
             simplePlayerAction = simplePlayerAction,
             playerAction = playerAction,
             onFavoriteClick = onFavoriteClick,
-            expanded = expanded,
             onClose = onClose,
-            onPlayersReorder = onPlayersReorder,
-            queueAction = queueAction,
-            moveToPlayer = moveToPlayer,
-            contentPadding = contentPadding,
-            localPlayerId = homeScreenViewModel.localPlayerId,
-            onAdjustPlaybackDelay = homeScreenViewModel::adjustSendspinStaticDelayMs,
-            fetchColors = fetchColors,
-            observePosition = homeScreenViewModel::observePosition,
             navigateToItem = { item ->
                 backStack.add(
                     MainNav.ItemDetails(
@@ -445,6 +436,15 @@ private fun Players(
                     ),
                 )
             },
+            onPlayersReorder = onPlayersReorder,
+            queueAction = queueAction,
+            moveToPlayer = moveToPlayer,
+            contentPadding = contentPadding,
+            localPlayerId = homeScreenViewModel.localPlayerId,
+            onAdjustPlaybackDelay = homeScreenViewModel::adjustSendspinStaticDelayMs,
+            fetchColors = fetchColors,
+            observePosition = homeScreenViewModel::observePosition,
+            compact = !expanded,
         )
     } else {
         Box(Modifier.fillMaxWidth().height(84.dp)) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -31,7 +31,6 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.unit.Dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.NavKey
@@ -182,63 +181,65 @@ fun MainNavigationRoot(
     AdaptiveNavigationScaffold(
         showNavBar = !playerExpanded,
         navigationItems = navigationItems,
-    ) { contentPadding ->
+    ) { scaffoldContentPadding ->
         val isExpandedScreen = WindowClass.isAtLeastExpanded()
-        val bottomPadding = contentPadding.calculateBottomPadding()
-        val floatingBarHeight = collapsedPlayerHeight(isExpandedScreen)
+        val bottomPadding = scaffoldContentPadding.calculateBottomPadding()
 
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(bottom = bottomPadding)
-                .background(MaterialTheme.colorScheme.background),
-        ) {
-            NavDisplay(
-                entries = multiBackStack.toEntries(
-                    mainNavEntryProvider(
-                        floatingBarHeight,
-                        connectionState,
-                        dataState,
-                        hiddenFolderIds,
-                        serverUrl,
-                        multiBackStack,
-                        viewModel,
-                        playlistActions,
-                        libraryActions,
-                        progressActions,
-                        actionsViewModel,
+        FloatingBarLayout(
+            modifier = Modifier.padding(bottom = bottomPadding),
+            floatingBar = {
+                FloatingBar(
+                    expanded = playerExpanded,
+                    onExpand = onExpandPlayer,
+                ) { expanded, contentPadding ->
+                    Players(
+                        playerPagerState = playerPagerState,
+                        state = playersState,
+                        serverUrl = serverUrl,
+                        homeScreenViewModel = viewModel,
+                        actionsViewModel = actionsViewModel,
+                        expanded = expanded,
+                        onClose = { playerExpanded = false },
+                        isExpandedScreen = isExpandedScreen,
+                        contentPadding = contentPadding,
+                        backStack = multiBackStack,
+                    )
+                }
+            },
+        ) { floatingBarContentPadding ->
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background),
+            ) {
+                NavDisplay(
+                    entries = multiBackStack.toEntries(
+                        mainNavEntryProvider(
+                            floatingBarContentPadding,
+                            connectionState,
+                            dataState,
+                            hiddenFolderIds,
+                            serverUrl,
+                            multiBackStack,
+                            viewModel,
+                            playlistActions,
+                            libraryActions,
+                            progressActions,
+                            actionsViewModel,
+                        ),
                     ),
-                ),
-                onBack = {
-                    multiBackStack.removeLastOrNull()
-                },
-            )
-        }
-
-        FloatingBar(
-            bottomPadding = bottomPadding,
-            expanded = playerExpanded,
-            onExpand = onExpandPlayer,
-        ) { expanded, contentPadding ->
-            Players(
-                playerPagerState = playerPagerState,
-                state = playersState,
-                serverUrl = serverUrl,
-                homeScreenViewModel = viewModel,
-                actionsViewModel = actionsViewModel,
-                expanded = expanded,
-                onClose = { playerExpanded = false },
-                isExpandedScreen = isExpandedScreen,
-                contentPadding = contentPadding,
-                backStack = multiBackStack,
-            )
+                    onBack = {
+                        multiBackStack.removeLastOrNull()
+                    },
+                )
+            }
         }
     }
 }
 
 @Composable
 private fun mainNavEntryProvider(
-    floatingBarHeight: Dp,
+    contentPadding: PaddingValues,
     connectionState: SessionState,
     dataState: DataState<List<AppMediaItem.RecommendationFolder>>,
     hiddenFolderIds: Set<String>,
@@ -254,9 +255,7 @@ private fun mainNavEntryProvider(
     return entryProvider {
         entry<MainNav.Landing> {
             HomeScreen(
-                contentPadding = PaddingValues(
-                    bottom = floatingBarHeight + FloatingBarDefaults.padding,
-                ),
+                contentPadding = contentPadding,
                 connectionState = connectionState,
                 dataState = dataState,
                 serverUrl = serverUrl,
@@ -301,9 +300,7 @@ private fun mainNavEntryProvider(
 
         entry<MainNav.Library> {
             LibraryScreen(
-                contentPadding = PaddingValues(
-                    bottom = floatingBarHeight + FloatingBarDefaults.padding,
-                ),
+                contentPadding = contentPadding,
                 initialTabType = it.type,
                 onNavigateClick = { item ->
                     when (item) {
@@ -331,9 +328,7 @@ private fun mainNavEntryProvider(
 
         entry<MainNav.ItemDetails> {
             ItemDetailsScreen(
-                contentPadding = PaddingValues(
-                    bottom = floatingBarHeight + FloatingBarDefaults.padding,
-                ),
+                contentPadding = contentPadding,
                 itemId = it.itemId,
                 mediaType = it.mediaType,
                 providerId = it.providerId,
@@ -361,9 +356,7 @@ private fun mainNavEntryProvider(
                         ),
                     )
                 },
-                contentPadding = PaddingValues(
-                    bottom = floatingBarHeight + FloatingBarDefaults.padding,
-                ),
+                contentPadding = contentPadding,
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.NavKey
@@ -51,7 +52,6 @@ import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.home.nav.MainNav
 import io.music_assistant.client.ui.compose.home.nav.rememberMainNavBackStack
 import io.music_assistant.client.ui.compose.home.players.PlayersPager
-import io.music_assistant.client.ui.compose.home.players.collapsedPlayerHeight
 import io.music_assistant.client.ui.compose.item.ItemDetailsScreen
 import io.music_assistant.client.ui.compose.library.LibraryNavCoordinator
 import io.music_assistant.client.ui.compose.library.LibraryScreen
@@ -452,7 +452,7 @@ private fun Players(
             },
         )
     } else {
-        Box(Modifier.fillMaxWidth().height(collapsedPlayerHeight(isExpandedScreen))) {
+        Box(Modifier.fillMaxWidth().height(84.dp)) {
             val text = when (state) {
                 is HomeScreenViewModel.PlayersState.Loading -> "Loading players..."
                 is HomeScreenViewModel.PlayersState.Data -> "No players available"

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerControls.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerControls.kt
@@ -46,6 +46,7 @@ fun PlayerControls(
     showAdditionalButtons: Boolean = true,
     mainButtonSize: Dp,
     showSkip: Boolean = true,
+    showSkipBack: Boolean = true,
     tint: Color = MaterialTheme.colorScheme.primary,
 ) {
     val player = playerData.player
@@ -79,7 +80,7 @@ fun PlayerControls(
             }
         }
 
-        if (showAdditionalButtons) {
+        if (showSkipBack || showAdditionalButtons) {
             ActionButton(
                 icon = SkipBackIcon,
                 tint = tint,
@@ -180,12 +181,13 @@ private fun ActionButton(
 
 @Preview
 @Composable
-private fun Preview(showAdditionButtons: Boolean = true, showSkip: Boolean = true) {
+private fun Preview(showAdditionButtons: Boolean = true, showSkip: Boolean = true, showSkipBack: Boolean = true) {
     MaterialTheme {
         PlayerControls(
             playerData = PlayerDataFixtures.playerData(),
             playerAction = { _, _ -> },
             showSkip = showSkip,
+            showSkipBack = showSkipBack,
             mainButtonSize = 60.dp,
             showAdditionalButtons = showAdditionButtons,
         )
@@ -201,5 +203,5 @@ private fun PreviewNoAdditional() {
 @Preview
 @Composable
 private fun PreviewNoSkipNoAdditional() {
-    Preview(showSkip = false, showAdditionButtons = false)
+    Preview(showSkip = false, showAdditionButtons = false, showSkipBack = false)
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
@@ -61,6 +61,7 @@ import kotlin.time.DurationUnit
 
 @Composable
 fun CompactPlayerItem(
+    modifier: Modifier,
     item: PlayerData,
     colors: PlayerColors,
     playerAction: (PlayerData, PlayerAction) -> Unit = { _, _ -> },
@@ -73,7 +74,7 @@ fun CompactPlayerItem(
     val onPrimaryContainer = MaterialTheme.colorScheme.onPrimaryContainer
 
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
@@ -164,6 +164,7 @@ fun CompactPlayerItem(
             showAdditionalButtons = showAdditionalControls,
             mainButtonSize = 48.dp,
             showSkip = true,
+            showSkipBack = onSelectPlayer != null,
             tint = colors.controlTint,
         )
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -393,6 +393,7 @@ private fun ExpandedPlayerPage(
         Row {
             Column(
                 modifier = Modifier
+                    .padding(top = 8.dp)
                     .widthIn(max = WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND.dp),
             ) {
                 Column(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -60,9 +60,10 @@ import io.music_assistant.client.data.model.client.AppMediaItem
 import io.music_assistant.client.data.model.client.AppMediaItemFixtures
 import io.music_assistant.client.data.model.client.PlayerData
 import io.music_assistant.client.data.model.client.PlayerDataFixtures
+import io.music_assistant.client.data.model.client.PlayerDataFixtures.toPlayerMedia
+import io.music_assistant.client.data.model.client.PlayerDataFixtures.toQueueTrack
 import io.music_assistant.client.data.model.client.Queue
 import io.music_assistant.client.data.model.client.QueueInfo
-import io.music_assistant.client.data.model.client.QueueTrack
 import io.music_assistant.client.data.model.server.RepeatMode
 import io.music_assistant.client.player.sendspin.SendspinState
 import io.music_assistant.client.ui.alphaOn
@@ -586,7 +587,9 @@ private fun PlayerOverflowMenu(
     }
 
     val navigationOptions =
-        (currentPlayer.queueInfo?.currentItem?.track as? AppMediaItem)?.navigationOptions(navigateToItem)
+        (currentPlayer.queueInfo?.currentItem?.track as? AppMediaItem)?.navigationOptions(
+            navigateToItem,
+        )
             ?: emptyList()
 
     val menuOptions = queueOptions + playerOptions + navigationOptions
@@ -651,7 +654,8 @@ fun collapsedPlayerHeight(isExpandedScreen: Boolean): Dp {
 @Composable
 fun ExpandedPlayerPagePreview() {
     MaterialTheme {
-        val track = AppMediaItemFixtures.tracks(listOf("Test Track")).first()
+        val track = AppMediaItemFixtures.track()
+        val queueTrack = track.toQueueTrack()
         val queueInfo = QueueInfo(
             id = "queue1",
             available = true,
@@ -659,29 +663,20 @@ fun ExpandedPlayerPagePreview() {
             repeatMode = RepeatMode.OFF,
             elapsedTime = 100.0,
             elapsedTimeLastUpdated = null,
-            currentItem = QueueTrack(
-                track = track,
-                id = "",
-                isPlayable = true,
-                format = null,
-                dsp = null,
-            ),
+            currentItem = queueTrack,
         )
 
+        val queue = Queue(info = queueInfo, items = DataState.Data(listOf(queueTrack)))
         val playerData = PlayerDataFixtures.playerData().copy(
-            queue = DataState.Data(
-                Queue(
-                    info = queueInfo,
-                    items = DataState.NoData(),
-                ),
-            ),
+            player = PlayerDataFixtures.player(currentMedia = queueTrack.toPlayerMedia(queueInfo.id)),
+            queue = DataState.Data(queue),
         )
 
         ExpandedPlayerPage(
             player = playerData,
             colors = PlayerColors(
-                MaterialTheme.colorScheme.primary,
-                MaterialTheme.colorScheme.onPrimary,
+                MaterialTheme.colorScheme.surface,
+                MaterialTheme.colorScheme.onSurface,
             ),
             onSelectPlayer = {},
             onGroupButton = {},

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -540,14 +540,13 @@ private fun ExpandedPlayerPage(
 
             if (isLargeScreen && player.queue is DataState.Data) {
                 Queue(
-                    modifier = Modifier,
                     queue = player.queue,
-                    onGoToLibrary = {},
+                    onGoToLibrary = onClose,
                     isQueueExpanded = true,
-                    isCurrentPage = true,
+                    isCurrentPage = isCurrentPage,
                     contentPadding = contentPadding,
-                    queueAction = {},
-                    serverUrl = null,
+                    queueAction = queueAction,
+                    serverUrl = serverUrl,
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -60,11 +60,8 @@ import io.music_assistant.client.data.model.client.AppMediaItem
 import io.music_assistant.client.data.model.client.AppMediaItemFixtures
 import io.music_assistant.client.data.model.client.PlayerData
 import io.music_assistant.client.data.model.client.PlayerDataFixtures
-import io.music_assistant.client.data.model.client.PlayerDataFixtures.toPlayerMedia
+import io.music_assistant.client.data.model.client.PlayerDataFixtures.toQueue
 import io.music_assistant.client.data.model.client.PlayerDataFixtures.toQueueTrack
-import io.music_assistant.client.data.model.client.Queue
-import io.music_assistant.client.data.model.client.QueueInfo
-import io.music_assistant.client.data.model.server.RepeatMode
 import io.music_assistant.client.player.sendspin.SendspinState
 import io.music_assistant.client.ui.alphaOn
 import io.music_assistant.client.ui.compose.common.DataState
@@ -655,22 +652,7 @@ fun collapsedPlayerHeight(isExpandedScreen: Boolean): Dp {
 fun ExpandedPlayerPagePreview() {
     MaterialTheme {
         val track = AppMediaItemFixtures.track()
-        val queueTrack = track.toQueueTrack()
-        val queueInfo = QueueInfo(
-            id = "queue1",
-            available = true,
-            shuffleEnabled = false,
-            repeatMode = RepeatMode.OFF,
-            elapsedTime = 100.0,
-            elapsedTimeLastUpdated = null,
-            currentItem = queueTrack,
-        )
-
-        val queue = Queue(info = queueInfo, items = DataState.Data(listOf(queueTrack)))
-        val playerData = PlayerDataFixtures.playerData().copy(
-            player = PlayerDataFixtures.player(currentMedia = queueTrack.toPlayerMedia(queueInfo.id)),
-            queue = DataState.Data(queue),
-        )
+        val playerData = PlayerDataFixtures.playerData(listOf(track.toQueueTrack()).toQueue())
 
         ExpandedPlayerPage(
             player = playerData,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -511,6 +511,8 @@ private fun ExpandedPlayerPage(
                         isCurrentPage = isCurrentPage,
                         contentPadding = contentPadding,
                     )
+                } else {
+                    Spacer(modifier = Modifier.fillMaxWidth().height(contentPadding.calculateBottomPadding()))
                 }
             }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -54,7 +54,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.window.core.layout.WindowSizeClass
@@ -506,7 +505,10 @@ private fun ExpandedPlayerPage(
                         contentPadding = contentPadding,
                     )
                 } else {
-                    Spacer(modifier = Modifier.fillMaxWidth().height(contentPadding.calculateBottomPadding()))
+                    Spacer(
+                        modifier = Modifier.fillMaxWidth()
+                            .height(contentPadding.calculateBottomPadding()),
+                    )
                 }
             }
 
@@ -661,14 +663,6 @@ private fun CollapsedPlayerPage(
         onGroupButton = if (isExpandedScreen) onGroupButton else null,
         sendSpinState = sendspinState,
     )
-}
-
-fun collapsedPlayerHeight(isExpandedScreen: Boolean): Dp {
-    return if (isExpandedScreen) {
-        84.dp
-    } else {
-        130.dp
-    }
 }
 
 @Preview

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -109,7 +109,6 @@ internal fun PlayersPager(
     simplePlayerAction: (String, PlayerAction) -> Unit,
     playerAction: (PlayerData, PlayerAction) -> Unit,
     onFavoriteClick: (AppMediaItem) -> Unit,
-    expanded: Boolean,
     onClose: () -> Unit,
     navigateToItem: (AppMediaItem) -> Unit,
     onPlayersReorder: (List<String>) -> Unit,
@@ -120,6 +119,7 @@ internal fun PlayersPager(
     onAdjustPlaybackDelay: (Int) -> Unit,
     fetchColors: ExtractedColorsFetcher,
     observePosition: (queueId: String) -> Flow<Double>,
+    compact: Boolean,
 ) {
     var isQueueExpanded by remember { mutableStateOf(false) }
 
@@ -152,20 +152,13 @@ internal fun PlayersPager(
     }
 
     val isExpandedScreen = WindowClass.isAtLeastExpanded()
-    Column(modifier = modifier) {
-        if (expanded) {
-            IconButton(
-                onClick = onClose,
-                modifier = Modifier.statusBarsPadding().fillMaxWidth().height(36.dp),
-            ) {
-                Icon(
-                    Icons.Default.ExpandMore,
-                    "Collapse",
-                    modifier = Modifier.size(32.dp),
-                )
-            }
-        }
+    val modifier = if (compact) {
+        modifier
+    } else {
+        modifier.statusBarsPadding()
+    }
 
+    Column(modifier = modifier) {
         if (playerDataList.size > 1) {
             HorizontalPagerIndicator(
                 pagerState = playerPagerState,
@@ -222,7 +215,17 @@ internal fun PlayersPager(
                             },
                         ),
                 ) {
-                    if (expanded) {
+                    if (compact) {
+                        CollapsedPlayerPage(
+                            isExpandedScreen = isExpandedScreen,
+                            player = player,
+                            colors = colors,
+                            sendspinState = playersState.sendspinState,
+                            onSelectPlayer = onSelectPlayer,
+                            onGroupButton = onGroupButton,
+                            playerAction = playerAction,
+                        )
+                    } else {
                         ExpandedPlayerPage(
                             player = player,
                             colors = colors,
@@ -244,16 +247,6 @@ internal fun PlayersPager(
                             isCurrentPage = page == playerPagerState.currentPage,
                             navigateToItem = navigateToItem,
                             livePositionFlow = player.queueInfo?.id?.let(observePosition),
-                        )
-                    } else {
-                        CollapsedPlayerPage(
-                            isExpandedScreen = isExpandedScreen,
-                            player = player,
-                            colors = colors,
-                            sendspinState = playersState.sendspinState,
-                            onSelectPlayer = onSelectPlayer,
-                            onGroupButton = onGroupButton,
-                            playerAction = playerAction,
                         )
                     }
                 }
@@ -326,10 +319,22 @@ private fun ExpandedPlayerPage(
         modifier = Modifier.padding(top = 8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        Box(
-            modifier = Modifier.fillMaxWidth(),
-            contentAlignment = Alignment.CenterEnd,
-        ) {
+        Box(modifier = Modifier.fillMaxWidth()) {
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                IconButton(
+                    onClick = onClose,
+                ) {
+                    Icon(
+                        Icons.Default.ExpandMore,
+                        "Collapse",
+                        modifier = Modifier.size(32.dp),
+                    )
+                }
+            }
+
             Box(
                 modifier = Modifier.fillMaxWidth(),
                 contentAlignment = Alignment.Center,
@@ -342,17 +347,22 @@ private fun ExpandedPlayerPage(
                 )
             }
 
-            PlayerOverflowMenu(
-                currentPlayer = player,
-                allPlayers = allPlayers,
-                queueAction = queueAction,
-                navigateToItem = {
-                    navigateToItem(it)
-                    onClose()
-                },
-                onPlayerSelected = { moveToPlayer(it) },
-                onOpenDsp = onDspButton,
-            )
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.CenterEnd,
+            ) {
+                PlayerOverflowMenu(
+                    currentPlayer = player,
+                    allPlayers = allPlayers,
+                    queueAction = queueAction,
+                    navigateToItem = {
+                        navigateToItem(it)
+                        onClose()
+                    },
+                    onPlayerSelected = { moveToPlayer(it) },
+                    onOpenDsp = onDspButton,
+                )
+            }
         }
 
         AnimatedVisibility(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -121,12 +121,6 @@ internal fun PlayersPager(
     fetchColors: ExtractedColorsFetcher,
     observePosition: (queueId: String) -> Flow<Double>,
 ) {
-    val modifier = if (expanded) {
-        modifier
-    } else {
-        modifier.height(collapsedPlayerHeight(isExpandedScreen))
-    }
-
     var isQueueExpanded by remember { mutableStateOf(false) }
 
     // Extract playerData list to ensure proper recomposition
@@ -193,10 +187,9 @@ internal fun PlayersPager(
 
             val colors by playerColors.getValue(player)
 
-            Box(modifier = Modifier.fillMaxSize()) {
+            Box(modifier = Modifier.wrapContentHeight()) {
                 Column(
                     Modifier
-                        .fillMaxSize()
                         .background(
                             brush = if (player.isLocal) {
                                 Brush.verticalGradient(
@@ -360,6 +353,7 @@ private fun ExpandedPlayerPage(
                     .clickable { onExpandQueue(false) },
             ) {
                 CompactPlayerItem(
+                    modifier = Modifier,
                     item = player,
                     colors = colors,
                     playerAction = playerAction,
@@ -659,6 +653,7 @@ private fun CollapsedPlayerPage(
     }
 
     CompactPlayerItem(
+        modifier = Modifier.padding(top = 8.dp, bottom = 16.dp),
         item = player,
         colors = colors,
         playerAction = playerAction,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.pager.HorizontalPager
@@ -56,6 +57,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import androidx.window.core.layout.WindowSizeClass
 import io.music_assistant.client.data.model.client.AppMediaItem
 import io.music_assistant.client.data.model.client.AppMediaItemFixtures
 import io.music_assistant.client.data.model.client.PlayerData
@@ -80,7 +82,9 @@ import io.music_assistant.client.ui.compose.common.rememberAnimatedPlayerColors
 import io.music_assistant.client.ui.compose.home.CollapsibleQueue
 import io.music_assistant.client.ui.compose.home.HomeScreenViewModel
 import io.music_assistant.client.ui.compose.home.HorizontalPagerIndicator
+import io.music_assistant.client.ui.compose.home.Queue
 import io.music_assistant.client.ui.inactive
+import io.music_assistant.client.utils.WindowClass
 import io.music_assistant.client.utils.conditional
 import kotlinx.coroutines.flow.Flow
 import musicassistantclient.composeapp.generated.resources.Res
@@ -367,139 +371,162 @@ private fun ExpandedPlayerPage(
             }
         }
 
-        Column(
-            modifier = Modifier
-                .conditional(
-                    condition = !isQueueExpanded,
-                    ifTrue = { weight(1f) },
-                    ifFalse = { wrapContentHeight() },
-                ),
-        ) {
-            AnimatedVisibility(
-                visible = !isQueueExpanded,
-                enter = fadeIn(tween(300)) + expandVertically(tween(300)),
-                exit = fadeOut(tween(200)) + shrinkVertically(tween(300)),
+        val isLargeScreen = WindowClass.isAtLeastLarge()
+        Row {
+            Column(
+                modifier = Modifier
+                    .widthIn(max = WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND.dp),
             ) {
-                FullPlayerItem(
-                    modifier = Modifier.fillMaxSize(),
-                    item = player,
-                    colors = colors,
-                    playerAction = playerAction,
-                    onFavoriteClick = onFavoriteClick,
-                    livePositionFlow = livePositionFlow,
-                )
-            }
-        }
-
-        // Fixed-height shell keeps album art space consistent whether
-        // the volume control is shown for this player.
-        Box(modifier = Modifier.fillMaxWidth().height(36.dp)) {
-            if (player.player.isVolumeSliderAccessible && player.player.currentVolume != null) {
-                var currentVolume by remember(player.player.currentVolume) {
-                    mutableStateOf(player.player.currentVolume)
-                }
-                val controlTint = colors.controlTint
-                val volumeSliderColors = SliderDefaults.colors().copy(
-                    thumbColor = controlTint,
-                    activeTrackColor = controlTint,
-                    inactiveTrackColor = controlTint.inactive(),
-                )
-                Row(
-                    modifier = Modifier.fillMaxSize().padding(horizontal = 32.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                Column(
+                    modifier = Modifier
+                        .conditional(
+                            condition = !isQueueExpanded,
+                            ifTrue = { weight(1f) },
+                            ifFalse = { wrapContentHeight() },
+                        ),
                 ) {
-                    Icon(
-                        modifier = Modifier
-                            .size(24.dp)
-                            .alphaOn(player.player.canMute)
-                            .clickable(enabled = player.player.canMute) {
-                                playerAction(
-                                    player,
-                                    if (player.childrenBinds.none { it.isBound }) {
-                                        PlayerAction.ToggleMute(player.player.currentMuteState)
-                                    } else {
-                                        PlayerAction.GroupToggleMute(player.player.currentMuteState)
+                    AnimatedVisibility(
+                        visible = !isQueueExpanded,
+                        enter = fadeIn(tween(300)) + expandVertically(tween(300)),
+                        exit = fadeOut(tween(200)) + shrinkVertically(tween(300)),
+                    ) {
+                        FullPlayerItem(
+                            modifier = Modifier.fillMaxSize(),
+                            item = player,
+                            colors = colors,
+                            playerAction = playerAction,
+                            onFavoriteClick = onFavoriteClick,
+                            livePositionFlow = livePositionFlow,
+                        )
+                    }
+                }
+
+                // Fixed-height shell keeps album art space consistent whether
+                // the volume control is shown for this player.
+                Box(modifier = Modifier.fillMaxWidth().height(36.dp)) {
+                    if (player.player.isVolumeSliderAccessible && player.player.currentVolume != null) {
+                        var currentVolume by remember(player.player.currentVolume) {
+                            mutableStateOf(player.player.currentVolume)
+                        }
+                        val controlTint = colors.controlTint
+                        val volumeSliderColors = SliderDefaults.colors().copy(
+                            thumbColor = controlTint,
+                            activeTrackColor = controlTint,
+                            inactiveTrackColor = controlTint.inactive(),
+                        )
+                        Row(
+                            modifier = Modifier.fillMaxSize().padding(horizontal = 32.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Icon(
+                                modifier = Modifier
+                                    .size(24.dp)
+                                    .alphaOn(player.player.canMute)
+                                    .clickable(enabled = player.player.canMute) {
+                                        playerAction(
+                                            player,
+                                            if (player.childrenBinds.none { it.isBound }) {
+                                                PlayerAction.ToggleMute(player.player.currentMuteState)
+                                            } else {
+                                                PlayerAction.GroupToggleMute(player.player.currentMuteState)
+                                            },
+                                        )
                                     },
-                                )
-                            },
-                        imageVector = if (player.player.currentMuteState) {
-                            VolumeMutedIcon
-                        } else {
-                            VolumeIcon
-                        },
-                        contentDescription = if (player.player.currentMuteState) {
-                            stringResource(
-                                Res.string.cd_unmute,
-                            )
-                        } else {
-                            stringResource(Res.string.cd_mute)
-                        },
-                        tint = controlTint,
-                    )
-                    Slider(
-                        modifier = Modifier.weight(1f),
-                        value = currentVolume,
-                        valueRange = 0f..100f,
-                        onValueChange = {
-                            currentVolume = it
-                        },
-                        onValueChangeFinished = {
-                            playerAction(
-                                player,
-                                if (player.childrenBinds.none { it.isBound }) {
-                                    PlayerAction.VolumeSet(currentVolume.toDouble())
+                                imageVector = if (player.player.currentMuteState) {
+                                    VolumeMutedIcon
                                 } else {
-                                    PlayerAction.GroupVolumeSet(currentVolume.toDouble())
+                                    VolumeIcon
+                                },
+                                contentDescription = if (player.player.currentMuteState) {
+                                    stringResource(
+                                        Res.string.cd_unmute,
+                                    )
+                                } else {
+                                    stringResource(Res.string.cd_mute)
+                                },
+                                tint = controlTint,
+                            )
+                            Slider(
+                                modifier = Modifier.weight(1f),
+                                value = currentVolume,
+                                valueRange = 0f..100f,
+                                onValueChange = {
+                                    currentVolume = it
+                                },
+                                onValueChangeFinished = {
+                                    playerAction(
+                                        player,
+                                        if (player.childrenBinds.none { it.isBound }) {
+                                            PlayerAction.VolumeSet(currentVolume.toDouble())
+                                        } else {
+                                            PlayerAction.GroupVolumeSet(currentVolume.toDouble())
+                                        },
+                                    )
+                                },
+                                thumb = {
+                                    SliderDefaults.Thumb(
+                                        interactionSource = remember { MutableInteractionSource() },
+                                        thumbSize = DpSize(16.dp, 16.dp),
+                                        colors = volumeSliderColors,
+                                    )
+                                },
+                                track = { sliderState ->
+                                    SliderDefaults.Track(
+                                        sliderState = sliderState,
+                                        colors = volumeSliderColors,
+                                        thumbTrackGapSize = 0.dp,
+                                        trackInsideCornerSize = 0.dp,
+                                        drawStopIndicator = null,
+                                        modifier = Modifier.height(4.dp),
+                                    )
                                 },
                             )
-                        },
-                        thumb = {
-                            SliderDefaults.Thumb(
-                                interactionSource = remember { MutableInteractionSource() },
-                                thumbSize = DpSize(16.dp, 16.dp),
-                                colors = volumeSliderColors,
+                            VolumeValue(
+                                volume = currentVolume.roundToInt(),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = controlTint,
                             )
-                        },
-                        track = { sliderState ->
-                            SliderDefaults.Track(
-                                sliderState = sliderState,
-                                colors = volumeSliderColors,
-                                thumbTrackGapSize = 0.dp,
-                                trackInsideCornerSize = 0.dp,
-                                drawStopIndicator = null,
-                                modifier = Modifier.height(4.dp),
-                            )
-                        },
-                    )
-                    VolumeValue(
-                        volume = currentVolume.roundToInt(),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = controlTint,
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.fillMaxWidth().height(8.dp))
+
+                if (!isLargeScreen) {
+                    CollapsibleQueue(
+                        modifier = Modifier
+                            .conditional(
+                                condition = isQueueExpanded,
+                                ifTrue = { weight(1f) },
+                                ifFalse = { wrapContentHeight() },
+                            ),
+                        queue = player.queue,
+                        isQueueExpanded = isQueueExpanded,
+                        onQueueExpandedSwitch = { onExpandQueue(!isQueueExpanded) },
+                        onGoToLibrary = onClose,
+                        serverUrl = serverUrl,
+                        queueAction = queueAction,
+                        tint = colors.controlTint,
+                        isCurrentPage = isCurrentPage,
+                        contentPadding = contentPadding,
                     )
                 }
             }
+
+            if (isLargeScreen && player.queue is DataState.Data) {
+                Queue(
+                    modifier = Modifier,
+                    queue = player.queue,
+                    onGoToLibrary = {},
+                    isQueueExpanded = true,
+                    isCurrentPage = true,
+                    contentPadding = contentPadding,
+                    queueAction = {},
+                    serverUrl = null,
+                )
+            }
         }
-
-        Spacer(modifier = Modifier.fillMaxWidth().height(8.dp))
-
-        CollapsibleQueue(
-            modifier = Modifier
-                .conditional(
-                    condition = isQueueExpanded,
-                    ifTrue = { weight(1f) },
-                    ifFalse = { wrapContentHeight() },
-                ),
-            queue = player.queue,
-            isQueueExpanded = isQueueExpanded,
-            onQueueExpandedSwitch = { onExpandQueue(!isQueueExpanded) },
-            onGoToLibrary = onClose,
-            serverUrl = serverUrl,
-            queueAction = queueAction,
-            tint = colors.controlTint,
-            isCurrentPage = isCurrentPage,
-            contentPadding = contentPadding,
-        )
     }
 }
 
@@ -650,6 +677,117 @@ fun collapsedPlayerHeight(isExpandedScreen: Boolean): Dp {
 @Preview
 @Composable
 fun ExpandedPlayerPagePreview() {
+    MaterialTheme {
+        val track = AppMediaItemFixtures.track()
+        val playerData = PlayerDataFixtures.playerData(listOf(track.toQueueTrack()).toQueue())
+
+        ExpandedPlayerPage(
+            player = playerData,
+            colors = PlayerColors(
+                MaterialTheme.colorScheme.surface,
+                MaterialTheme.colorScheme.onSurface,
+            ),
+            onSelectPlayer = {},
+            onGroupButton = {},
+            onDspButton = null,
+            serverUrl = null,
+            playerAction = { _, _ -> },
+            onFavoriteClick = {},
+            onClose = {},
+            queueAction = {},
+            allPlayers = listOf(playerData),
+            moveToPlayer = {},
+            isExpandedScreen = false,
+            sendspinState = null,
+            isQueueExpanded = false,
+            onExpandQueue = {},
+            contentPadding = PaddingValues(),
+            isCurrentPage = true,
+            livePositionFlow = null,
+        )
+    }
+}
+
+@Preview(
+    widthDp = WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND,
+    heightDp = WindowSizeClass.HEIGHT_DP_MEDIUM_LOWER_BOUND,
+)
+@Composable
+fun ExpandedPlayerPageMediumScreenPreview() {
+    MaterialTheme {
+        val track = AppMediaItemFixtures.track()
+        val playerData = PlayerDataFixtures.playerData(listOf(track.toQueueTrack()).toQueue())
+
+        ExpandedPlayerPage(
+            player = playerData,
+            colors = PlayerColors(
+                MaterialTheme.colorScheme.surface,
+                MaterialTheme.colorScheme.onSurface,
+            ),
+            onSelectPlayer = {},
+            onGroupButton = {},
+            onDspButton = null,
+            serverUrl = null,
+            playerAction = { _, _ -> },
+            onFavoriteClick = {},
+            onClose = {},
+            queueAction = {},
+            allPlayers = listOf(playerData),
+            moveToPlayer = {},
+            isExpandedScreen = false,
+            sendspinState = null,
+            isQueueExpanded = false,
+            onExpandQueue = {},
+            contentPadding = PaddingValues(),
+            isCurrentPage = true,
+            livePositionFlow = null,
+        )
+    }
+}
+
+@Preview(
+    widthDp = WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND,
+    heightDp = WindowSizeClass.HEIGHT_DP_EXPANDED_LOWER_BOUND,
+)
+@Composable
+fun ExpandedPlayerPageExpandedScreenPreview() {
+    MaterialTheme {
+        val track = AppMediaItemFixtures.track()
+        val playerData = PlayerDataFixtures.playerData(listOf(track.toQueueTrack()).toQueue())
+
+        ExpandedPlayerPage(
+            player = playerData,
+            colors = PlayerColors(
+                MaterialTheme.colorScheme.surface,
+                MaterialTheme.colorScheme.onSurface,
+            ),
+            onSelectPlayer = {},
+            onGroupButton = {},
+            onDspButton = null,
+            serverUrl = null,
+            playerAction = { _, _ -> },
+            onFavoriteClick = {},
+            onClose = {},
+            queueAction = {},
+            allPlayers = listOf(playerData),
+            moveToPlayer = {},
+            isExpandedScreen = true,
+            sendspinState = null,
+            isQueueExpanded = false,
+            onExpandQueue = {},
+            contentPadding = PaddingValues(),
+            isCurrentPage = true,
+            livePositionFlow = null,
+        )
+    }
+}
+
+@Preview(
+    widthDp = WindowSizeClass.WIDTH_DP_LARGE_LOWER_BOUND,
+    heightDp = WindowSizeClass.HEIGHT_DP_EXPANDED_LOWER_BOUND,
+)
+@Composable
+fun ExpandedPlayerPageLargeScreenPreview() {
     MaterialTheme {
         val track = AppMediaItemFixtures.track()
         val playerData = PlayerDataFixtures.playerData(listOf(track.toQueueTrack()).toQueue())

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
@@ -32,6 +33,7 @@ import androidx.compose.foundation.pager.PagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowRight
 import androidx.compose.material.icons.filled.DeleteSweep
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Smartphone
 import androidx.compose.material.icons.filled.Speaker
@@ -151,6 +153,19 @@ internal fun PlayersPager(
 
     val isExpandedScreen = WindowClass.isAtLeastExpanded()
     Column(modifier = modifier) {
+        if (expanded) {
+            IconButton(
+                onClick = onClose,
+                modifier = Modifier.statusBarsPadding().fillMaxWidth().height(36.dp),
+            ) {
+                Icon(
+                    Icons.Default.ExpandMore,
+                    "Collapse",
+                    modifier = Modifier.size(32.dp),
+                )
+            }
+        }
+
         if (playerDataList.size > 1) {
             HorizontalPagerIndicator(
                 pagerState = playerPagerState,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -113,7 +113,6 @@ internal fun PlayersPager(
     onPlayersReorder: (List<String>) -> Unit,
     queueAction: (QueueAction) -> Unit,
     moveToPlayer: (String) -> Unit,
-    isExpandedScreen: Boolean,
     contentPadding: PaddingValues,
     localPlayerId: String,
     onAdjustPlaybackDelay: (Int) -> Unit,
@@ -150,6 +149,7 @@ internal fun PlayersPager(
         )
     }
 
+    val isExpandedScreen = WindowClass.isAtLeastExpanded()
     Column(modifier = modifier) {
         if (playerDataList.size > 1) {
             HorizontalPagerIndicator(
@@ -306,6 +306,7 @@ private fun ExpandedPlayerPage(
     navigateToItem: (AppMediaItem) -> Unit = {},
     livePositionFlow: Flow<Double>?,
 ) {
+    val isLargeScreen = WindowClass.isAtLeastLarge()
     Column(
         modifier = Modifier.padding(top = 8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -364,7 +365,6 @@ private fun ExpandedPlayerPage(
             }
         }
 
-        val isLargeScreen = WindowClass.isAtLeastLarge()
         Row {
             Column(
                 modifier = Modifier

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/WindowClass.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/WindowClass.kt
@@ -12,4 +12,12 @@ object WindowClass {
         return windowSizeClass
             .isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND)
     }
+
+    @Composable
+    fun isAtLeastLarge(): Boolean {
+        val windowSizeClass =
+            currentWindowAdaptiveInfo(supportLargeAndXLargeWidth = true).windowSizeClass
+        return windowSizeClass
+            .isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_LARGE_LOWER_BOUND)
+    }
 }

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -96,8 +96,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>


### PR DESCRIPTION
Closes #113

<img width="1920" height="1200" alt="Screenshot_20260512_163946" src="https://github.com/user-attachments/assets/b9807c46-8802-4789-a121-8c8f811d3b04" />

Just a basic rework of the layout here. We could definitely tweak this further in future if we're seeing a lot of tablet usage.

I've also locked orientation on compact Android devices and iPhones as discussed in the issue.