### PR TITLE
Fix iOS Ktor-Darwin uncaught WebSocket exception → SIGABRT

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/DirectTransport.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/DirectTransport.kt
@@ -10,8 +10,11 @@ import io.ktor.client.plugins.websocket.wss
 import io.ktor.http.HttpMethod
 import io.ktor.websocket.Frame
 import io.ktor.websocket.close
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -21,15 +24,34 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonObject
+import kotlin.concurrent.Volatile
 
 class DirectTransport(
     private val client: HttpClient,
     private val connectionInfoProvider: () -> ConnectionInfo,
-    private val scope: CoroutineScope,
+    parentScope: CoroutineScope,
     private val networkAvailable: StateFlow<Boolean>? = null,
     private val maxReconnectAttempts: Int = DEFAULT_MAX_RECONNECT_ATTEMPTS,
 ) : Transport {
     private val logger = Logger.withTag("DirectTransport")
+
+    private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        logger.e(throwable) { "Uncaught exception in DirectTransport scope" }
+        when (_state.value) {
+            TransportState.Connected -> verifyConnection()
+            TransportState.Connecting, is TransportState.Reconnecting ->
+                _state.value = TransportState.Failed(
+                    Exception("Recovery machinery died: ${throwable.message}", throwable),
+                )
+            TransportState.Disconnected, is TransportState.Failed -> Unit
+        }
+    }
+
+    private val scope: CoroutineScope = CoroutineScope(
+        parentScope.coroutineContext +
+            SupervisorJob(parentScope.coroutineContext[Job]) +
+            exceptionHandler,
+    )
 
     private val _state = MutableStateFlow<TransportState>(TransportState.Disconnected)
     override val state = _state.asStateFlow()
@@ -38,8 +60,12 @@ class DirectTransport(
     override val messages = _messages.asSharedFlow()
 
     private var connectionJob: Job? = null
+
+    @Volatile
     private var session: DefaultClientWebSocketSession? = null
     private var wasConnected = false
+
+    @Volatile
     private var messageCounter = 0L
 
     override fun connect() {
@@ -156,6 +182,10 @@ class DirectTransport(
             scope.launch { s.close() }
         }
         _state.value = TransportState.Disconnected
+    }
+
+    override fun close() {
+        scope.cancel()
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -30,6 +30,7 @@ import io.music_assistant.client.utils.myJson
 import io.music_assistant.client.utils.resultAs
 import io.music_assistant.client.utils.update
 import io.music_assistant.client.webrtc.model.RemoteId
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -67,8 +68,15 @@ class KtorServiceClient(
     private val settings: SettingsRepository,
     private val errorBus: ErrorMessageBus,
 ) : ServiceClient, CoroutineScope, KoinComponent {
+    private val logger = Logger.withTag("ServiceClient")
     private val supervisorJob = SupervisorJob()
-    override val coroutineContext: CoroutineContext = supervisorJob + Dispatchers.IO
+
+    private val scopeExceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        logger.e(throwable) { "Uncaught exception in KtorServiceClient scope (non-transport)" }
+    }
+
+    override val coroutineContext: CoroutineContext =
+        supervisorJob + Dispatchers.IO + scopeExceptionHandler
 
     private val client = createPlatformHttpClient {
         install(WebSockets) {
@@ -195,8 +203,6 @@ class KtorServiceClient(
         }
         return base.trimEnd('/') + tail
     }
-
-    private val logger = Logger.withTag("ServiceClient")
 
     /**
      * Force a full WebRTC reconnection to get fresh SDP-negotiated data channels.
@@ -576,12 +582,13 @@ class KtorServiceClient(
         // observer processes TransportState.Disconnected and briefly sets ByUser
         transportObserverJob?.cancel()
         transport?.disconnect()
+        transport?.close()
         _sessionState.update { SessionState.Connecting }
 
         val directTransport = DirectTransport(
             client = client,
             connectionInfoProvider = { connection },
-            scope = this,
+            parentScope = this,
             networkAvailable = networkMonitor.isAvailable,
         )
         transport = directTransport
@@ -629,12 +636,13 @@ class KtorServiceClient(
     private fun forceConnectWebRTC(remoteId: RemoteId) {
         transportObserverJob?.cancel()
         transport?.disconnect()
+        transport?.close()
         _sessionState.update { SessionState.Connecting }
 
         val webrtcTransport = WebRTCTransport(
             httpClient = webrtcHttpClient,
             remoteId = remoteId,
-            scope = this,
+            parentScope = this,
             networkAvailable = networkMonitor.isAvailable,
         )
         transport = webrtcTransport
@@ -690,6 +698,7 @@ class KtorServiceClient(
             transportObserverJob?.cancel()
             transportObserverJob = null
             transport?.disconnect()
+            transport?.close()
             transport = null
             _sessionState.update { newState }
             rpcEngine.clear()

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/TransportState.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/TransportState.kt
@@ -25,4 +25,7 @@ interface Transport {
      * Default no-op for transports with built-in keepalive (e.g. WebRTC ICE).
      */
     fun verifyConnection(timeoutMs: Long = 1000) {}
+
+    /** Release the transport's coroutine scope. Call [disconnect] first; unusable after. */
+    fun close() {}
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/WebRTCTransport.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/WebRTCTransport.kt
@@ -12,8 +12,11 @@ import io.music_assistant.client.webrtc.WebRTCConnectionManager
 import io.music_assistant.client.webrtc.WebRTCHttpProxy
 import io.music_assistant.client.webrtc.model.RemoteId
 import io.music_assistant.client.webrtc.model.WebRTCConnectionState
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -44,11 +47,29 @@ private val HTTP_PROXY_TYPE_REGEX = Regex("\"type\"\\s*:\\s*\"http-proxy-respons
 class WebRTCTransport(
     private val httpClient: HttpClient,
     private val remoteId: RemoteId,
-    private val scope: CoroutineScope,
+    parentScope: CoroutineScope,
     private val networkAvailable: StateFlow<Boolean>? = null,
     private val maxReconnectAttempts: Int = DEFAULT_MAX_RECONNECT_ATTEMPTS,
 ) : Transport {
     private val logger = Logger.withTag("WebRTCTransport")
+
+    private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        logger.e(throwable) { "Uncaught exception in WebRTCTransport scope" }
+        when (_state.value) {
+            TransportState.Connected -> forceReconnect()
+            TransportState.Connecting, is TransportState.Reconnecting ->
+                _state.value = TransportState.Failed(
+                    Exception("Recovery machinery died: ${throwable.message}", throwable),
+                )
+            TransportState.Disconnected, is TransportState.Failed -> Unit
+        }
+    }
+
+    private val scope: CoroutineScope = CoroutineScope(
+        parentScope.coroutineContext +
+            SupervisorJob(parentScope.coroutineContext[Job]) +
+            exceptionHandler,
+    )
 
     private val _state = MutableStateFlow<TransportState>(TransportState.Disconnected)
     override val state = _state.asStateFlow()
@@ -106,9 +127,11 @@ class WebRTCTransport(
     private fun onNetworkLost() {
         // Pre-empt the slow path: cancel state monitor, tear down manager, and start the
         // reconnection loop. The loop gates on networkAvailable, so it waits until a
-        // network is back before attempting.
+        // network is back before attempting. connectionJob is also cancelled so an
+        // in-flight forceReconnect doesn't race a second startReconnection() against ours.
         stateMonitorJob?.cancel()
         messageListenerJob?.cancel()
+        connectionJob?.cancel()
         reconnectionJob?.cancel()
         reconnectionJob = scope.launch {
             cleanupManager()
@@ -251,6 +274,10 @@ class WebRTCTransport(
             }
         }
         _state.value = TransportState.Disconnected
+    }
+
+    override fun close() {
+        scope.cancel()
     }
 
     /** Cleans up the current manager and its listener jobs. Does NOT cancel reconnectionJob. */

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/webrtc/SignalingClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/webrtc/SignalingClient.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
+import kotlin.concurrent.Volatile
 
 /**
  * WebSocket state for signaling server connection.
@@ -65,6 +66,7 @@ class SignalingClient(
     private val logger = Logger.withTag("SignalingClient")
     private val mutex = Mutex()
 
+    @Volatile
     private var session: io.ktor.client.plugins.websocket.DefaultClientWebSocketSession? = null
     private var receiveJob: Job? = null
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/webrtc/WebRTCConnectionManager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/webrtc/WebRTCConnectionManager.kt
@@ -426,7 +426,14 @@ class WebRTCConnectionManager(
         _connectionState.value = WebRTCConnectionState.Error(
             WebRTCError.SignalingError(message.error),
         )
-        scope.launch { cleanup() }
+        scope.launch {
+            try {
+                cleanup()
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                logger.w(e) { "cleanup() after signaling error failed" }
+            }
+        }
     }
 
     /**
@@ -437,7 +444,14 @@ class WebRTCConnectionManager(
         _connectionState.value = WebRTCConnectionState.Error(
             WebRTCError.ConnectionError("Remote peer disconnected"),
         )
-        scope.launch { cleanup() }
+        scope.launch {
+            try {
+                cleanup()
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                logger.w(e) { "cleanup() after peer disconnect failed" }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
I got a crash report from @remon1496 and tracked it down to this. I went with this (small) refactor approach vs. just catching the one exception so that we don't mask real problems / conflate them with network issues. And then found a couple of latent issues while I was in the neighborhood.

Ktor's Darwin engine can throw NSError-derived Kotlin exceptions from NSOperationQueue workers, outside our try/catch boundaries. With no CoroutineExceptionHandler in the failing coroutine's context, they reach Kotlin/Native's propagateExceptionFinalResort and abort the process.

Each transport now derives its own internal CoroutineScope from SupervisorJob(parentJob) + a state-aware CoroutineExceptionHandler: probe/forceReconnect when Connected; transition to Failed when Connecting/Reconnecting so the existing observer → Disconnected.Error → kickRecovery → reconnectFromHistory chain self-heals instead of getting permanently stuck. Adds Transport.close() (= scope.cancel()) called at every teardown site so we don't leak the old transport's SupervisorJob into the parent's job hierarchy on rebuild.

KtorServiceClient gets a log-only handler as a backstop for non- transport launches (settings collector, observe-transport callbacks, handleIncomingMessage's uncaught Event branch) not otherwise wrapped in try/catch.

While in the area:
- @Volatile on DirectTransport.session/messageCounter and SignalingClient.session — pre-existing races widened by routing handler execution onto the failing thread.
- WebRTCConnectionManager.handleSignalingError/handlePeerDisconnected now wrap their scope.launch { cleanup() } in try/catch.
- WebRTCTransport.onNetworkLost() also cancels connectionJob so a forceReconnect-in-flight can't race a parallel startReconnection().