### PR TITLE
Fix backstack weirdness when restoring process

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -241,7 +241,7 @@ private fun mainNavEntryProvider(
     dataState: DataState<List<AppMediaItem.RecommendationFolder>>,
     hiddenFolderIds: Set<String>,
     serverUrl: String?,
-    multiBackStack: MultiBackStack,
+    multiBackStack: MultiBackStack<NavKey>,
     viewModel: HomeScreenViewModel,
     playlistActions: ActionsViewModel.PlaylistActions,
     libraryActions: ActionsViewModel.LibraryActions,
@@ -369,7 +369,7 @@ private fun Players(
     expanded: Boolean,
     onClose: () -> Unit,
     contentPadding: PaddingValues,
-    backStack: MultiBackStack,
+    backStack: MultiBackStack<NavKey>,
 ) {
     if (state is HomeScreenViewModel.PlayersState.Data && state.playerData.isNotEmpty()) {
         val simplePlayerAction = remember(homeScreenViewModel) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/AdaptiveNavigationScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/AdaptiveNavigationScaffold.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.navigation3.runtime.NavKey
 import androidx.window.core.layout.WindowSizeClass
 import io.music_assistant.client.utils.WindowClass
 
@@ -81,7 +82,7 @@ data class NavigationItem(
     val label: String? = null,
 )
 
-fun MultiBackStack.createNavigationItem(
+fun <T : NavKey> MultiBackStack<T>.createNavigationItem(
     backStack: Int,
     icon: ImageVector,
     label: String? = null,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/MultiBackStack.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/MultiBackStack.kt
@@ -18,7 +18,7 @@ import androidx.navigation3.runtime.NavKey
 class MultiBackStack<T : NavKey>(private val backStacks: List<MutableList<T>>) {
     var currentBackStack by mutableStateOf(0)
 
-    private val originalItems = backStacks.map { it.toList() }
+    private val roots = backStacks.map { it.first() }
 
     /**
      * Clear the current back stack and reset it back to its original state
@@ -26,7 +26,7 @@ class MultiBackStack<T : NavKey>(private val backStacks: List<MutableList<T>>) {
     fun resetCurrentBackStack() {
         backStacks[currentBackStack].apply {
             clear()
-            addAll(originalItems[currentBackStack])
+            add(roots[currentBackStack])
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/MultiBackStack.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/MultiBackStack.kt
@@ -15,7 +15,7 @@ import androidx.navigation3.runtime.NavKey
  * navigating backways from the last element of any back stack except the first leads to the top
  * element of the first back stack.
  */
-class MultiBackStack(private val backStacks: List<MutableList<NavKey>>) {
+class MultiBackStack<T : NavKey>(private val backStacks: List<MutableList<T>>) {
     var currentBackStack by mutableStateOf(0)
 
     private val originalItems = backStacks.map { it.toList() }
@@ -30,7 +30,7 @@ class MultiBackStack(private val backStacks: List<MutableList<NavKey>>) {
         }
     }
 
-    fun add(element: NavKey) {
+    fun add(element: T) {
         backStacks[currentBackStack].add(element)
     }
 
@@ -39,7 +39,7 @@ class MultiBackStack(private val backStacks: List<MutableList<NavKey>>) {
      * [replacementBottom] entry. Used to redirect navigation into another tab's stack
      * (e.g. tapping "All Albums" on Home jumps to the Library tab rooted at Albums).
      */
-    fun switchTo(index: Int, replacementBottom: NavKey? = null) {
+    fun switchTo(index: Int, replacementBottom: T? = null) {
         currentBackStack = index
         replacementBottom?.let {
             backStacks[index].apply {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/MultiBackStack.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/MultiBackStack.kt
@@ -1,26 +1,21 @@
 package io.music_assistant.client.ui.compose.nav
 
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.runtime.setValue
-import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.NavKey
-import androidx.navigation3.runtime.rememberDecoratedNavEntries
-import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 
 /**
- * Allows multiple [NavBackStack] instances to be treated as one for use with components like
+ * Allows multiple back stacks to be treated as one for use with components like
  * [androidx.navigation3.ui.NavDisplay] (with [toEntries] when combined with a
  * [androidx.compose.material3.NavigationBar].
  *
- * The [NavBackStack] entries are combined to provide "exit through home" style navigation where
+ * The back stack entries are combined to provide "exit through home" style navigation where
  * navigating backways from the last element of any back stack except the first leads to the top
  * element of the first back stack.
  */
-class MultiBackStack(private val backStacks: List<NavBackStack<NavKey>>) {
+class MultiBackStack(private val backStacks: List<MutableList<NavKey>>) {
     var currentBackStack by mutableStateOf(0)
 
     private val originalItems = backStacks.map { it.toList() }
@@ -63,7 +58,6 @@ class MultiBackStack(private val backStacks: List<NavBackStack<NavKey>>) {
         }
     }
 
-    @Composable
     fun toEntries(entryProvider: (NavKey) -> NavEntry<NavKey>): List<NavEntry<NavKey>> {
         val activeBackStacks = if (currentBackStack == 0) {
             listOf(backStacks[0])
@@ -71,15 +65,8 @@ class MultiBackStack(private val backStacks: List<NavBackStack<NavKey>>) {
             listOf(backStacks[0]) + listOf(backStacks[currentBackStack])
         }
 
-        val saveableStateHolderForHome = rememberSaveableStateHolder()
-        return activeBackStacks.flatMap {
-            rememberDecoratedNavEntries(
-                backStack = it,
-                entryDecorators = listOf(
-                    rememberSaveableStateHolderNavEntryDecorator(saveableStateHolderForHome),
-                ),
-                entryProvider = entryProvider,
-            )
+        return activeBackStacks.flatMap { backStack ->
+            backStack.map { entryProvider(it) }
         }
     }
 }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/nav/MultiBackStackTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/nav/MultiBackStackTest.kt
@@ -1,0 +1,17 @@
+package io.music_assistant.client.ui.compose.nav
+
+import androidx.navigation3.runtime.NavKey
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MultiBackStackTest {
+    @Test
+    fun `#resetCurrentBackStack restores back stack to original root`() {
+        val backStack = mutableListOf(TestNavKey("root"), TestNavKey("top"))
+        val multiBackStack = MultiBackStack(listOf(backStack))
+        multiBackStack.resetCurrentBackStack()
+        assertEquals(listOf(TestNavKey("root")), backStack)
+    }
+}
+
+private data class TestNavKey(val id: String) :  NavKey


### PR DESCRIPTION
This fixes issues when the process is recreated and the "original" items of a back stack were treated as the ones in place before the restore causing the "return" action (clicking the nav item when already on it) to act weirdly.

Now when restoring, the back stacks should remain the same as they were before and "return" should work as expected. One caveat that was already the case, when restoring the app will always switch the "Home" stack because the "current stack" state doesn't survive process recreation (it's just a `State` wrapped in a `remember`). If that's something we see a lot in the wild, we can improve on it.