### PR TITLE
Fix LazyList duplicate-key crash on iOS scroll/prefetch

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/RecommendationFolder.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/RecommendationFolder.kt
@@ -18,7 +18,7 @@ data class RecommendationFolder(
     override val providerMappings: List<ProviderMapping>? = null
     override val metadata: Metadata? = null
     override val favorite: Boolean? = null
-    override val mediaType: MediaType = MediaType.ARTIST
+    override val mediaType: MediaType = MediaType.FOLDER
 
     val rowItemType = when (itemId) {
         "recently_added_tracks", "recent_favorite_tracks" -> MediaType.TRACK

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/BrowsableItemWithMenu.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/BrowsableItemWithMenu.kt
@@ -548,7 +548,7 @@ private fun <T : AppMediaItem> BrowsableItemWithMenu(
                         LazyColumn {
                             items(
                                 items = playlists,
-                                key = { p -> p.itemId },
+                                key = { p -> p.lazyListKey() },
                             ) { playlist ->
                                 TextButton(
                                     onClick = {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/LazyListKeys.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/LazyListKeys.kt
@@ -1,0 +1,27 @@
+package io.music_assistant.client.ui.compose.common.items
+
+import io.music_assistant.client.data.model.client.MediaType
+import io.music_assistant.client.data.model.client.items.AppMediaItem
+
+/**
+ * Stable, unique key for an [AppMediaItem] inside a Compose `LazyColumn`,
+ * `LazyRow`, or `LazyVerticalGrid`'s `key = { ... }` lambda.
+ *
+ * Combines `mediaType`, `provider`, and `itemId` so the same canonical
+ * `itemId` carried by two different providers (e.g. a track with the same
+ * server-side `itemId` from Spotify and Apple Music) produces distinct
+ * keys. Without this, Compose's `SubcomposeLayout.subcompose` precondition
+ * (`SubcomposeLayout.kt:614` — "Key X was already used") fires during
+ * fling/prefetch on iOS and the app crashes.
+ *
+ * Returns a structured [Triple] rather than a delimited string so the
+ * encoding cannot accidentally collide on field contents — e.g. without
+ * this, `(provider="apple_music", itemId="xyz")` would generate the same
+ * underscore-joined string as `(provider="apple", itemId="music_xyz")`.
+ * Compose's slot identity uses `equals`/`hashCode`, both of which Triple
+ * implements structurally.
+ *
+ * Contract pinned by `LazyListKeysTest`.
+ */
+fun AppMediaItem.lazyListKey(): Triple<MediaType, String, String> =
+    Triple(mediaType, provider, itemId)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/PlayableItemWithMenu.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/PlayableItemWithMenu.kt
@@ -451,7 +451,7 @@ private fun <T : PlayableItem> PlayableItemWithMenu(
                         LazyColumn {
                             items(
                                 items = playlists,
-                                key = { p -> p.itemId },
+                                key = { p -> p.lazyListKey() },
                             ) { playlist ->
                                 TextButton(
                                     onClick = {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -66,6 +66,7 @@ import io.music_assistant.client.ui.compose.common.items.PodcastWithMenu
 import io.music_assistant.client.ui.compose.common.items.ProgressActions
 import io.music_assistant.client.ui.compose.common.items.RadioWithMenu
 import io.music_assistant.client.ui.compose.common.items.TrackWithMenu
+import io.music_assistant.client.ui.compose.common.items.lazyListKey
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.nav.BackHandler
 import io.music_assistant.client.ui.compose.nav.Screen
@@ -106,19 +107,21 @@ fun HomeScreen(
 
     val baseList = remember(dataState) {
         if (dataState is DataState.Data) {
-            dataState.data.filter {
-                it.items?.any { item ->
-                    item is Track ||
-                            item is Artist ||
-                            item is Album ||
-                            item is Playlist ||
-                            item is Audiobook ||
-                            item is Podcast ||
-                            item is PodcastEpisode ||
-                            item is RadioStation ||
-                            item is Genre
-                } == true
-            }
+            dataState.data
+                .filter {
+                    it.items?.any { item ->
+                        item is Track ||
+                                item is Artist ||
+                                item is Album ||
+                                item is Playlist ||
+                                item is Audiobook ||
+                                item is Podcast ||
+                                item is PodcastEpisode ||
+                                item is RadioStation ||
+                                item is Genre
+                    } == true
+                }
+                .distinctBy { it.lazyListKey() }
         } else {
             emptyList()
         }
@@ -170,7 +173,7 @@ fun HomeScreen(
             } else {
                 items(
                     items = displayedData,
-                    key = { it.itemId },
+                    key = { it.lazyListKey() },
                 ) { row ->
                     Box(modifier = Modifier.fillMaxWidth()) {
                         CategoryRow(
@@ -304,22 +307,7 @@ fun CategoryRow(
         ) {
             items(
                 items = mediaItems,
-                key = { item ->
-                    when (item) {
-                        is Track,
-                        is Artist,
-                        is Album,
-                        is Playlist,
-                        is Audiobook,
-                        is Podcast,
-                        is PodcastEpisode,
-                        is RadioStation,
-                        is Genre,
-                        -> "${item::class.simpleName}_${item.itemId}"
-
-                        else -> item.hashCode()
-                    }
-                },
+                key = { it.lazyListKey() },
                 contentType = { item ->
                     when (item) {
                         is Track -> "Track"

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/DspSettingsDialog.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/DspSettingsDialog.kt
@@ -134,9 +134,9 @@ private fun DspContent(
             val iconSize = 20.dp
 
             LazyColumn(modifier = Modifier.heightIn(max = 300.dp)) {
-                items(state.presets, key = { it.presetId ?: it.name }) { preset ->
-                    val presetKey = preset.presetId ?: preset.name
-                    val isApplied = state.appliedPresetId == presetKey
+                items(state.presets, key = { it.presetId to it.name }) { preset ->
+                    val presetKey = preset.presetId to preset.name
+                    val isApplied = state.appliedPresetKey == presetKey
 
                     Row(
                         modifier = Modifier

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/DspSettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/DspSettingsViewModel.kt
@@ -21,7 +21,7 @@ class DspSettingsViewModel(
         data class Content(
             val config: DspConfig,
             val presets: List<DspConfigPreset>,
-            val appliedPresetId: String? = null,
+            val appliedPresetKey: Pair<String?, String>? = null,
         ) : DspDialogState()
 
         data object Error : DspDialogState()
@@ -40,7 +40,8 @@ class DspSettingsViewModel(
                     configDeferred.await() to presetsDeferred.await()
                 }
                 if (config != null) {
-                    _state.value = DspDialogState.Content(config = config, presets = presets)
+                    val uniquePresets = presets.distinctBy { it.presetId to it.name }
+                    _state.value = DspDialogState.Content(config = config, presets = uniquePresets)
                 } else {
                     _state.value = DspDialogState.Error
                 }
@@ -68,10 +69,13 @@ class DspSettingsViewModel(
         viewModelScope.launch {
             val saved = dataSource.saveDspConfig(playerId, configToSave)
             if (saved != null) {
-                _state.value = current.copy(config = saved, appliedPresetId = preset.presetId ?: preset.name)
+                _state.value = current.copy(
+                    config = saved,
+                    appliedPresetKey = preset.presetId to preset.name,
+                )
                 delay(1000)
                 _state.update { state ->
-                    (state as? DspDialogState.Content)?.copy(appliedPresetId = null) ?: state
+                    (state as? DspDialogState.Content)?.copy(appliedPresetKey = null) ?: state
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/AdaptiveMediaGrid.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/AdaptiveMediaGrid.kt
@@ -45,6 +45,7 @@ import io.music_assistant.client.ui.compose.common.items.PodcastWithMenu
 import io.music_assistant.client.ui.compose.common.items.ProgressActions
 import io.music_assistant.client.ui.compose.common.items.RadioWithMenu
 import io.music_assistant.client.ui.compose.common.items.TrackWithMenu
+import io.music_assistant.client.ui.compose.common.items.lazyListKey
 import io.music_assistant.client.utils.gridItemMinSize
 
 @Composable
@@ -92,7 +93,7 @@ fun AdaptiveMediaGrid(
     ) {
         items(
             items = items,
-            key = { "${it.mediaType}_${it.provider}_${it.itemId}" },
+            key = { it.lazyListKey() },
             span = if (isRow) {
                 { GridItemSpan(maxLineSpan) }
             } else {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
@@ -63,6 +63,7 @@ import io.music_assistant.client.ui.compose.common.items.PodcastWithMenu
 import io.music_assistant.client.ui.compose.common.items.ProgressActions
 import io.music_assistant.client.ui.compose.common.items.RadioWithMenu
 import io.music_assistant.client.ui.compose.common.items.TrackWithMenu
+import io.music_assistant.client.ui.compose.common.items.lazyListKey
 import io.music_assistant.client.ui.compose.common.providers.ProviderIcon
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
@@ -249,7 +250,7 @@ private fun SearchContent(
                             }
                             items(
                                 items = items,
-                                key = { "${it.mediaType}_${it.provider}_${it.itemId}" },
+                                key = { it.lazyListKey() },
                             ) { item ->
                                 when (item) {
                                     is Track -> TrackWithMenu(

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/common/items/LazyListKeysTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/common/items/LazyListKeysTest.kt
@@ -1,0 +1,145 @@
+package io.music_assistant.client.ui.compose.common.items
+
+import io.music_assistant.client.data.model.client.items.Album
+import io.music_assistant.client.data.model.client.items.AppMediaItem
+import io.music_assistant.client.data.model.client.items.Artist
+import io.music_assistant.client.data.model.client.items.RecommendationFolder
+import io.music_assistant.client.data.model.client.items.Track
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * Pins the [AppMediaItem.lazyListKey] contract.
+ *
+ * The crash that motivated this test (TestFlight build-29 LayoutNode
+ * regression) fired Compose's "Key X was already used" precondition
+ * (SubcomposeLayout.kt:614) during fling/prefetch on a LazyRow whose items
+ * were keyed by `"${item::class.simpleName}_${item.itemId}"` — missing the
+ * provider, so a cross-provider duplicate-itemId collision crashed the app
+ * on scroll. CM 1.10.3 got away with it; CM 1.11.0's tightened prefetch
+ * actually subcomposes the colliding sibling.
+ *
+ * Contract:
+ *   - Any two AppMediaItems that differ in (mediaType, provider, itemId)
+ *     MUST produce different keys.
+ *   - Identical AppMediaItems MUST produce the same key (stable).
+ */
+class LazyListKeysTest {
+    @Test
+    fun `cross-provider same itemId produces different keys`() {
+        val spotify = track(provider = "spotify", itemId = "abc")
+        val apple = track(provider = "apple_music", itemId = "abc")
+        assertNotEquals(spotify.lazyListKey(), apple.lazyListKey())
+    }
+
+    @Test
+    fun `same media type same provider same itemId produces same key`() {
+        val a = track(provider = "library", itemId = "xyz")
+        val b = track(provider = "library", itemId = "xyz")
+        assertEquals(a.lazyListKey(), b.lazyListKey())
+    }
+
+    @Test
+    fun `different media type same provider same itemId produces different keys`() {
+        val asTrack = track(provider = "library", itemId = "foo")
+        val asAlbum = album(provider = "library", itemId = "foo")
+        assertNotEquals(asTrack.lazyListKey(), asAlbum.lazyListKey())
+    }
+
+    @Test
+    fun `cross-provider mixed-type list produces fully-distinct keys`() {
+        val items: List<AppMediaItem> = listOf(
+            track(provider = "spotify", itemId = "x"),
+            track(provider = "apple_music", itemId = "x"),
+            track(provider = "ytmusic", itemId = "x"),
+            album(provider = "library", itemId = "x"),
+        )
+        val keys = items.map { it.lazyListKey() }
+        assertEquals(items.size, keys.distinct().size)
+    }
+
+    @Test
+    fun `recommendation folders distinguished by provider`() {
+        // Two folders with the same canonical itemId (e.g. "random_albums")
+        // but coming from different providers must still produce distinct
+        // keys; otherwise scrolling the home screen with such data crashes.
+        val libraryFolder = recommendationFolder(provider = "library", itemId = "random_albums")
+        val spotifyFolder = recommendationFolder(provider = "spotify", itemId = "random_albums")
+        assertNotEquals(libraryFolder.lazyListKey(), spotifyFolder.lazyListKey())
+    }
+
+    @Test
+    fun `recommendation folder does not collide with same-id same-provider artist`() {
+        // RecommendationFolder's mediaType must be distinct from MediaType.ARTIST
+        // so a folder and a real Artist sharing (provider, itemId) get different
+        // keys when they ever end up in the same lazy list.
+        val folder = recommendationFolder(provider = "library", itemId = "random_albums")
+        val artist = artist(provider = "library", itemId = "random_albums")
+        assertNotEquals(folder.lazyListKey(), artist.lazyListKey())
+    }
+
+    @Test
+    fun `underscore-bearing provider does not collide with other field arrangements`() {
+        // Compose accepts Any? as a slot key, so the key MUST be a structurally
+        // typed value (Triple) rather than an underscore-delimited string —
+        // otherwise (provider="apple_music", itemId="xyz") collides with
+        // (provider="apple", itemId="music_xyz").
+        val a = track(provider = "apple_music", itemId = "xyz")
+        val b = track(provider = "apple", itemId = "music_xyz")
+        assertNotEquals(a.lazyListKey(), b.lazyListKey())
+    }
+
+    private fun track(provider: String, itemId: String): Track = Track(
+        itemId = itemId,
+        provider = provider,
+        name = "name",
+        providerMappings = null,
+        metadata = null,
+        favorite = null,
+        uri = null,
+        images = emptyMap(),
+        duration = null,
+        artists = emptyList(),
+        album = null,
+        discNumber = null,
+        trackNumber = null,
+        position = null,
+        version = null,
+    )
+
+    private fun artist(provider: String, itemId: String): Artist = Artist(
+        itemId = itemId,
+        provider = provider,
+        name = "name",
+        providerMappings = null,
+        metadata = null,
+        favorite = null,
+        uri = null,
+        images = emptyMap(),
+    )
+
+    private fun album(provider: String, itemId: String): Album = Album(
+        itemId = itemId,
+        provider = provider,
+        name = "name",
+        providerMappings = null,
+        metadata = null,
+        favorite = null,
+        uri = null,
+        images = emptyMap(),
+        version = null,
+        year = null,
+        artists = emptyList(),
+    )
+
+    private fun recommendationFolder(provider: String, itemId: String): RecommendationFolder =
+        RecommendationFolder(
+            itemId = itemId,
+            provider = provider,
+            name = "name",
+            uri = null,
+            images = emptyMap(),
+            items = null,
+        )
+}


### PR DESCRIPTION
CM 1.11.0 (bumped in 98f01dd) tightened iOS prefetch, so latent duplicate-key bugs in our LazyColumn/LazyRow callsites now reliably trip `SubcomposeLayout.kt:614`'s "Key X was already used" precondition — the build-26→29 regression in TestFlight.

New `AppMediaItem.lazyListKey()` returns `Triple<MediaType, String, String>` applied at every AppMediaItem-bearing callsite.

Also:
- `RecommendationFolder.mediaType` was `MediaType.ARTIST` placeholder; switched to `MediaType.FOLDER` — closes a latent folder/artist key collision.
- DSP preset key/dedup: `presetId ?: name` (cross-field collision) → `presetId to name`. `appliedPresetId: String?` becomes `appliedPresetKey: Pair<String?, String>?`.