### PR TITLE
Convert `ActionViewModel` data classes into interfaces

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/BrowsableItemWithMenu.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/BrowsableItemWithMenu.kt
@@ -46,7 +46,6 @@ import io.music_assistant.client.data.model.client.items.Podcast
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.settings.ViewMode
 import io.music_assistant.client.ui.compose.common.icons.PlayIcon
-import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import kotlinx.coroutines.launch
 import musicassistantclient.composeapp.generated.resources.*
 import musicassistantclient.composeapp.generated.resources.Res
@@ -180,7 +179,7 @@ fun AudiobookWithMenu(
     onPlayOption: ((Audiobook, QueueOption, Boolean) -> Unit),
     playlistActions: PlaylistActions? = null,
     libraryActions: LibraryActions,
-    progressActions: ActionsViewModel.ProgressActions? = null,
+    progressActions: ProgressActions? = null,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)?,
 ) {
     BrowsableItemWithMenu(
@@ -302,7 +301,7 @@ private fun <T : AppMediaItem> BrowsableItemWithMenu(
     onPlayOption: ((T, QueueOption, Boolean) -> Unit),
     playlistActions: PlaylistActions? = null,
     libraryActions: LibraryActions? = null,
-    progressActions: ActionsViewModel.ProgressActions? = null,
+    progressActions: ProgressActions? = null,
     itemComposable: @Composable (
         modifier: Modifier,
         onClick: (T) -> Unit,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/BrowsableItemWithMenu.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/BrowsableItemWithMenu.kt
@@ -59,7 +59,7 @@ fun AlbumWithMenu(
     onNavigateClick: (Album) -> Unit,
     onPlayOption: ((Album, QueueOption, Boolean) -> Unit),
     playlistActions: PlaylistActions? = null,
-    libraryActions: ActionsViewModel.LibraryActions,
+    libraryActions: LibraryActions,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)?,
 ) {
     BrowsableItemWithMenu(
@@ -99,7 +99,7 @@ fun ArtistWithMenu(
     onNavigateClick: (Artist) -> Unit,
     onPlayOption: ((Artist, QueueOption, Boolean) -> Unit),
     playlistActions: PlaylistActions? = null,
-    libraryActions: ActionsViewModel.LibraryActions,
+    libraryActions: LibraryActions,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)?,
 ) {
     BrowsableItemWithMenu(
@@ -139,7 +139,7 @@ fun PlaylistWithMenu(
     onNavigateClick: (Playlist) -> Unit,
     onPlayOption: ((Playlist, QueueOption, Boolean) -> Unit),
     playlistActions: PlaylistActions? = null,
-    libraryActions: ActionsViewModel.LibraryActions,
+    libraryActions: LibraryActions,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)?,
 ) {
     BrowsableItemWithMenu(
@@ -179,7 +179,7 @@ fun AudiobookWithMenu(
     onNavigateClick: (Audiobook) -> Unit,
     onPlayOption: ((Audiobook, QueueOption, Boolean) -> Unit),
     playlistActions: PlaylistActions? = null,
-    libraryActions: ActionsViewModel.LibraryActions,
+    libraryActions: LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)?,
 ) {
@@ -221,7 +221,7 @@ fun GenreWithMenu(
     onNavigateClick: (Genre) -> Unit,
     onPlayOption: ((Genre, QueueOption, Boolean) -> Unit),
     playlistActions: PlaylistActions? = null,
-    libraryActions: ActionsViewModel.LibraryActions,
+    libraryActions: LibraryActions,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)?,
 ) {
     BrowsableItemWithMenu(
@@ -261,7 +261,7 @@ fun PodcastWithMenu(
     onNavigateClick: (Podcast) -> Unit,
     onPlayOption: ((Podcast, QueueOption, Boolean) -> Unit),
     playlistActions: PlaylistActions? = null,
-    libraryActions: ActionsViewModel.LibraryActions,
+    libraryActions: LibraryActions,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)?,
 ) {
     BrowsableItemWithMenu(
@@ -301,7 +301,7 @@ private fun <T : AppMediaItem> BrowsableItemWithMenu(
     onNavigateClick: (T) -> Unit,
     onPlayOption: ((T, QueueOption, Boolean) -> Unit),
     playlistActions: PlaylistActions? = null,
-    libraryActions: ActionsViewModel.LibraryActions? = null,
+    libraryActions: LibraryActions? = null,
     progressActions: ActionsViewModel.ProgressActions? = null,
     itemComposable: @Composable (
         modifier: Modifier,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/BrowsableItemWithMenu.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/BrowsableItemWithMenu.kt
@@ -58,7 +58,7 @@ fun AlbumWithMenu(
     viewMode: ViewMode = ViewMode.GRID,
     onNavigateClick: (Album) -> Unit,
     onPlayOption: ((Album, QueueOption, Boolean) -> Unit),
-    playlistActions: ActionsViewModel.PlaylistActions? = null,
+    playlistActions: PlaylistActions? = null,
     libraryActions: ActionsViewModel.LibraryActions,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)?,
 ) {
@@ -98,7 +98,7 @@ fun ArtistWithMenu(
     viewMode: ViewMode = ViewMode.GRID,
     onNavigateClick: (Artist) -> Unit,
     onPlayOption: ((Artist, QueueOption, Boolean) -> Unit),
-    playlistActions: ActionsViewModel.PlaylistActions? = null,
+    playlistActions: PlaylistActions? = null,
     libraryActions: ActionsViewModel.LibraryActions,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)?,
 ) {
@@ -138,7 +138,7 @@ fun PlaylistWithMenu(
     viewMode: ViewMode = ViewMode.GRID,
     onNavigateClick: (Playlist) -> Unit,
     onPlayOption: ((Playlist, QueueOption, Boolean) -> Unit),
-    playlistActions: ActionsViewModel.PlaylistActions? = null,
+    playlistActions: PlaylistActions? = null,
     libraryActions: ActionsViewModel.LibraryActions,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)?,
 ) {
@@ -178,7 +178,7 @@ fun AudiobookWithMenu(
     viewMode: ViewMode = ViewMode.GRID,
     onNavigateClick: (Audiobook) -> Unit,
     onPlayOption: ((Audiobook, QueueOption, Boolean) -> Unit),
-    playlistActions: ActionsViewModel.PlaylistActions? = null,
+    playlistActions: PlaylistActions? = null,
     libraryActions: ActionsViewModel.LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)?,
@@ -220,7 +220,7 @@ fun GenreWithMenu(
     viewMode: ViewMode = ViewMode.GRID,
     onNavigateClick: (Genre) -> Unit,
     onPlayOption: ((Genre, QueueOption, Boolean) -> Unit),
-    playlistActions: ActionsViewModel.PlaylistActions? = null,
+    playlistActions: PlaylistActions? = null,
     libraryActions: ActionsViewModel.LibraryActions,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)?,
 ) {
@@ -260,7 +260,7 @@ fun PodcastWithMenu(
     viewMode: ViewMode = ViewMode.GRID,
     onNavigateClick: (Podcast) -> Unit,
     onPlayOption: ((Podcast, QueueOption, Boolean) -> Unit),
-    playlistActions: ActionsViewModel.PlaylistActions? = null,
+    playlistActions: PlaylistActions? = null,
     libraryActions: ActionsViewModel.LibraryActions,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)?,
 ) {
@@ -300,7 +300,7 @@ private fun <T : AppMediaItem> BrowsableItemWithMenu(
     item: T,
     onNavigateClick: (T) -> Unit,
     onPlayOption: ((T, QueueOption, Boolean) -> Unit),
-    playlistActions: ActionsViewModel.PlaylistActions? = null,
+    playlistActions: PlaylistActions? = null,
     libraryActions: ActionsViewModel.LibraryActions? = null,
     progressActions: ActionsViewModel.ProgressActions? = null,
     itemComposable: @Composable (
@@ -460,7 +460,7 @@ private fun <T : AppMediaItem> BrowsableItemWithMenu(
                         // Load playlists when dialogue opens
                         coroutineScope.launch {
                             isLoadingPlaylists = true
-                            playlists = playlistActions.onLoadPlaylists()
+                            playlists = playlistActions.getEditablePlaylists()
                             isLoadingPlaylists = false
                         }
                     },
@@ -539,8 +539,7 @@ private fun <T : AppMediaItem> BrowsableItemWithMenu(
                             ) { playlist ->
                                 TextButton(
                                     onClick = {
-                                        playlistActions?.onAddToPlaylist
-                                            ?.invoke(item, playlist)
+                                        playlistActions?.addToPlaylist(item, playlist)
                                         showPlaylistDialog = false
                                         playlists = emptyList()
                                     },

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/ItemActions.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/ItemActions.kt
@@ -1,0 +1,12 @@
+package io.music_assistant.client.ui.compose.common.items
+
+import io.music_assistant.client.data.model.client.items.AppMediaItem
+import io.music_assistant.client.data.model.client.items.Playlist
+
+interface PlaylistActions {
+    suspend fun getEditablePlaylists(): List<Playlist>
+    fun addToPlaylist(
+        mediaItem: AppMediaItem,
+        playlist: Playlist,
+    )
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/ItemActions.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/ItemActions.kt
@@ -10,3 +10,8 @@ interface PlaylistActions {
         playlist: Playlist,
     )
 }
+
+interface LibraryActions {
+    fun onLibraryClick(item: AppMediaItem)
+    fun onFavoriteClick(item: AppMediaItem)
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/ItemActions.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/ItemActions.kt
@@ -15,3 +15,8 @@ interface LibraryActions {
     fun onLibraryClick(item: AppMediaItem)
     fun onFavoriteClick(item: AppMediaItem)
 }
+
+interface ProgressActions {
+    fun onMarkPlayed(item: AppMediaItem)
+    fun onMarkUnplayed(item: AppMediaItem)
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/PlayableItemWithMenu.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/PlayableItemWithMenu.kt
@@ -45,7 +45,6 @@ import io.music_assistant.client.data.model.client.items.RadioStation
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.settings.ViewMode
 import io.music_assistant.client.ui.compose.common.icons.PlayIcon
-import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import kotlinx.coroutines.launch
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.action_add_to_bottom
@@ -116,7 +115,7 @@ fun PodcastEpisodeWithMenu(
     playlistActions: PlaylistActions? = null,
     onRemoveFromPlaylist: (() -> Unit)? = null,
     libraryActions: LibraryActions,
-    progressActions: ActionsViewModel.ProgressActions? = null,
+    progressActions: ProgressActions? = null,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)?,
 ) {
     PlayableItemWithMenu(
@@ -208,7 +207,7 @@ private fun <T : PlayableItem> PlayableItemWithMenu(
     playlistActions: PlaylistActions? = null,
     onRemoveFromPlaylist: (() -> Unit)? = null,
     libraryActions: LibraryActions,
-    progressActions: ActionsViewModel.ProgressActions? = null,
+    progressActions: ProgressActions? = null,
     itemComposable: @Composable (
         modifier: Modifier,
         onClick: (T) -> Unit,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/PlayableItemWithMenu.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/PlayableItemWithMenu.kt
@@ -71,7 +71,7 @@ fun TrackWithMenu(
     item: Track,
     viewMode: ViewMode = ViewMode.GRID,
     onPlayOption: ((Track, QueueOption, Boolean) -> Unit),
-    playlistActions: ActionsViewModel.PlaylistActions? = null,
+    playlistActions: PlaylistActions? = null,
     onRemoveFromPlaylist: (() -> Unit)? = null,
     libraryActions: ActionsViewModel.LibraryActions,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)?,
@@ -113,7 +113,7 @@ fun PodcastEpisodeWithMenu(
     item: PodcastEpisode,
     viewMode: ViewMode = ViewMode.GRID,
     onPlayOption: ((PodcastEpisode, QueueOption, Boolean) -> Unit),
-    playlistActions: ActionsViewModel.PlaylistActions? = null,
+    playlistActions: PlaylistActions? = null,
     onRemoveFromPlaylist: (() -> Unit)? = null,
     libraryActions: ActionsViewModel.LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
@@ -157,7 +157,7 @@ fun RadioWithMenu(
     item: RadioStation,
     viewMode: ViewMode = ViewMode.GRID,
     onPlayOption: ((RadioStation, QueueOption, Boolean) -> Unit),
-    playlistActions: ActionsViewModel.PlaylistActions? = null,
+    playlistActions: PlaylistActions? = null,
     onRemoveFromPlaylist: (() -> Unit)? = null,
     libraryActions: ActionsViewModel.LibraryActions,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)?,
@@ -205,7 +205,7 @@ private fun <T : PlayableItem> PlayableItemWithMenu(
     modifier: Modifier = Modifier,
     item: T,
     onPlayOption: ((T, QueueOption, Boolean) -> Unit),
-    playlistActions: ActionsViewModel.PlaylistActions? = null,
+    playlistActions: PlaylistActions? = null,
     onRemoveFromPlaylist: (() -> Unit)? = null,
     libraryActions: ActionsViewModel.LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
@@ -362,7 +362,7 @@ private fun <T : PlayableItem> PlayableItemWithMenu(
                         // Load playlists when dialogue opens
                         coroutineScope.launch {
                             isLoadingPlaylists = true
-                            playlists = playlistActions.onLoadPlaylists()
+                            playlists = playlistActions.getEditablePlaylists()
                             isLoadingPlaylists = false
                         }
                     },
@@ -456,8 +456,7 @@ private fun <T : PlayableItem> PlayableItemWithMenu(
                             ) { playlist ->
                                 TextButton(
                                     onClick = {
-                                        playlistActions?.onAddToPlaylist
-                                            ?.invoke(item, playlist)
+                                        playlistActions?.addToPlaylist(item, playlist)
                                         showPlaylistDialog = false
                                         playlists = emptyList()
                                     },

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/PlayableItemWithMenu.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/PlayableItemWithMenu.kt
@@ -73,7 +73,7 @@ fun TrackWithMenu(
     onPlayOption: ((Track, QueueOption, Boolean) -> Unit),
     playlistActions: PlaylistActions? = null,
     onRemoveFromPlaylist: (() -> Unit)? = null,
-    libraryActions: ActionsViewModel.LibraryActions,
+    libraryActions: LibraryActions,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)?,
 ) {
     PlayableItemWithMenu(
@@ -115,7 +115,7 @@ fun PodcastEpisodeWithMenu(
     onPlayOption: ((PodcastEpisode, QueueOption, Boolean) -> Unit),
     playlistActions: PlaylistActions? = null,
     onRemoveFromPlaylist: (() -> Unit)? = null,
-    libraryActions: ActionsViewModel.LibraryActions,
+    libraryActions: LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)?,
 ) {
@@ -159,7 +159,7 @@ fun RadioWithMenu(
     onPlayOption: ((RadioStation, QueueOption, Boolean) -> Unit),
     playlistActions: PlaylistActions? = null,
     onRemoveFromPlaylist: (() -> Unit)? = null,
-    libraryActions: ActionsViewModel.LibraryActions,
+    libraryActions: LibraryActions,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)?,
 ) {
     PlayableItemWithMenu(
@@ -207,7 +207,7 @@ private fun <T : PlayableItem> PlayableItemWithMenu(
     onPlayOption: ((T, QueueOption, Boolean) -> Unit),
     playlistActions: PlaylistActions? = null,
     onRemoveFromPlaylist: (() -> Unit)? = null,
-    libraryActions: ActionsViewModel.LibraryActions,
+    libraryActions: LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
     itemComposable: @Composable (
         modifier: Modifier,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/viewmodel/ActionsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/viewmodel/ActionsViewModel.kt
@@ -10,6 +10,7 @@ import io.music_assistant.client.data.model.client.items.Playlist
 import io.music_assistant.client.data.repository.MediaItemRepository
 import io.music_assistant.client.ui.compose.common.items.LibraryActions
 import io.music_assistant.client.ui.compose.common.items.PlaylistActions
+import io.music_assistant.client.ui.compose.common.items.ProgressActions
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
@@ -22,7 +23,7 @@ class ActionsViewModel(
     private val apiClient: ServiceClient,
     private val dataSource: MainDataSource,
     private val mediaItemRepository: MediaItemRepository,
-) : ViewModel(), PlaylistActions, LibraryActions {
+) : ViewModel(), PlaylistActions, LibraryActions, ProgressActions {
     private val _toasts = MutableSharedFlow<String>()
     val toasts = _toasts.asSharedFlow()
 
@@ -114,7 +115,7 @@ class ActionsViewModel(
     /**
      * Mark an audiobook or podcast episode as fully played.
      */
-    fun onMarkPlayed(item: AppMediaItem) {
+    override fun onMarkPlayed(item: AppMediaItem) {
         viewModelScope.launch {
             item.uri?.let { uri ->
                 apiClient.sendRequest(Request.Library.markPlayed(uri))
@@ -127,7 +128,7 @@ class ActionsViewModel(
     /**
      * Mark an audiobook or podcast episode as unplayed (resets progress).
      */
-    fun onMarkUnplayed(item: AppMediaItem) {
+    override fun onMarkUnplayed(item: AppMediaItem) {
         viewModelScope.launch {
             item.uri?.let { uri ->
                 apiClient.sendRequest(Request.Library.markUnplayed(uri))
@@ -138,9 +139,4 @@ class ActionsViewModel(
     }
 
     fun getProviderIcon(provider: String) = dataSource.providerIcon(provider)
-
-    data class ProgressActions(
-        val onMarkPlayed: ((AppMediaItem) -> Unit),
-        val onMarkUnplayed: ((AppMediaItem) -> Unit),
-    )
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/viewmodel/ActionsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/viewmodel/ActionsViewModel.kt
@@ -8,6 +8,7 @@ import io.music_assistant.client.data.MainDataSource
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Playlist
 import io.music_assistant.client.data.repository.MediaItemRepository
+import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
@@ -20,7 +21,7 @@ class ActionsViewModel(
     private val apiClient: ServiceClient,
     private val dataSource: MainDataSource,
     private val mediaItemRepository: MediaItemRepository,
-) : ViewModel() {
+) : ViewModel(), PlaylistActions {
     private val _toasts = MutableSharedFlow<String>()
     val toasts = _toasts.asSharedFlow()
 
@@ -59,14 +60,14 @@ class ActionsViewModel(
         }
     }
 
-    suspend fun getEditablePlaylists(): List<Playlist> =
+    override suspend fun getEditablePlaylists(): List<Playlist> =
         mediaItemRepository.fetchMediaItems(Request.Playlist.listLibrary())
             .getOrNull()
             ?.filterIsInstance<Playlist>()
             ?.filter { it.isEditable }
             ?: emptyList()
 
-    fun addToPlaylist(
+    override fun addToPlaylist(
         mediaItem: AppMediaItem,
         playlist: Playlist,
     ) {
@@ -136,11 +137,6 @@ class ActionsViewModel(
     }
 
     fun getProviderIcon(provider: String) = dataSource.providerIcon(provider)
-
-    data class PlaylistActions(
-        val onLoadPlaylists: suspend () -> List<Playlist>,
-        val onAddToPlaylist: (AppMediaItem, Playlist) -> Unit,
-    )
 
     data class LibraryActions(
         val onLibraryClick: ((AppMediaItem) -> Unit),

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/viewmodel/ActionsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/viewmodel/ActionsViewModel.kt
@@ -8,6 +8,7 @@ import io.music_assistant.client.data.MainDataSource
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Playlist
 import io.music_assistant.client.data.repository.MediaItemRepository
+import io.music_assistant.client.ui.compose.common.items.LibraryActions
 import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -21,7 +22,7 @@ class ActionsViewModel(
     private val apiClient: ServiceClient,
     private val dataSource: MainDataSource,
     private val mediaItemRepository: MediaItemRepository,
-) : ViewModel(), PlaylistActions {
+) : ViewModel(), PlaylistActions, LibraryActions {
     private val _toasts = MutableSharedFlow<String>()
     val toasts = _toasts.asSharedFlow()
 
@@ -29,7 +30,7 @@ class ActionsViewModel(
      * Toggles library status of the item.
      * Adds to library if not in library, removes if already in library.
      */
-    fun onLibraryClick(item: AppMediaItem) {
+    override fun onLibraryClick(item: AppMediaItem) {
         viewModelScope.launch {
             if (item.isInLibrary) {
                 apiClient.sendRequest(
@@ -46,9 +47,9 @@ class ActionsViewModel(
     /**
      * Sets exact or toggles favorite status of the item.
      */
-    fun onFavoriteClick(item: AppMediaItem, newState: Boolean? = null) {
+    override fun onFavoriteClick(item: AppMediaItem) {
         viewModelScope.launch {
-            if (newState ?: (item.favorite != true)) {
+            if (item.favorite != true) {
                 item.uri?.let {
                     apiClient.sendRequest(Request.Library.addFavorite(it))
                 }
@@ -137,11 +138,6 @@ class ActionsViewModel(
     }
 
     fun getProviderIcon(provider: String) = dataSource.providerIcon(provider)
-
-    data class LibraryActions(
-        val onLibraryClick: ((AppMediaItem) -> Unit),
-        val onFavoriteClick: ((AppMediaItem) -> Unit),
-    )
 
     data class ProgressActions(
         val onMarkPlayed: ((AppMediaItem) -> Unit),

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -84,17 +84,15 @@ import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun HomeScreen(
+    homeScreenViewModel: HomeScreenViewModel,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues,
     connectionState: SessionState,
     dataState: DataState<List<RecommendationFolder>>,
     onNavigateClick: (AppMediaItem) -> Unit,
-    onPlayClick: ((AppMediaItem, QueueOption, Boolean) -> Unit),
     onLibraryItemClick: (MediaType?) -> Unit,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
-    onRefresh: () -> Unit,
     hiddenFolderIds: Set<String>,
-    onSaveHiddenFolders: (Set<String>) -> Unit,
     actionsViewModel: ActionsViewModel,
 ) {
     var editMode by remember { mutableStateOf(false) }
@@ -140,10 +138,10 @@ fun HomeScreen(
             LandingPageTopBar(
                 scrollBehavior = scrollBehavior,
                 editMode = editMode,
-                onRefresh = onRefresh,
+                onRefresh = { homeScreenViewModel.loadRecommendations() },
                 onToggleEditMode = {
                     if (editMode) {
-                        onSaveHiddenFolders(pendingHidden)
+                        homeScreenViewModel.saveHiddenRecommendationFolders(pendingHidden)
                         editMode = false
                     } else {
                         pendingHidden = hiddenFolderIds
@@ -176,7 +174,7 @@ fun HomeScreen(
                             title = row.displayName,
                             rowItemType = row.rowItemType,
                             onNavigateClick = onNavigateClick,
-                            onPlayClick = onPlayClick,
+                            onPlayClick = homeScreenViewModel::onPlayClick,
                             onAllClick = { row.rowItemType?.let { onLibraryItemClick(it) } },
                             mediaItems = row.items.orEmpty(),
                             playlistActions = ActionsViewModel.PlaylistActions(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -58,6 +58,7 @@ import io.music_assistant.client.ui.compose.common.items.AlbumWithMenu
 import io.music_assistant.client.ui.compose.common.items.ArtistWithMenu
 import io.music_assistant.client.ui.compose.common.items.AudiobookWithMenu
 import io.music_assistant.client.ui.compose.common.items.GenreWithMenu
+import io.music_assistant.client.ui.compose.common.items.LibraryActions
 import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import io.music_assistant.client.ui.compose.common.items.PlaylistWithMenu
 import io.music_assistant.client.ui.compose.common.items.PodcastEpisodeWithMenu
@@ -179,10 +180,7 @@ fun HomeScreen(
                             onAllClick = { row.rowItemType?.let { onLibraryItemClick(it) } },
                             mediaItems = row.items.orEmpty(),
                             playlistActions = actionsViewModel,
-                            libraryActions = ActionsViewModel.LibraryActions(
-                                onLibraryClick = actionsViewModel::onLibraryClick,
-                                onFavoriteClick = actionsViewModel::onFavoriteClick,
-                            ),
+                            libraryActions = actionsViewModel,
                             progressActions = ActionsViewModel.ProgressActions(
                                 onMarkPlayed = actionsViewModel::onMarkPlayed,
                                 onMarkUnplayed = actionsViewModel::onMarkUnplayed,
@@ -271,7 +269,7 @@ fun CategoryRow(
     onAllClick: () -> Unit,
     mediaItems: List<AppMediaItem>,
     playlistActions: PlaylistActions,
-    libraryActions: ActionsViewModel.LibraryActions,
+    libraryActions: LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
 ) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -63,6 +63,7 @@ import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import io.music_assistant.client.ui.compose.common.items.PlaylistWithMenu
 import io.music_assistant.client.ui.compose.common.items.PodcastEpisodeWithMenu
 import io.music_assistant.client.ui.compose.common.items.PodcastWithMenu
+import io.music_assistant.client.ui.compose.common.items.ProgressActions
 import io.music_assistant.client.ui.compose.common.items.RadioWithMenu
 import io.music_assistant.client.ui.compose.common.items.TrackWithMenu
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
@@ -181,10 +182,7 @@ fun HomeScreen(
                             mediaItems = row.items.orEmpty(),
                             playlistActions = actionsViewModel,
                             libraryActions = actionsViewModel,
-                            progressActions = ActionsViewModel.ProgressActions(
-                                onMarkPlayed = actionsViewModel::onMarkPlayed,
-                                onMarkUnplayed = actionsViewModel::onMarkUnplayed,
-                            ),
+                            progressActions = actionsViewModel,
                             providerIconFetcher = providerIconFetcher,
                         )
                         if (editMode) {
@@ -270,7 +268,7 @@ fun CategoryRow(
     mediaItems: List<AppMediaItem>,
     playlistActions: PlaylistActions,
     libraryActions: LibraryActions,
-    progressActions: ActionsViewModel.ProgressActions? = null,
+    progressActions: ProgressActions? = null,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
 ) {
     val rowListState = rememberLazyListState()

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -58,6 +58,7 @@ import io.music_assistant.client.ui.compose.common.items.AlbumWithMenu
 import io.music_assistant.client.ui.compose.common.items.ArtistWithMenu
 import io.music_assistant.client.ui.compose.common.items.AudiobookWithMenu
 import io.music_assistant.client.ui.compose.common.items.GenreWithMenu
+import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import io.music_assistant.client.ui.compose.common.items.PlaylistWithMenu
 import io.music_assistant.client.ui.compose.common.items.PodcastEpisodeWithMenu
 import io.music_assistant.client.ui.compose.common.items.PodcastWithMenu
@@ -177,10 +178,7 @@ fun HomeScreen(
                             onPlayClick = homeScreenViewModel::onPlayClick,
                             onAllClick = { row.rowItemType?.let { onLibraryItemClick(it) } },
                             mediaItems = row.items.orEmpty(),
-                            playlistActions = ActionsViewModel.PlaylistActions(
-                                onLoadPlaylists = actionsViewModel::getEditablePlaylists,
-                                onAddToPlaylist = actionsViewModel::addToPlaylist,
-                            ),
+                            playlistActions = actionsViewModel,
                             libraryActions = ActionsViewModel.LibraryActions(
                                 onLibraryClick = actionsViewModel::onLibraryClick,
                                 onFavoriteClick = actionsViewModel::onFavoriteClick,
@@ -272,7 +270,7 @@ fun CategoryRow(
     onPlayClick: ((AppMediaItem, QueueOption, Boolean) -> Unit),
     onAllClick: () -> Unit,
     mediaItems: List<AppMediaItem>,
-    playlistActions: ActionsViewModel.PlaylistActions,
+    playlistActions: PlaylistActions,
     libraryActions: ActionsViewModel.LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -91,13 +91,11 @@ fun HomeScreen(
     onNavigateClick: (AppMediaItem) -> Unit,
     onPlayClick: ((AppMediaItem, QueueOption, Boolean) -> Unit),
     onLibraryItemClick: (MediaType?) -> Unit,
-    playlistActions: ActionsViewModel.PlaylistActions,
-    libraryActions: ActionsViewModel.LibraryActions,
-    progressActions: ActionsViewModel.ProgressActions? = null,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
     onRefresh: () -> Unit,
     hiddenFolderIds: Set<String>,
     onSaveHiddenFolders: (Set<String>) -> Unit,
+    actionsViewModel: ActionsViewModel,
 ) {
     var editMode by remember { mutableStateOf(false) }
     var pendingHidden by remember { mutableStateOf(hiddenFolderIds) }
@@ -181,9 +179,18 @@ fun HomeScreen(
                             onPlayClick = onPlayClick,
                             onAllClick = { row.rowItemType?.let { onLibraryItemClick(it) } },
                             mediaItems = row.items.orEmpty(),
-                            playlistActions = playlistActions,
-                            libraryActions = libraryActions,
-                            progressActions = progressActions,
+                            playlistActions = ActionsViewModel.PlaylistActions(
+                                onLoadPlaylists = actionsViewModel::getEditablePlaylists,
+                                onAddToPlaylist = actionsViewModel::addToPlaylist,
+                            ),
+                            libraryActions = ActionsViewModel.LibraryActions(
+                                onLibraryClick = actionsViewModel::onLibraryClick,
+                                onFavoriteClick = actionsViewModel::onFavoriteClick,
+                            ),
+                            progressActions = ActionsViewModel.ProgressActions(
+                                onMarkPlayed = actionsViewModel::onMarkPlayed,
+                                onMarkUnplayed = actionsViewModel::onMarkUnplayed,
+                            ),
                             providerIconFetcher = providerIconFetcher,
                         )
                         if (editMode) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -238,13 +238,14 @@ private fun mainNavEntryProvider(
     dataState: DataState<List<RecommendationFolder>>,
     hiddenFolderIds: Set<String>,
     multiBackStack: MultiBackStack<NavKey>,
-    homeScrenViewModel: HomeScreenViewModel,
+    homeScreenViewModel: HomeScreenViewModel,
     actionsViewModel: ActionsViewModel,
 ): (NavKey) -> NavEntry<NavKey> {
     val libraryNavCoordinator: LibraryNavCoordinator = koinInject()
     return entryProvider {
         entry<MainNav.Landing> {
             HomeScreen(
+                homeScreenViewModel,
                 contentPadding = contentPadding,
                 connectionState = connectionState,
                 dataState = dataState,
@@ -269,7 +270,6 @@ private fun mainNavEntryProvider(
                         else -> Unit
                     }
                 },
-                onPlayClick = homeScrenViewModel::onPlayClick,
                 onLibraryItemClick = { type ->
                     type?.let { libraryNavCoordinator.requestTab(it) }
                     multiBackStack.switchTo(1, MainNav.Library(type))
@@ -278,9 +278,7 @@ private fun mainNavEntryProvider(
                     actionsViewModel.getProviderIcon(provider)
                         ?.let { ProviderIcon(modifier, it) }
                 },
-                onRefresh = { homeScrenViewModel.loadRecommendations() },
                 hiddenFolderIds = hiddenFolderIds,
-                onSaveHiddenFolders = homeScrenViewModel::saveHiddenRecommendationFolders,
                 actionsViewModel = actionsViewModel,
             )
         }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -7,9 +7,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
@@ -19,7 +16,6 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -27,10 +23,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavEntry
@@ -42,9 +36,7 @@ import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import androidx.savedstate.serialization.SavedStateConfiguration
 import io.music_assistant.client.data.model.client.MediaType
-import io.music_assistant.client.data.model.client.PlayerData
 import io.music_assistant.client.data.model.client.items.Album
-import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Artist
 import io.music_assistant.client.data.model.client.items.Audiobook
 import io.music_assistant.client.data.model.client.items.Genre
@@ -52,10 +44,7 @@ import io.music_assistant.client.data.model.client.items.Playlist
 import io.music_assistant.client.data.model.client.items.Podcast
 import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.ui.compose.common.DataState
-import io.music_assistant.client.ui.compose.common.action.PlayerAction
-import io.music_assistant.client.ui.compose.common.action.QueueAction
 import io.music_assistant.client.ui.compose.common.providers.ProviderIcon
-import io.music_assistant.client.ui.compose.common.rememberExtractedColorsFetcher
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.home.players.DspSettingsViewModel
@@ -142,25 +131,6 @@ fun MainNavigationRoot(
 
     var playerExpanded by remember { mutableStateOf(false) }
 
-    val playlistActions = remember(actionsViewModel) {
-        ActionsViewModel.PlaylistActions(
-            onLoadPlaylists = actionsViewModel::getEditablePlaylists,
-            onAddToPlaylist = actionsViewModel::addToPlaylist,
-        )
-    }
-    val libraryActions = remember(actionsViewModel) {
-        ActionsViewModel.LibraryActions(
-            onLibraryClick = actionsViewModel::onLibraryClick,
-            onFavoriteClick = actionsViewModel::onFavoriteClick,
-        )
-    }
-    val progressActions = remember(actionsViewModel) {
-        ActionsViewModel.ProgressActions(
-            onMarkPlayed = actionsViewModel::onMarkPlayed,
-            onMarkUnplayed = actionsViewModel::onMarkUnplayed,
-        )
-    }
-
     val onExpandPlayer = remember { { expanded: Boolean -> playerExpanded = expanded } }
 
     val backStacks = listOf(
@@ -207,7 +177,7 @@ fun MainNavigationRoot(
                     expanded = playerExpanded,
                     onExpand = onExpandPlayer,
                     { expanded, contentPadding ->
-                        Players(
+                        PlayersPager(
                             playerPagerState = playerPagerState,
                             state = playersState,
                             homeScreenViewModel = homeScreenViewModel,
@@ -216,8 +186,15 @@ fun MainNavigationRoot(
                             expanded = expanded,
                             onClose = { playerExpanded = false },
                             contentPadding = contentPadding,
-                            backStack = multiBackStack,
-                        )
+                        ) { item ->
+                            multiBackStack.add(
+                                MainNav.ItemDetails(
+                                    itemId = item.itemId,
+                                    mediaType = item.mediaType,
+                                    providerId = item.provider,
+                                ),
+                            )
+                        }
                     },
                 )
             },
@@ -239,12 +216,8 @@ fun MainNavigationRoot(
                                 connectionState,
                                 dataState,
                                 hiddenFolderIds,
-
                                 multiBackStack,
                                 homeScreenViewModel,
-                                playlistActions,
-                                libraryActions,
-                                progressActions,
                                 actionsViewModel,
                             ),
                         ),
@@ -265,10 +238,7 @@ private fun mainNavEntryProvider(
     dataState: DataState<List<RecommendationFolder>>,
     hiddenFolderIds: Set<String>,
     multiBackStack: MultiBackStack<NavKey>,
-    viewModel: HomeScreenViewModel,
-    playlistActions: ActionsViewModel.PlaylistActions,
-    libraryActions: ActionsViewModel.LibraryActions,
-    progressActions: ActionsViewModel.ProgressActions,
+    homeScrenViewModel: HomeScreenViewModel,
     actionsViewModel: ActionsViewModel,
 ): (NavKey) -> NavEntry<NavKey> {
     val libraryNavCoordinator: LibraryNavCoordinator = koinInject()
@@ -299,21 +269,19 @@ private fun mainNavEntryProvider(
                         else -> Unit
                     }
                 },
-                onPlayClick = viewModel::onPlayClick,
+                onPlayClick = homeScrenViewModel::onPlayClick,
                 onLibraryItemClick = { type ->
                     type?.let { libraryNavCoordinator.requestTab(it) }
                     multiBackStack.switchTo(1, MainNav.Library(type))
                 },
-                playlistActions = playlistActions,
-                libraryActions = libraryActions,
-                progressActions = progressActions,
                 providerIconFetcher = { modifier, provider ->
                     actionsViewModel.getProviderIcon(provider)
                         ?.let { ProviderIcon(modifier, it) }
                 },
-                onRefresh = { viewModel.loadRecommendations() },
+                onRefresh = { homeScrenViewModel.loadRecommendations() },
                 hiddenFolderIds = hiddenFolderIds,
-                onSaveHiddenFolders = viewModel::saveHiddenRecommendationFolders,
+                onSaveHiddenFolders = homeScrenViewModel::saveHiddenRecommendationFolders,
+                actionsViewModel = actionsViewModel,
             )
         }
 
@@ -386,104 +354,6 @@ private fun mainNavEntryProvider(
                 },
                 contentPadding = contentPadding,
                 actionsViewModel = actionsViewModel,
-            )
-        }
-    }
-}
-
-@Composable
-private fun Players(
-    playerPagerState: PagerState,
-    state: HomeScreenViewModel.PlayersState,
-    homeScreenViewModel: HomeScreenViewModel,
-    actionsViewModel: ActionsViewModel,
-    dspSettingsViewModel: DspSettingsViewModel,
-    expanded: Boolean,
-    onClose: () -> Unit,
-    contentPadding: PaddingValues,
-    backStack: MultiBackStack<NavKey>,
-) {
-    if (state is HomeScreenViewModel.PlayersState.Data && state.playerData.isNotEmpty()) {
-        val simplePlayerAction = remember(homeScreenViewModel) {
-            {
-                playerId: String, action: PlayerAction ->
-                homeScreenViewModel.playerAction(playerId, action)
-            }
-        }
-        val playerAction = remember(homeScreenViewModel) {
-            {
-                playerData: PlayerData, action: PlayerAction ->
-                homeScreenViewModel.playerAction(playerData, action)
-            }
-        }
-        val onFavoriteClick = remember(actionsViewModel) {
-            {
-                item: AppMediaItem ->
-                    actionsViewModel.onFavoriteClick(item)
-                }
-        }
-        val queueAction = remember(homeScreenViewModel) {
-            {
-                action: QueueAction ->
-                    homeScreenViewModel.queueAction(action)
-                }
-        }
-        val moveToPlayer = remember(state, homeScreenViewModel) {
-            {
-                id: String ->
-                state.playerData.find { it.player.id == id }
-                    ?.let { homeScreenViewModel.selectPlayer(it.player) }
-                Unit
-            }
-        }
-        val onPlayersReorder = remember(homeScreenViewModel) {
-            {
-                newPlayerIds: List<String> ->
-                homeScreenViewModel.onPlayersSortChanged(newPlayerIds)
-            }
-        }
-        val fetchColors = rememberExtractedColorsFetcher()
-
-        PlayersPager(
-            playerPagerState = playerPagerState,
-            playersState = state,
-            simplePlayerAction = simplePlayerAction,
-            playerAction = playerAction,
-            onFavoriteClick = onFavoriteClick,
-            onClose = onClose,
-            navigateToItem = { item ->
-                backStack.add(
-                    MainNav.ItemDetails(
-                        itemId = item.itemId,
-                        mediaType = item.mediaType,
-                        providerId = item.provider,
-                    ),
-                )
-            },
-            onPlayersReorder = onPlayersReorder,
-            queueAction = queueAction,
-            moveToPlayer = moveToPlayer,
-            contentPadding = contentPadding,
-            localPlayerId = homeScreenViewModel.localPlayerId,
-            onAdjustPlaybackDelay = homeScreenViewModel::adjustSendspinStaticDelayMs,
-            fetchColors = fetchColors,
-            observePosition = homeScreenViewModel::observePosition,
-            compact = !expanded,
-            dspSettingsViewModel = dspSettingsViewModel,
-        )
-    } else {
-        Box(Modifier.fillMaxWidth().height(84.dp)) {
-            val text = when (state) {
-                is HomeScreenViewModel.PlayersState.Loading -> "Loading players..."
-                is HomeScreenViewModel.PlayersState.Data -> "No players available"
-                else -> "No players available"
-            }
-
-            Text(
-                modifier = Modifier.align(Alignment.Center),
-                text = text,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -1,4 +1,3 @@
-@file:OptIn(ExperimentalMaterial3Api::class)
 // Compose layout values (sizes, alphas, animation durations) are visual design tokens.
 @file:Suppress("MagicNumber")
 
@@ -48,6 +47,7 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -76,7 +76,6 @@ import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.player.sendspin.SendspinState
 import io.music_assistant.client.ui.alphaOn
 import io.music_assistant.client.ui.compose.common.DataState
-import io.music_assistant.client.ui.compose.common.ExtractedColorsFetcher
 import io.music_assistant.client.ui.compose.common.OverflowMenu
 import io.music_assistant.client.ui.compose.common.OverflowMenuButton
 import io.music_assistant.client.ui.compose.common.OverflowMenuOption
@@ -88,6 +87,8 @@ import io.music_assistant.client.ui.compose.common.icons.VolumeIcon
 import io.music_assistant.client.ui.compose.common.icons.VolumeMutedIcon
 import io.music_assistant.client.ui.compose.common.items.navigationOptions
 import io.music_assistant.client.ui.compose.common.rememberAnimatedPlayerColors
+import io.music_assistant.client.ui.compose.common.rememberExtractedColorsFetcher
+import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.home.CollapsibleQueue
 import io.music_assistant.client.ui.compose.home.HomeScreenViewModel
 import io.music_assistant.client.ui.compose.home.HorizontalPagerIndicator
@@ -107,158 +108,186 @@ import musicassistantclient.composeapp.generated.resources.queue_transfer
 import org.jetbrains.compose.resources.stringResource
 import kotlin.math.roundToInt
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-internal fun PlayersPager(
-    modifier: Modifier = Modifier,
+@OptIn(ExperimentalMaterial3Api::class)
+fun PlayersPager(
     playerPagerState: PagerState,
-    playersState: HomeScreenViewModel.PlayersState.Data,
-    simplePlayerAction: (String, PlayerAction) -> Unit,
-    playerAction: (PlayerData, PlayerAction) -> Unit,
-    onFavoriteClick: (AppMediaItem) -> Unit,
-    onClose: () -> Unit,
-    navigateToItem: (AppMediaItem) -> Unit,
-    onPlayersReorder: (List<String>) -> Unit,
-    queueAction: (QueueAction) -> Unit,
-    moveToPlayer: (String) -> Unit,
-    contentPadding: PaddingValues,
-    localPlayerId: String,
-    onAdjustPlaybackDelay: (Int) -> Unit,
-    fetchColors: ExtractedColorsFetcher,
-    observePosition: (queueId: String) -> Flow<Double>,
-    compact: Boolean,
+    state: HomeScreenViewModel.PlayersState,
+    homeScreenViewModel: HomeScreenViewModel,
+    actionsViewModel: ActionsViewModel,
     dspSettingsViewModel: DspSettingsViewModel,
+    expanded: Boolean,
+    onClose: () -> Unit,
+    contentPadding: PaddingValues,
+    navigateToItem: (AppMediaItem) -> Unit,
 ) {
-    var isQueueExpanded by remember { mutableStateOf(false) }
-
-    // Extract playerData list to ensure proper recomposition
-    val playerDataList = playersState.playerData
-
-    // Select-player dialog is hoisted out of the pager so that reordering-induced
-    // pager scrolls don't tear down the dialog's composable.
-    var selectDialogPlayerId by remember { mutableStateOf<String?>(null) }
-    val selectDialogPlayer = selectDialogPlayerId?.let { id ->
-        playerDataList.firstOrNull { it.player.id == id }
-    }
-    if (selectDialogPlayer != null) {
-        SelectPlayerDialog(
-            selectedPlayer = selectDialogPlayer,
-            players = playerDataList,
-            onDismissRequest = { selectDialogPlayerId = null },
-            onMoveToPlayer = { moveToPlayer(it) },
-            onReorder = onPlayersReorder,
-        )
-    }
-
-    val playerColors = playerDataList.associateWith {
-        val imageUrl = it.player.currentMedia?.imageUrl
-        rememberAnimatedPlayerColors(
-            imageUrl = imageUrl,
-            fallback = MaterialTheme.colorScheme.primaryContainer,
-            fetchColors = fetchColors,
-        )
-    }
-
-    val isExpandedScreen = WindowClass.isAtLeastExpanded()
-    val modifier = if (compact) {
-        modifier
-    } else {
-        modifier.statusBarsPadding()
-    }
-
-    Column(modifier = modifier) {
-        if (playerDataList.size > 1) {
-            HorizontalPagerIndicator(
-                modifier = Modifier.padding(top = 4.dp),
-                pagerState = playerPagerState,
-            )
+    if (state is HomeScreenViewModel.PlayersState.Data && state.playerData.isNotEmpty()) {
+        val moveToPlayer: (String) -> Unit = { id: String ->
+            state.playerData.find { it.player.id == id }
+                ?.let { homeScreenViewModel.selectPlayer(it.player) }
         }
 
-        HorizontalPager(
-            modifier = Modifier,
-            state = playerPagerState,
-            key = { page -> playerDataList.getOrNull(page)?.player?.id ?: page },
-        ) { page ->
-            val player = playerDataList.getOrNull(page) ?: return@HorizontalPager
-            var showGroupDialog by remember { mutableStateOf(false) }
-            var showDspDialog by remember { mutableStateOf(false) }
-            val onSelectPlayer = { selectDialogPlayerId = player.player.id }
-            val onGroupButton = { showGroupDialog = true }
-            val onDspButton = { showDspDialog = true }
-            if (showGroupDialog) {
-                GroupSettingsDialog(
-                    player = player,
-                    onDismissRequest = { showGroupDialog = false },
-                    groupAction = simplePlayerAction,
-                    localPlayerId = localPlayerId,
-                    onAdjustPlaybackDelay = onAdjustPlaybackDelay,
+        val fetchColors = rememberExtractedColorsFetcher()
+
+        val playerAction1 =
+            { data: PlayerData, action: PlayerAction ->
+                homeScreenViewModel.playerAction(
+                    data,
+                    action,
                 )
             }
-            if (showDspDialog) {
-                DspSettingsDialog(
-                    playerId = player.player.id,
-                    dspSettingsViewModel = dspSettingsViewModel,
-                    onDismissRequest = { showDspDialog = false },
+        var isQueueExpanded by remember { mutableStateOf(false) }
+        // Extract playerData list to ensure proper recomposition
+        val playerDataList = state.playerData
+        // Select-player dialog is hoisted out of the pager so that reordering-induced
+        // pager scrolls don't tear down the dialog's composable.
+        var selectDialogPlayerId by remember<MutableState<String?>> { mutableStateOf(null) }
+        val selectDialogPlayer = selectDialogPlayerId?.let { id ->
+            playerDataList.firstOrNull { it.player.id == id }
+        }
+        if (selectDialogPlayer != null) {
+            SelectPlayerDialog(
+                selectedPlayer = selectDialogPlayer,
+                players = playerDataList,
+                onDismissRequest = { selectDialogPlayerId = null },
+                onMoveToPlayer = { moveToPlayer(it) },
+                onReorder = { homeScreenViewModel.onPlayersSortChanged(it) },
+            )
+        }
+        val playerColors = playerDataList.associateWith {
+            val imageUrl = it.player.currentMedia?.imageUrl
+            rememberAnimatedPlayerColors(
+                imageUrl = imageUrl,
+                fallback = MaterialTheme.colorScheme.primaryContainer,
+                fetchColors = fetchColors,
+            )
+        }
+        val isExpandedScreen = WindowClass.isAtLeastExpanded()
+        val modifier = if (!expanded) {
+            Modifier
+        } else {
+            Modifier.statusBarsPadding()
+        }
+        Column(modifier = modifier) {
+            if (playerDataList.size > 1) {
+                HorizontalPagerIndicator(
+                    modifier = Modifier.padding(top = 4.dp),
+                    pagerState = playerPagerState,
                 )
             }
 
-            val colors by playerColors.getValue(player)
+            HorizontalPager(
+                modifier = Modifier,
+                state = playerPagerState,
+                key = { page -> playerDataList.getOrNull(page)?.player?.id ?: page },
+            ) { page ->
+                val player = playerDataList.getOrNull(page) ?: return@HorizontalPager
+                var showGroupDialog by remember { mutableStateOf(false) }
+                var showDspDialog by remember { mutableStateOf(false) }
+                val onSelectPlayer = { selectDialogPlayerId = player.player.id }
+                val onGroupButton = { showGroupDialog = true }
+                val onDspButton = { showDspDialog = true }
+                if (showGroupDialog) {
+                    GroupSettingsDialog(
+                        player = player,
+                        onDismissRequest = { showGroupDialog = false },
+                        groupAction = { playerId: String, action: PlayerAction ->
+                            homeScreenViewModel.playerAction(
+                                playerId,
+                                action,
+                            )
+                        },
+                        localPlayerId = homeScreenViewModel.localPlayerId,
+                        onAdjustPlaybackDelay = {
+                            homeScreenViewModel.adjustSendspinStaticDelayMs(it)
+                        },
+                    )
+                }
+                if (showDspDialog) {
+                    DspSettingsDialog(
+                        playerId = player.player.id,
+                        dspSettingsViewModel = dspSettingsViewModel,
+                        onDismissRequest = { showDspDialog = false },
+                    )
+                }
 
-            Box(modifier = Modifier.wrapContentHeight()) {
-                Column(
-                    Modifier
-                        .background(
-                            brush = Brush.verticalGradient(
-                                listOf(
-                                    MaterialTheme.colorScheme.surfaceContainerHigh,
-                                    colors.dominant.inactive(),
+                val colors by playerColors.getValue(player)
+
+                Box(modifier = Modifier.wrapContentHeight()) {
+                    Column(
+                        Modifier
+                            .background(
+                                brush = Brush.verticalGradient(
+                                    listOf(
+                                        MaterialTheme.colorScheme.surfaceContainerHigh,
+                                        colors.dominant.inactive(),
+                                    ),
                                 ),
                             ),
-                        ),
-                ) {
-                    if (compact) {
-                        CollapsedPlayerPage(
-                            isExpandedScreen = isExpandedScreen,
-                            player = player,
-                            colors = colors,
-                            sendspinState = playersState.sendspinState,
-                            onSelectPlayer = onSelectPlayer,
-                            onGroupButton = onGroupButton,
-                            playerAction = playerAction,
-                        )
-                    } else {
-                        ExpandedPlayerPage(
-                            player = player,
-                            colors = colors,
-                            onSelectPlayer = onSelectPlayer,
-                            onGroupButton = onGroupButton,
-                            onDspButton = onDspButton.takeIf { !player.player.isGroup },
-                            playerAction = playerAction,
-                            onFavoriteClick = onFavoriteClick,
-                            onClose = onClose,
-                            queueAction = queueAction,
-                            allPlayers = playerDataList,
+                    ) {
+                        if (!expanded) {
+                            CollapsedPlayerPage(
+                                isExpandedScreen = isExpandedScreen,
+                                player = player,
+                                colors = colors,
+                                sendspinState = state.sendspinState,
+                                onSelectPlayer = onSelectPlayer,
+                                onGroupButton = onGroupButton,
+                                playerAction = playerAction1,
+                            )
+                        } else {
+                            ExpandedPlayerPage(
+                                player = player,
+                                colors = colors,
+                                onSelectPlayer = onSelectPlayer,
+                                onGroupButton = onGroupButton,
+                                onDspButton = onDspButton.takeIf { !player.player.isGroup },
+                                playerAction = playerAction1,
+                                onFavoriteClick = {
+                                    actionsViewModel.onFavoriteClick(it)
+                                },
+                                onClose = onClose,
+                                queueAction = { homeScreenViewModel.queueAction(it) },
+                                allPlayers = playerDataList,
+                                moveToPlayer = moveToPlayer,
+                                isExpandedScreen = isExpandedScreen,
+                                sendspinState = state.sendspinState,
+                                isQueueExpanded = isQueueExpanded,
+                                onExpandQueue = { isQueueExpanded = it },
+                                contentPadding = contentPadding,
+                                isCurrentPage = page == playerPagerState.currentPage,
+                                navigateToItem = navigateToItem,
+                                livePositionFlow = player.queueInfo?.id?.let(block = {
+                                    homeScreenViewModel.observePosition(it)
+                                }),
+                            )
+                        }
+                    }
+                    player.parentBind?.let {
+                        BoundPlayerInfo(
+                            modifier = Modifier.matchParentSize(),
+                            playerName = player.player.name,
+                            parent = it,
                             moveToPlayer = moveToPlayer,
-                            isExpandedScreen = isExpandedScreen,
-                            sendspinState = playersState.sendspinState,
-                            isQueueExpanded = isQueueExpanded,
-                            onExpandQueue = { isQueueExpanded = it },
-                            contentPadding = contentPadding,
-                            isCurrentPage = page == playerPagerState.currentPage,
-                            navigateToItem = navigateToItem,
-                            livePositionFlow = player.queueInfo?.id?.let(observePosition),
                         )
                     }
                 }
-                player.parentBind?.let {
-                    BoundPlayerInfo(
-                        modifier = Modifier.matchParentSize(),
-                        playerName = player.player.name,
-                        parent = it,
-                        moveToPlayer = moveToPlayer,
-                    )
-                }
             }
+        }
+    } else {
+        Box(Modifier.fillMaxWidth().height(84.dp)) {
+            val text = when (state) {
+                is HomeScreenViewModel.PlayersState.Loading -> "Loading players..."
+                is HomeScreenViewModel.PlayersState.Data -> "No players available"
+                else -> "No players available"
+            }
+
+            Text(
+                modifier = Modifier.align(Alignment.Center),
+                text = text,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -68,6 +68,7 @@ import io.music_assistant.client.ui.compose.common.ToastHost
 import io.music_assistant.client.ui.compose.common.ToastState
 import io.music_assistant.client.ui.compose.common.items.AlbumWithMenu
 import io.music_assistant.client.ui.compose.common.items.ArtistWithMenu
+import io.music_assistant.client.ui.compose.common.items.LibraryActions
 import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import io.music_assistant.client.ui.compose.common.items.PodcastEpisodeWithMenu
 import io.music_assistant.client.ui.compose.common.items.TrackWithMenu
@@ -167,10 +168,15 @@ fun ItemDetails(
         }
     }
 
-    val libraryActions = ActionsViewModel.LibraryActions(
-        onLibraryClick = onLibraryClick,
-        onFavoriteClick = onFavoriteClick,
-    )
+    val libraryActions = object : LibraryActions {
+        override fun onLibraryClick(item: AppMediaItem) {
+            onLibraryClick(item)
+        }
+
+        override fun onFavoriteClick(item: AppMediaItem) {
+            onFavoriteClick(item)
+        }
+    }
 
     val progressActions = ActionsViewModel.ProgressActions(
         onMarkPlayed = onMarkPlayed,
@@ -249,7 +255,7 @@ private fun ItemChildren(
     playlistActions: PlaylistActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
     onRemoveFromPlaylist: (String, Int) -> Unit,
-    libraryActions: ActionsViewModel.LibraryActions,
+    libraryActions: LibraryActions,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
     onBack: () -> Unit,
     onToggleViewMode: (MediaType) -> Unit,
@@ -317,7 +323,7 @@ private fun ItemContent(
     playlistActions: PlaylistActions,
     progressActions: ActionsViewModel.ProgressActions?,
     onRemoveFromPlaylist: (String, Int) -> Unit,
-    libraryActions: ActionsViewModel.LibraryActions,
+    libraryActions: LibraryActions,
     providerIconFetcher: @Composable (Modifier, String) -> Unit,
     onBack: () -> Unit,
     viewModeProvider: @Composable (MediaType) -> ViewMode,
@@ -478,7 +484,7 @@ private fun TabContent(
     playlistActions: PlaylistActions,
     progressActions: ActionsViewModel.ProgressActions?,
     onRemoveFromPlaylist: (String, Int) -> Unit,
-    libraryActions: ActionsViewModel.LibraryActions,
+    libraryActions: LibraryActions,
     providerIconFetcher: @Composable (Modifier, String) -> Unit,
     contentPadding: PaddingValues,
     heroSlot: @Composable () -> Unit,
@@ -551,7 +557,7 @@ private fun AlbumsTabContent(
     viewModeProvider: @Composable (MediaType) -> ViewMode,
     onNavigateClick: (AppMediaItem) -> Unit,
     onPlayChildClick: (AppMediaItem, QueueOption, Boolean) -> Unit,
-    libraryActions: ActionsViewModel.LibraryActions,
+    libraryActions: LibraryActions,
     providerIconFetcher: @Composable (Modifier, String) -> Unit,
     contentPadding: PaddingValues,
     heroSlot: @Composable () -> Unit,
@@ -606,7 +612,7 @@ private fun ArtistsTabContent(
     viewModeProvider: @Composable (MediaType) -> ViewMode,
     onNavigateClick: (AppMediaItem) -> Unit,
     onPlayChildClick: (AppMediaItem, QueueOption, Boolean) -> Unit,
-    libraryActions: ActionsViewModel.LibraryActions,
+    libraryActions: LibraryActions,
     providerIconFetcher: @Composable (Modifier, String) -> Unit,
     contentPadding: PaddingValues,
     heroSlot: @Composable () -> Unit,
@@ -664,7 +670,7 @@ private fun PlayablesTabContent(
     playlistActions: PlaylistActions,
     progressActions: ActionsViewModel.ProgressActions?,
     onRemoveFromPlaylist: (String, Int) -> Unit,
-    libraryActions: ActionsViewModel.LibraryActions,
+    libraryActions: LibraryActions,
     providerIconFetcher: @Composable (Modifier, String) -> Unit,
     contentPadding: PaddingValues,
     heroSlot: @Composable () -> Unit,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -71,6 +71,7 @@ import io.music_assistant.client.ui.compose.common.items.ArtistWithMenu
 import io.music_assistant.client.ui.compose.common.items.LibraryActions
 import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import io.music_assistant.client.ui.compose.common.items.PodcastEpisodeWithMenu
+import io.music_assistant.client.ui.compose.common.items.ProgressActions
 import io.music_assistant.client.ui.compose.common.items.TrackWithMenu
 import io.music_assistant.client.ui.compose.common.providers.ProviderIcon
 import io.music_assistant.client.ui.compose.common.rememberToastState
@@ -178,10 +179,15 @@ fun ItemDetails(
         }
     }
 
-    val progressActions = ActionsViewModel.ProgressActions(
-        onMarkPlayed = onMarkPlayed,
-        onMarkUnplayed = onMarkUnplayed,
-    )
+    val progressActions = object : ProgressActions {
+        override fun onMarkPlayed(item: AppMediaItem) {
+            onMarkPlayed(item)
+        }
+
+        override fun onMarkUnplayed(item: AppMediaItem) {
+            onMarkUnplayed(item)
+        }
+    }
 
     ItemChildren(
         state = state,
@@ -253,7 +259,7 @@ private fun ItemChildren(
     onPlayChildClick: (AppMediaItem, QueueOption, Boolean) -> Unit,
     onChapterClick: (Int) -> Unit,
     playlistActions: PlaylistActions,
-    progressActions: ActionsViewModel.ProgressActions? = null,
+    progressActions: ProgressActions? = null,
     onRemoveFromPlaylist: (String, Int) -> Unit,
     libraryActions: LibraryActions,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
@@ -321,7 +327,7 @@ private fun ItemContent(
     onPlayChildClick: (AppMediaItem, QueueOption, Boolean) -> Unit,
     onChapterClick: (Int) -> Unit,
     playlistActions: PlaylistActions,
-    progressActions: ActionsViewModel.ProgressActions?,
+    progressActions: ProgressActions?,
     onRemoveFromPlaylist: (String, Int) -> Unit,
     libraryActions: LibraryActions,
     providerIconFetcher: @Composable (Modifier, String) -> Unit,
@@ -482,7 +488,7 @@ private fun TabContent(
     onPlayChildClick: (AppMediaItem, QueueOption, Boolean) -> Unit,
     onChapterClick: (Int) -> Unit,
     playlistActions: PlaylistActions,
-    progressActions: ActionsViewModel.ProgressActions?,
+    progressActions: ProgressActions?,
     onRemoveFromPlaylist: (String, Int) -> Unit,
     libraryActions: LibraryActions,
     providerIconFetcher: @Composable (Modifier, String) -> Unit,
@@ -668,7 +674,7 @@ private fun PlayablesTabContent(
     viewModeProvider: @Composable (MediaType) -> ViewMode,
     onPlayChildClick: (AppMediaItem, QueueOption, Boolean) -> Unit,
     playlistActions: PlaylistActions,
-    progressActions: ActionsViewModel.ProgressActions?,
+    progressActions: ProgressActions?,
     onRemoveFromPlaylist: (String, Int) -> Unit,
     libraryActions: LibraryActions,
     providerIconFetcher: @Composable (Modifier, String) -> Unit,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -68,6 +68,7 @@ import io.music_assistant.client.ui.compose.common.ToastHost
 import io.music_assistant.client.ui.compose.common.ToastState
 import io.music_assistant.client.ui.compose.common.items.AlbumWithMenu
 import io.music_assistant.client.ui.compose.common.items.ArtistWithMenu
+import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import io.music_assistant.client.ui.compose.common.items.PodcastEpisodeWithMenu
 import io.music_assistant.client.ui.compose.common.items.TrackWithMenu
 import io.music_assistant.client.ui.compose.common.providers.ProviderIcon
@@ -153,10 +154,18 @@ fun ItemDetails(
     onAlbumsSortChanged: (SubItemContext, SortOption) -> Unit = { _, _ -> },
     onPlayableItemsSortChanged: (SubItemContext, SortOption) -> Unit = { _, _ -> },
 ) {
-    val playlistActions = ActionsViewModel.PlaylistActions(
-        onLoadPlaylists = geEditablePlaylists,
-        onAddToPlaylist = addToPlaylist,
-    )
+    val playlistActions = object : PlaylistActions {
+        override suspend fun getEditablePlaylists(): List<Playlist> {
+            return geEditablePlaylists()
+        }
+
+        override fun addToPlaylist(
+            mediaItem: AppMediaItem,
+            playlist: Playlist,
+        ) {
+            addToPlaylist(mediaItem, playlist)
+        }
+    }
 
     val libraryActions = ActionsViewModel.LibraryActions(
         onLibraryClick = onLibraryClick,
@@ -237,7 +246,7 @@ private fun ItemChildren(
     onPlayItemClick: (QueueOption, Boolean) -> Unit,
     onPlayChildClick: (AppMediaItem, QueueOption, Boolean) -> Unit,
     onChapterClick: (Int) -> Unit,
-    playlistActions: ActionsViewModel.PlaylistActions,
+    playlistActions: PlaylistActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
     onRemoveFromPlaylist: (String, Int) -> Unit,
     libraryActions: ActionsViewModel.LibraryActions,
@@ -305,7 +314,7 @@ private fun ItemContent(
     onPlayItemClick: (QueueOption, Boolean) -> Unit,
     onPlayChildClick: (AppMediaItem, QueueOption, Boolean) -> Unit,
     onChapterClick: (Int) -> Unit,
-    playlistActions: ActionsViewModel.PlaylistActions,
+    playlistActions: PlaylistActions,
     progressActions: ActionsViewModel.ProgressActions?,
     onRemoveFromPlaylist: (String, Int) -> Unit,
     libraryActions: ActionsViewModel.LibraryActions,
@@ -466,7 +475,7 @@ private fun TabContent(
     onNavigateClick: (AppMediaItem) -> Unit,
     onPlayChildClick: (AppMediaItem, QueueOption, Boolean) -> Unit,
     onChapterClick: (Int) -> Unit,
-    playlistActions: ActionsViewModel.PlaylistActions,
+    playlistActions: PlaylistActions,
     progressActions: ActionsViewModel.ProgressActions?,
     onRemoveFromPlaylist: (String, Int) -> Unit,
     libraryActions: ActionsViewModel.LibraryActions,
@@ -652,7 +661,7 @@ private fun PlayablesTabContent(
     parentItem: AppMediaItem,
     viewModeProvider: @Composable (MediaType) -> ViewMode,
     onPlayChildClick: (AppMediaItem, QueueOption, Boolean) -> Unit,
-    playlistActions: ActionsViewModel.PlaylistActions,
+    playlistActions: PlaylistActions,
     progressActions: ActionsViewModel.ProgressActions?,
     onRemoveFromPlaylist: (String, Int) -> Unit,
     libraryActions: ActionsViewModel.LibraryActions,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
@@ -64,6 +64,7 @@ import io.music_assistant.client.ui.compose.common.OverflowMenuButton
 import io.music_assistant.client.ui.compose.common.OverflowMenuOption
 import io.music_assistant.client.ui.compose.common.icons.TrackIcon
 import io.music_assistant.client.ui.compose.common.items.Badges
+import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import io.music_assistant.client.ui.compose.common.items.navigationOptions
 import io.music_assistant.client.ui.compose.common.painters.rememberPlaceholderPainter
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
@@ -132,7 +133,7 @@ internal fun ItemTopBar(
     item: AppMediaItem,
     onBack: () -> Unit,
     libraryActions: ActionsViewModel.LibraryActions?,
-    playlistActions: ActionsViewModel.PlaylistActions?,
+    playlistActions: PlaylistActions?,
     scrollBehavior: TopAppBarScrollBehavior? = null,
     navigateToItem: (AppMediaItem) -> Unit,
 ) {
@@ -159,7 +160,7 @@ internal fun ItemTopBar(
 private fun ItemOverflow(
     item: AppMediaItem,
     libraryActions: ActionsViewModel.LibraryActions?,
-    playlistActions: ActionsViewModel.PlaylistActions?,
+    playlistActions: PlaylistActions?,
     navigateToItem: (AppMediaItem) -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -218,7 +219,7 @@ private fun ItemOverflow(
                         // Load playlists when dialog opens
                         coroutineScope.launch {
                             isLoadingPlaylists = true
-                            playlists = it.onLoadPlaylists()
+                            playlists = it.getEditablePlaylists()
                             isLoadingPlaylists = false
                         }
                     },
@@ -259,7 +260,7 @@ private fun ItemOverflow(
                         playlists.forEach { playlist ->
                             TextButton(
                                 onClick = {
-                                    playlistActions?.onAddToPlaylist(item, playlist)
+                                    playlistActions?.addToPlaylist(item, playlist)
                                     showPlaylistDialog = false
                                     playlists = emptyList()
                                 },

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
@@ -64,10 +64,10 @@ import io.music_assistant.client.ui.compose.common.OverflowMenuButton
 import io.music_assistant.client.ui.compose.common.OverflowMenuOption
 import io.music_assistant.client.ui.compose.common.icons.TrackIcon
 import io.music_assistant.client.ui.compose.common.items.Badges
+import io.music_assistant.client.ui.compose.common.items.LibraryActions
 import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import io.music_assistant.client.ui.compose.common.items.navigationOptions
 import io.music_assistant.client.ui.compose.common.painters.rememberPlaceholderPainter
-import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.utils.WindowClass
 import kotlinx.coroutines.launch
 import musicassistantclient.composeapp.generated.resources.Res
@@ -132,7 +132,7 @@ fun ItemHeader(
 internal fun ItemTopBar(
     item: AppMediaItem,
     onBack: () -> Unit,
-    libraryActions: ActionsViewModel.LibraryActions?,
+    libraryActions: LibraryActions?,
     playlistActions: PlaylistActions?,
     scrollBehavior: TopAppBarScrollBehavior? = null,
     navigateToItem: (AppMediaItem) -> Unit,
@@ -159,7 +159,7 @@ internal fun ItemTopBar(
 @Composable
 private fun ItemOverflow(
     item: AppMediaItem,
-    libraryActions: ActionsViewModel.LibraryActions?,
+    libraryActions: LibraryActions?,
     playlistActions: PlaylistActions?,
     navigateToItem: (AppMediaItem) -> Unit,
 ) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/AdaptiveMediaGrid.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/AdaptiveMediaGrid.kt
@@ -37,6 +37,7 @@ import io.music_assistant.client.ui.compose.common.items.AlbumWithMenu
 import io.music_assistant.client.ui.compose.common.items.ArtistWithMenu
 import io.music_assistant.client.ui.compose.common.items.AudiobookWithMenu
 import io.music_assistant.client.ui.compose.common.items.GenreWithMenu
+import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import io.music_assistant.client.ui.compose.common.items.PlaylistWithMenu
 import io.music_assistant.client.ui.compose.common.items.PodcastEpisodeWithMenu
 import io.music_assistant.client.ui.compose.common.items.PodcastWithMenu
@@ -55,7 +56,7 @@ fun AdaptiveMediaGrid(
     onPlayClick: ((AppMediaItem, QueueOption, Boolean) -> Unit),
     onLoadMore: () -> Unit = {},
     gridState: LazyGridState = rememberLazyGridState(),
-    playlistActions: ActionsViewModel.PlaylistActions,
+    playlistActions: PlaylistActions,
     libraryActions: ActionsViewModel.LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
     contentPadding: PaddingValues,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/AdaptiveMediaGrid.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/AdaptiveMediaGrid.kt
@@ -42,9 +42,9 @@ import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import io.music_assistant.client.ui.compose.common.items.PlaylistWithMenu
 import io.music_assistant.client.ui.compose.common.items.PodcastEpisodeWithMenu
 import io.music_assistant.client.ui.compose.common.items.PodcastWithMenu
+import io.music_assistant.client.ui.compose.common.items.ProgressActions
 import io.music_assistant.client.ui.compose.common.items.RadioWithMenu
 import io.music_assistant.client.ui.compose.common.items.TrackWithMenu
-import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 
 @Composable
 fun AdaptiveMediaGrid(
@@ -59,7 +59,7 @@ fun AdaptiveMediaGrid(
     gridState: LazyGridState = rememberLazyGridState(),
     playlistActions: PlaylistActions,
     libraryActions: LibraryActions,
-    progressActions: ActionsViewModel.ProgressActions? = null,
+    progressActions: ProgressActions? = null,
     contentPadding: PaddingValues,
 ) {
     val isRow = viewMode == ViewMode.LIST

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/AdaptiveMediaGrid.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/AdaptiveMediaGrid.kt
@@ -37,6 +37,7 @@ import io.music_assistant.client.ui.compose.common.items.AlbumWithMenu
 import io.music_assistant.client.ui.compose.common.items.ArtistWithMenu
 import io.music_assistant.client.ui.compose.common.items.AudiobookWithMenu
 import io.music_assistant.client.ui.compose.common.items.GenreWithMenu
+import io.music_assistant.client.ui.compose.common.items.LibraryActions
 import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import io.music_assistant.client.ui.compose.common.items.PlaylistWithMenu
 import io.music_assistant.client.ui.compose.common.items.PodcastEpisodeWithMenu
@@ -57,7 +58,7 @@ fun AdaptiveMediaGrid(
     onLoadMore: () -> Unit = {},
     gridState: LazyGridState = rememberLazyGridState(),
     playlistActions: PlaylistActions,
-    libraryActions: ActionsViewModel.LibraryActions,
+    libraryActions: LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
     contentPadding: PaddingValues,
 ) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryScreen.kt
@@ -61,6 +61,7 @@ import io.music_assistant.client.ui.compose.common.SortChip
 import io.music_assistant.client.ui.compose.common.ToastHost
 import io.music_assistant.client.ui.compose.common.ToastState
 import io.music_assistant.client.ui.compose.common.clearFocusOnScroll
+import io.music_assistant.client.ui.compose.common.items.LibraryActions
 import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
@@ -153,10 +154,7 @@ fun LibraryScreen(
             onDismissCreatePlaylistDialog = libraryViewModel::onDismissCreatePlaylistDialog,
             onCreatePlaylist = libraryViewModel::createPlaylist,
             playlistActions = actionsViewModel,
-            libraryActions = ActionsViewModel.LibraryActions(
-                onLibraryClick = actionsViewModel::onLibraryClick,
-                onFavoriteClick = actionsViewModel::onFavoriteClick,
-            ),
+            libraryActions = actionsViewModel,
             progressActions = ActionsViewModel.ProgressActions(
                 onMarkPlayed = actionsViewModel::onMarkPlayed,
                 onMarkUnplayed = actionsViewModel::onMarkUnplayed,
@@ -302,7 +300,7 @@ private fun Library(
     onDismissCreatePlaylistDialog: () -> Unit,
     onCreatePlaylist: (String) -> Unit,
     playlistActions: PlaylistActions,
-    libraryActions: ActionsViewModel.LibraryActions,
+    libraryActions: LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
     contentPadding: PaddingValues,
 ) {
@@ -398,7 +396,7 @@ private fun TabContent(
     onCreatePlaylistClick: () -> Unit,
     onLoadMore: () -> Unit,
     playlistActions: PlaylistActions,
-    libraryActions: ActionsViewModel.LibraryActions,
+    libraryActions: LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
     contentPadding: PaddingValues,
 ) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryScreen.kt
@@ -61,6 +61,7 @@ import io.music_assistant.client.ui.compose.common.SortChip
 import io.music_assistant.client.ui.compose.common.ToastHost
 import io.music_assistant.client.ui.compose.common.ToastState
 import io.music_assistant.client.ui.compose.common.clearFocusOnScroll
+import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.nav.Screen
@@ -151,10 +152,7 @@ fun LibraryScreen(
             onLoadMore = libraryViewModel::loadMore,
             onDismissCreatePlaylistDialog = libraryViewModel::onDismissCreatePlaylistDialog,
             onCreatePlaylist = libraryViewModel::createPlaylist,
-            playlistActions = ActionsViewModel.PlaylistActions(
-                onLoadPlaylists = actionsViewModel::getEditablePlaylists,
-                onAddToPlaylist = actionsViewModel::addToPlaylist,
-            ),
+            playlistActions = actionsViewModel,
             libraryActions = ActionsViewModel.LibraryActions(
                 onLibraryClick = actionsViewModel::onLibraryClick,
                 onFavoriteClick = actionsViewModel::onFavoriteClick,
@@ -303,7 +301,7 @@ private fun Library(
     onLoadMore: (LibraryViewModel.Tab) -> Unit,
     onDismissCreatePlaylistDialog: () -> Unit,
     onCreatePlaylist: (String) -> Unit,
-    playlistActions: ActionsViewModel.PlaylistActions,
+    playlistActions: PlaylistActions,
     libraryActions: ActionsViewModel.LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
     contentPadding: PaddingValues,
@@ -399,7 +397,7 @@ private fun TabContent(
     onPlayClick: (AppMediaItem, QueueOption, Boolean) -> Unit,
     onCreatePlaylistClick: () -> Unit,
     onLoadMore: () -> Unit,
-    playlistActions: ActionsViewModel.PlaylistActions,
+    playlistActions: PlaylistActions,
     libraryActions: ActionsViewModel.LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
     contentPadding: PaddingValues,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryScreen.kt
@@ -63,6 +63,7 @@ import io.music_assistant.client.ui.compose.common.ToastState
 import io.music_assistant.client.ui.compose.common.clearFocusOnScroll
 import io.music_assistant.client.ui.compose.common.items.LibraryActions
 import io.music_assistant.client.ui.compose.common.items.PlaylistActions
+import io.music_assistant.client.ui.compose.common.items.ProgressActions
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.nav.Screen
@@ -155,10 +156,7 @@ fun LibraryScreen(
             onCreatePlaylist = libraryViewModel::createPlaylist,
             playlistActions = actionsViewModel,
             libraryActions = actionsViewModel,
-            progressActions = ActionsViewModel.ProgressActions(
-                onMarkPlayed = actionsViewModel::onMarkPlayed,
-                onMarkUnplayed = actionsViewModel::onMarkUnplayed,
-            ),
+            progressActions = actionsViewModel,
         )
     }
 }
@@ -301,7 +299,7 @@ private fun Library(
     onCreatePlaylist: (String) -> Unit,
     playlistActions: PlaylistActions,
     libraryActions: LibraryActions,
-    progressActions: ActionsViewModel.ProgressActions? = null,
+    progressActions: ProgressActions? = null,
     contentPadding: PaddingValues,
 ) {
     Box(modifier = modifier) {
@@ -397,7 +395,7 @@ private fun TabContent(
     onLoadMore: () -> Unit,
     playlistActions: PlaylistActions,
     libraryActions: LibraryActions,
-    progressActions: ActionsViewModel.ProgressActions? = null,
+    progressActions: ProgressActions? = null,
     contentPadding: PaddingValues,
 ) {
     // Create separate grid states for each tab to preserve scroll position

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
@@ -56,6 +56,7 @@ import io.music_assistant.client.ui.compose.common.items.AlbumWithMenu
 import io.music_assistant.client.ui.compose.common.items.ArtistWithMenu
 import io.music_assistant.client.ui.compose.common.items.AudiobookWithMenu
 import io.music_assistant.client.ui.compose.common.items.GenreWithMenu
+import io.music_assistant.client.ui.compose.common.items.LibraryActions
 import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import io.music_assistant.client.ui.compose.common.items.PlaylistWithMenu
 import io.music_assistant.client.ui.compose.common.items.PodcastWithMenu
@@ -121,10 +122,7 @@ fun SearchScreen(
             },
             onPlayClick = searchViewModel::onPlayClick,
             playlistActions = actionsViewModel,
-            libraryActions = ActionsViewModel.LibraryActions(
-                onLibraryClick = actionsViewModel::onLibraryClick,
-                onFavoriteClick = actionsViewModel::onFavoriteClick,
-            ),
+            libraryActions = actionsViewModel,
             progressActions = ActionsViewModel.ProgressActions(
                 onMarkPlayed = actionsViewModel::onMarkPlayed,
                 onMarkUnplayed = actionsViewModel::onMarkUnplayed,
@@ -188,7 +186,7 @@ private fun SearchContent(
     onItemClick: (AppMediaItem) -> Unit,
     onPlayClick: (AppMediaItem, QueueOption, Boolean) -> Unit,
     playlistActions: PlaylistActions,
-    libraryActions: ActionsViewModel.LibraryActions,
+    libraryActions: LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
     contentPadding: PaddingValues,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
@@ -60,6 +60,7 @@ import io.music_assistant.client.ui.compose.common.items.LibraryActions
 import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import io.music_assistant.client.ui.compose.common.items.PlaylistWithMenu
 import io.music_assistant.client.ui.compose.common.items.PodcastWithMenu
+import io.music_assistant.client.ui.compose.common.items.ProgressActions
 import io.music_assistant.client.ui.compose.common.items.RadioWithMenu
 import io.music_assistant.client.ui.compose.common.items.TrackWithMenu
 import io.music_assistant.client.ui.compose.common.providers.ProviderIcon
@@ -123,10 +124,7 @@ fun SearchScreen(
             onPlayClick = searchViewModel::onPlayClick,
             playlistActions = actionsViewModel,
             libraryActions = actionsViewModel,
-            progressActions = ActionsViewModel.ProgressActions(
-                onMarkPlayed = actionsViewModel::onMarkPlayed,
-                onMarkUnplayed = actionsViewModel::onMarkUnplayed,
-            ),
+            progressActions = actionsViewModel,
             providerIconFetcher = { modifier, provider ->
                 actionsViewModel.getProviderIcon(provider)
                     ?.let { ProviderIcon(modifier, it) }
@@ -187,7 +185,7 @@ private fun SearchContent(
     onPlayClick: (AppMediaItem, QueueOption, Boolean) -> Unit,
     playlistActions: PlaylistActions,
     libraryActions: LibraryActions,
-    progressActions: ActionsViewModel.ProgressActions? = null,
+    progressActions: ProgressActions? = null,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
     contentPadding: PaddingValues,
 ) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
@@ -56,6 +56,7 @@ import io.music_assistant.client.ui.compose.common.items.AlbumWithMenu
 import io.music_assistant.client.ui.compose.common.items.ArtistWithMenu
 import io.music_assistant.client.ui.compose.common.items.AudiobookWithMenu
 import io.music_assistant.client.ui.compose.common.items.GenreWithMenu
+import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import io.music_assistant.client.ui.compose.common.items.PlaylistWithMenu
 import io.music_assistant.client.ui.compose.common.items.PodcastWithMenu
 import io.music_assistant.client.ui.compose.common.items.RadioWithMenu
@@ -119,10 +120,7 @@ fun SearchScreen(
                 }
             },
             onPlayClick = searchViewModel::onPlayClick,
-            playlistActions = ActionsViewModel.PlaylistActions(
-                onLoadPlaylists = actionsViewModel::getEditablePlaylists,
-                onAddToPlaylist = actionsViewModel::addToPlaylist,
-            ),
+            playlistActions = actionsViewModel,
             libraryActions = ActionsViewModel.LibraryActions(
                 onLibraryClick = actionsViewModel::onLibraryClick,
                 onFavoriteClick = actionsViewModel::onFavoriteClick,
@@ -189,7 +187,7 @@ private fun SearchContent(
     toastState: ToastState,
     onItemClick: (AppMediaItem) -> Unit,
     onPlayClick: (AppMediaItem, QueueOption, Boolean) -> Unit,
-    playlistActions: ActionsViewModel.PlaylistActions,
+    playlistActions: PlaylistActions,
     libraryActions: ActionsViewModel.LibraryActions,
     progressActions: ActionsViewModel.ProgressActions? = null,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),


### PR DESCRIPTION
Calls back up the `ActionViewModel` were being propagated via data classes holding callbacks which created a lot of noise in the code. I've switched this up so that there is a series of interfaces (corresponding to the previously existing data classes). This means that there is less noise when passing params down to Composables, but also keeps the actual detail of the view model away from the pure view code (as it was before).

I've also made the "screen" level Composables consistent so that they all accept ViewModels as they're main input. The actual creation of ViewModel classes all happens in the navigation roots where it's (hopefully) clearer which lifecycle/scope we're operating in.