### PR TITLE
Speed up iOS release link with smallBinary

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -39,6 +39,10 @@ kotlin {
             baseName = "ComposeApp"
             isStatic = true
             binaryOption("bundleId", "io.music_assistant.client.composeapp")
+            // Trades a touch of release-link optimization for ~28% faster
+            // linkReleaseFrameworkIosArm64 and a smaller binary. Experimental
+            // Kotlin/Native flag — revisit if release-build correctness regresses.
+            binaryOption("smallBinary", "true")
         }
 
         // Note: the previous webrtc-kmp test-linker block lived here. It pointed


### PR DESCRIPTION
Locally on Apple Silicon, linkReleaseFrameworkIosArm64 drops from 5m18s to 3m49s and the static framework shrinks from 180MB to 158MB.

This is part of me trying to figure out how to make the iOS build and release process less painful, without paying for larger GitHub action runners.