### PR TITLE
feat(carplay): Play All / Add All to Queue on drilldowns

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerDispatch.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerDispatch.kt
@@ -1,0 +1,65 @@
+package io.music_assistant.client.data
+
+import io.music_assistant.client.api.Request
+import io.music_assistant.client.api.ServiceClient
+import io.music_assistant.client.data.model.client.QueueOption
+
+/**
+ * Forces playback onto a specific player, mandatorily detaching it from
+ * any sync group first. For surfaces where mirroring to other players
+ * cannot be the user's intent: they're holding (or sitting in) the device
+ * the audio has to come out of.
+ */
+
+internal data class LocalPlayerDispatchPlan(
+    val playerId: String,
+    val mediaUri: String,
+    val detachFrom: String?,
+    val option: QueueOption,
+)
+
+/** Returns null when prerequisites (a local player, a media URI) are missing. */
+internal fun planLocalPlayerDispatch(
+    localPlayerId: String?,
+    localPlayerSyncedTo: String?,
+    mediaUri: String?,
+    option: QueueOption,
+): LocalPlayerDispatchPlan? {
+    if (localPlayerId == null || mediaUri == null) return null
+    return LocalPlayerDispatchPlan(
+        playerId = localPlayerId,
+        mediaUri = mediaUri,
+        detachFrom = localPlayerSyncedTo,
+        option = option,
+    )
+}
+
+/**
+ * Detach must land before play — MA otherwise promotes
+ * `play(queueOrPlayerId=childId)` to the group queue. Failures go through
+ * [onRpcFailure] rather than try/catch: `sendRequest` is contractually
+ * no-throw, and a catch-all would only break structured concurrency.
+ */
+internal suspend fun executeLocalPlayerDispatch(
+    serviceClient: ServiceClient,
+    plan: LocalPlayerDispatchPlan,
+    onRpcFailure: (label: String, error: Throwable) -> Unit = { _, _ -> },
+) {
+    plan.detachFrom?.let { syncedToId ->
+        serviceClient.sendRequest(
+            Request.Player.setGroupMembers(
+                playerId = syncedToId,
+                playersToAdd = null,
+                playersToRemove = listOf(plan.playerId),
+            ),
+        ).onFailure { onRpcFailure("detach", it) }
+    }
+    serviceClient.sendRequest(
+        Request.Library.play(
+            media = listOf(plan.mediaUri),
+            queueOrPlayerId = plan.playerId,
+            option = plan.option,
+            radioMode = false,
+        ),
+    ).onFailure { onRpcFailure("play(${plan.option})", it) }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/LocalPlayerDispatchTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/LocalPlayerDispatchTest.kt
@@ -1,0 +1,331 @@
+package io.music_assistant.client.data
+
+import io.music_assistant.client.api.APICommands
+import io.music_assistant.client.api.Answer
+import io.music_assistant.client.api.ConnectionInfo
+import io.music_assistant.client.api.Request
+import io.music_assistant.client.api.ServiceClient
+import io.music_assistant.client.data.model.client.QueueOption
+import io.music_assistant.client.data.model.server.events.Event
+import io.music_assistant.client.utils.SessionState
+import io.music_assistant.client.webrtc.DataChannelWrapper
+import io.music_assistant.client.webrtc.model.RemoteId
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+class LocalPlayerDispatchTest {
+    // --- planLocalPlayerDispatch ---
+
+    @Test
+    fun planReturnsNullWhenNoLocalPlayer() {
+        val plan = planLocalPlayerDispatch(
+            localPlayerId = null,
+            localPlayerSyncedTo = null,
+            mediaUri = "library://album/42",
+            option = QueueOption.PLAY,
+        )
+        assertNull(plan)
+    }
+
+    @Test
+    fun planReturnsNullWhenMediaUriMissing() {
+        // Container items occasionally surface without a URI (mostly Genre,
+        // pre-synthesis). The planner must refuse rather than dispatch an
+        // empty media list and let MA error out remotely.
+        val plan = planLocalPlayerDispatch(
+            localPlayerId = "sendspin-local",
+            localPlayerSyncedTo = null,
+            mediaUri = null,
+            option = QueueOption.PLAY,
+        )
+        assertNull(plan)
+    }
+
+    @Test
+    fun planCarriesAllFieldsThroughWhenNotSynced() {
+        val plan = planLocalPlayerDispatch(
+            localPlayerId = "sendspin-local",
+            localPlayerSyncedTo = null,
+            mediaUri = "library://album/42",
+            option = QueueOption.REPLACE,
+        )
+        assertNotNull(plan)
+        assertEquals("sendspin-local", plan.playerId)
+        assertEquals("library://album/42", plan.mediaUri)
+        assertEquals(QueueOption.REPLACE, plan.option)
+        assertNull(plan.detachFrom)
+    }
+
+    @Test
+    fun planSetsDetachFromWhenSyncedToIsNonNull() {
+        val plan = planLocalPlayerDispatch(
+            localPlayerId = "sendspin-local",
+            localPlayerSyncedTo = "kitchen-group",
+            mediaUri = "library://playlist/1",
+            option = QueueOption.ADD,
+        )
+        assertNotNull(plan)
+        assertEquals("kitchen-group", plan.detachFrom)
+        // The plan targets the LOCAL player, never the group it was synced
+        // to. Catches the easy bug of accidentally routing the play request
+        // at the group ID.
+        assertEquals("sendspin-local", plan.playerId)
+    }
+
+    @Test
+    fun planPreservesEveryQueueOption() {
+        // Pins the option through verbatim — guards against a future
+        // refactor introducing per-option dispatch branches in the planner.
+        QueueOption.entries.forEach { option ->
+            val plan = planLocalPlayerDispatch(
+                localPlayerId = "p",
+                localPlayerSyncedTo = null,
+                mediaUri = "uri",
+                option = option,
+            )
+            assertEquals(option, plan?.option, "option=$option round-trip mismatch")
+        }
+    }
+
+    // --- executeLocalPlayerDispatch ---
+
+    @Test
+    fun executeSendsOnlyPlayWhenNotDetaching() = runBlocking {
+        val client = RecordingClient()
+        executeLocalPlayerDispatch(
+            client,
+            LocalPlayerDispatchPlan(
+                playerId = "sendspin-local",
+                mediaUri = "library://album/42",
+                detachFrom = null,
+                option = QueueOption.PLAY,
+            ),
+        )
+        assertEquals(1, client.sent.size)
+        assertEquals(PLAY_MEDIA, client.sent[0].command)
+    }
+
+    @Test
+    fun executeSendsDetachBeforePlayWhenSyncedTo() = runBlocking {
+        // Ordering is load-bearing: MA promotes `play(queueOrPlayerId=childId)`
+        // to the group queue if the detach hasn't landed first, which would
+        // re-introduce the exact bug the unconditional detach exists to
+        // prevent.
+        val client = RecordingClient()
+        executeLocalPlayerDispatch(
+            client,
+            LocalPlayerDispatchPlan(
+                playerId = "sendspin-local",
+                mediaUri = "library://album/42",
+                detachFrom = "kitchen-group",
+                option = QueueOption.REPLACE,
+            ),
+        )
+        assertEquals(2, client.sent.size)
+        assertEquals(SET_MEMBERS, client.sent[0].command)
+        assertEquals(PLAY_MEDIA, client.sent[1].command)
+    }
+
+    @Test
+    fun executeDetachRequestTargetsTheGroupAndRemovesTheLocalPlayer() = runBlocking {
+        val client = RecordingClient()
+        executeLocalPlayerDispatch(
+            client,
+            LocalPlayerDispatchPlan(
+                playerId = "sendspin-local",
+                mediaUri = "uri",
+                detachFrom = "kitchen-group",
+                option = QueueOption.PLAY,
+            ),
+        )
+        val detachArgs = client.sent.first { it.command == SET_MEMBERS }.args
+        assertNotNull(detachArgs)
+        assertEquals("kitchen-group", detachArgs["target_player"]?.jsonPrimitive?.content)
+        val removed = detachArgs["player_ids_to_remove"]?.jsonArray
+            ?.map { it.jsonPrimitive.content }
+        assertContentEquals(listOf("sendspin-local"), removed)
+    }
+
+    @Test
+    fun executePlayRequestCarriesMediaUriPlayerIdAndServerEncodedOption() = runBlocking {
+        QueueOption.entries.forEach { option ->
+            val client = RecordingClient()
+            executeLocalPlayerDispatch(
+                client,
+                LocalPlayerDispatchPlan(
+                    playerId = "sendspin-local",
+                    mediaUri = "library://album/42",
+                    detachFrom = null,
+                    option = option,
+                ),
+            )
+            val playArgs = client.sent.single().args
+            assertNotNull(playArgs)
+            assertEquals(
+                option.serverValue,
+                playArgs["option"]?.jsonPrimitive?.content,
+                "option=$option not propagated to server payload",
+            )
+            assertEquals(
+                "sendspin-local",
+                playArgs["queue_id"]?.jsonPrimitive?.content,
+                "queue_id should be the local player id, not the group",
+            )
+            val media = playArgs["media"]?.jsonArray?.map { it.jsonPrimitive.content }
+            assertContentEquals(listOf("library://album/42"), media)
+        }
+    }
+
+    @Test
+    fun executeStillFiresPlayWhenDetachRpcFails() = runBlocking {
+        // sendRequest is contractually no-throw; failures land in Result.failure.
+        // The play RPC must not be skipped just because detach failed — at worst
+        // we land in MA's group-queue branch, which is no worse than not detaching
+        // at all, and silently dropping the play would leave the user staring at
+        // CarPlay wondering why nothing happened.
+        val client = RecordingClient { request ->
+            if (request.command == SET_MEMBERS) {
+                Result.failure(IllegalStateException("simulated detach failure"))
+            } else {
+                Result.success(emptyAnswer())
+            }
+        }
+        executeLocalPlayerDispatch(
+            client,
+            LocalPlayerDispatchPlan(
+                playerId = "sendspin-local",
+                mediaUri = "uri",
+                detachFrom = "kitchen-group",
+                option = QueueOption.PLAY,
+            ),
+        )
+        assertEquals(2, client.sent.size, "play must still fire after a failed detach")
+        assertEquals(PLAY_MEDIA, client.sent[1].command)
+    }
+
+    @Test
+    fun executeReportsRpcFailuresViaCallbackWithLabel() = runBlocking {
+        val failures = mutableListOf<Pair<String, Throwable>>()
+        val detachError = IllegalStateException("boom-detach")
+        val playError = IllegalStateException("boom-play")
+        val client = RecordingClient { request ->
+            when (request.command) {
+                SET_MEMBERS -> Result.failure(detachError)
+                PLAY_MEDIA -> Result.failure(playError)
+                else -> fail("unexpected command ${request.command}")
+            }
+        }
+        executeLocalPlayerDispatch(
+            client,
+            LocalPlayerDispatchPlan(
+                playerId = "p",
+                mediaUri = "u",
+                detachFrom = "g",
+                option = QueueOption.REPLACE,
+            ),
+            onRpcFailure = { label, error -> failures.add(label to error) },
+        )
+        assertEquals(2, failures.size)
+        // Labels must distinguish which RPC failed so logs aren't ambiguous.
+        assertEquals("detach", failures[0].first)
+        assertEquals(detachError, failures[0].second)
+        assertTrue(
+            failures[1].first.startsWith("play("),
+            "play failure label should include the option for log triage; got '${failures[1].first}'",
+        )
+        assertEquals(playError, failures[1].second)
+    }
+
+    @Test
+    fun executeDoesNotInvokeFailureCallbackOnSuccess() = runBlocking {
+        var calls = 0
+        val client = RecordingClient { Result.success(emptyAnswer()) }
+        executeLocalPlayerDispatch(
+            client,
+            LocalPlayerDispatchPlan(
+                playerId = "p",
+                mediaUri = "u",
+                detachFrom = "g",
+                option = QueueOption.PLAY,
+            ),
+            onRpcFailure = { _, _ -> calls++ },
+        )
+        assertEquals(0, calls)
+    }
+
+    private companion object {
+        const val PLAY_MEDIA = APICommands.PLAYER_QUEUES_PLAY_MEDIA
+        const val SET_MEMBERS = APICommands.PLAYERS_CMD_SET_MEMBERS
+
+        fun emptyAnswer(): Answer = Answer(
+            json = buildJsonObject {
+                put("message_id", JsonPrimitive("fake"))
+            },
+        )
+    }
+}
+
+/**
+ * Stub [ServiceClient] that records every request it sees and returns a
+ * configurable response per call. Only [sendRequest] is implemented;
+ * everything else throws because the unit under test never touches it.
+ */
+private class RecordingClient(
+    private val respondWith: (Request) -> Result<Answer> = {
+        Result.success(
+            Answer(
+                json = buildJsonObject {
+                    put("message_id", JsonPrimitive("fake"))
+                },
+            ),
+        )
+    },
+) : ServiceClient {
+    val sent: MutableList<Request> = mutableListOf()
+
+    override suspend fun sendRequest(request: Request): Result<Answer> {
+        sent.add(request)
+        return respondWith(request)
+    }
+
+    override val sessionState: StateFlow<SessionState>
+        get() = error("not used")
+    override val isReadyForCommands: StateFlow<Boolean>
+        get() = error("not used")
+    override val serverBaseUrl: StateFlow<String?>
+        get() = error("not used")
+    override val events: Flow<Event<out Any>>
+        get() = error("not used")
+    override val webrtcSendspinChannel: DataChannelWrapper? = null
+    override val webRTCHttpProxy: io.music_assistant.client.webrtc.WebRTCHttpProxy? = null
+    override val foregroundEvents: Flow<Unit>
+        get() = error("not used")
+
+    override suspend fun login(username: String, password: String) = Unit
+    override suspend fun authorize(token: String, isAutoLogin: Boolean) = Unit
+    override fun logout() = Unit
+    override fun resolveImageUrl(path: String, provider: String, isRemotelyAccessible: Boolean): String? = null
+    override fun rebaseServerImageUrl(rawUrl: String): String? = null
+    override fun forceWebRTCReconnect() = Unit
+    override fun onAppForeground() = Unit
+    override fun onAppBackground() = Unit
+    override fun disconnectByUser() = Unit
+    override fun connect(connection: ConnectionInfo) = Unit
+    override fun connectWebRTC(remoteId: RemoteId) = Unit
+    override fun onExternalConsumerActive() = Unit
+    override fun onPlaybackActive() = Unit
+    override fun onExternalConsumerInactive() = Unit
+    override fun onPlaybackInactive() = Unit
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/library/LibraryTabConfigUtilsTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/library/LibraryTabConfigUtilsTest.kt
@@ -35,7 +35,7 @@ class LibraryTabConfigUtilsTest {
     }
 
     @Test
-    fun `enabling a tab that's already last enabled is a no-op (boundary reinsert)`() {
+    fun `enabling a tab that's already last enabled is a no-op - boundary reinsert`() {
         val items = listOf("A" to true, "B" to true)
         val result = moveToEnabledBoundary(items, "B", newEnabled = true)
         assertEquals(items, result)

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/nav/MultiBackStackTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/nav/MultiBackStackTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.assertEquals
 
 class MultiBackStackTest {
     @Test
-    fun `#resetCurrentBackStack restores back stack to original root`() {
+    fun `resetCurrentBackStack restores back stack to original root`() {
         val backStack = mutableListOf(TestNavKey("root"), TestNavKey("top"))
         val multiBackStack = MultiBackStack(listOf(backStack))
         multiBackStack.resetCurrentBackStack()

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
@@ -11,6 +11,7 @@ import io.music_assistant.client.api.Request
 import io.music_assistant.client.api.ServiceClient
 import io.music_assistant.client.auth.AuthenticationManager
 import io.music_assistant.client.data.MainDataSource
+import io.music_assistant.client.data.executeLocalPlayerDispatch
 import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.QueueOption
 import io.music_assistant.client.data.model.client.items.Album
@@ -19,6 +20,7 @@ import io.music_assistant.client.data.model.client.items.Artist
 import io.music_assistant.client.data.model.client.items.Playlist
 import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.data.model.client.items.Track
+import io.music_assistant.client.data.planLocalPlayerDispatch
 import io.music_assistant.client.data.repository.MediaItemRepository
 import io.music_assistant.client.utils.HasConnectionData
 import io.music_assistant.client.utils.currentTimeMillis
@@ -338,37 +340,31 @@ object KmpHelper : KoinComponent {
     // MARK: - Playback
 
     /**
-     * Play [item] on the iOS local Sendspin player only — never the group
-     * it may be synced to. Detaches from any sync group first; MA promotes
-     * `play(queueOrPlayerId = childId)` to the group queue otherwise.
+     * Play, replace, or append [item] on the iOS local Sendspin player —
+     * never the group it may be synced to. When the local player is currently
+     * a sync-group child we always detach first, regardless of [option]:
+     * being in CarPlay means the user wants audio out of the phone they're
+     * holding, and there's no plausible scenario where they want the same
+     * audio mirrored to another player as well.
      *
      * Returns false on no-local-player or no-URI; callers use this to skip
      * Siri donation and respond with `.failure`.
      */
-    fun playOnLocalPlayer(item: AppMediaItem): Boolean {
-        val localPlayerData = mainDataSource.localPlayer.value ?: return false
-        val playerId = localPlayerData.player.id
-        val mediaUri = item.mediaUri ?: return false
-        val syncedToId = localPlayerData.player.syncedTo
+    fun playOnLocalPlayer(item: AppMediaItem, option: QueueOption): Boolean {
+        val player = mainDataSource.localPlayer.value?.player
+        val plan = planLocalPlayerDispatch(
+            localPlayerId = player?.id,
+            localPlayerSyncedTo = player?.syncedTo,
+            mediaUri = item.mediaUri,
+            option = option,
+        ) ?: return false
+        plan.detachFrom?.let { syncedToId ->
+            log.i { "playOnLocalPlayer($option): detaching ${plan.playerId} from $syncedToId" }
+        }
         mainScope.launch {
-            if (syncedToId != null) {
-                log.i { "playOnLocalPlayer: detaching $playerId from $syncedToId" }
-                serviceClient.sendRequest(
-                    Request.Player.setGroupMembers(
-                        playerId = syncedToId,
-                        playersToAdd = null,
-                        playersToRemove = listOf(playerId),
-                    ),
-                )
+            executeLocalPlayerDispatch(serviceClient, plan) { label, error ->
+                log.w(error) { "$label RPC failed: ${error.message}" }
             }
-            serviceClient.sendRequest(
-                Request.Library.play(
-                    media = listOf(mediaUri),
-                    queueOrPlayerId = playerId,
-                    option = QueueOption.PLAY,
-                    radioMode = false,
-                ),
-            )
         }
         return true
     }

--- a/iosApp/iosApp/CarPlay/CarPlayContentManager.swift
+++ b/iosApp/iosApp/CarPlay/CarPlayContentManager.swift
@@ -136,9 +136,22 @@ class CarPlayContentManager {
     // MARK: - Action Handling
 
     func playItem(_ item: AppMediaItem) {
-        guard KmpHelper.shared.playOnLocalPlayer(item: item) else { return }
-        // Donate the play so Siri learns Music Assistant is a media destination.
-        // Without donations, "Hey Siri, play X" never lists this app as a candidate.
+        play(item, option: .play)
+    }
+
+    func playAll(_ item: AppMediaItem) {
+        play(item, option: .replace)
+    }
+
+    func enqueueAll(_ item: AppMediaItem) {
+        play(item, option: .add)
+    }
+
+    // Donations train Siri's "play X in Music Assistant" model — fire on
+    // any user-initiated dispatch (immediate or queued), since intent to
+    // play is what matters, not whether the RPC ultimately landed.
+    private func play(_ item: AppMediaItem, option: QueueOption) {
+        guard KmpHelper.shared.playOnLocalPlayer(item: item, option: option) else { return }
         SiriIntentHandler.donatePlayed(item)
     }
     
@@ -169,7 +182,6 @@ class CarPlayContentManager {
         listItem.setImage(UIImage(systemName: iconName))
 
         // Load artwork asynchronously
-        let serverUrl = KmpHelper.shared.getServerUrl()
         if let imageUrl = item.image(type: ImageType.thumb)?.url {
             CarPlayImageLoader.shared.loadImage(from: imageUrl) { image in
                 if let image = image {

--- a/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
+++ b/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
@@ -287,7 +287,6 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
                 return
             }
 
-            let serverUrl = KmpHelper.shared.getServerUrl()
             let imageSize = CPListImageRowItem.maximumImageSize
             let maxImages = 8
 
@@ -464,7 +463,8 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     private func pushAlbumsForArtist(_ artist: Artist) {
         pushDrilldown(
             title: "Albums by \(artist.displayName)",
-            emptyText: "No albums for \(artist.displayName)"
+            emptyText: "No albums for \(artist.displayName)",
+            bulkActionParent: artist
         ) { completion in
             CarPlayContentManager.shared.fetchAlbumsForArtist(artist, completion: completion)
         }
@@ -473,7 +473,8 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     private func pushTracksForAlbum(_ album: Album) {
         pushDrilldown(
             title: album.displayName,
-            emptyText: "No tracks in this album"
+            emptyText: "No tracks in this album",
+            bulkActionParent: album
         ) { completion in
             CarPlayContentManager.shared.fetchTracksForAlbum(album, completion: completion)
         }
@@ -482,7 +483,8 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     private func pushTracksForPlaylist(_ playlist: Playlist) {
         pushDrilldown(
             title: playlist.displayName,
-            emptyText: "No tracks in this playlist"
+            emptyText: "No tracks in this playlist",
+            bulkActionParent: playlist
         ) { completion in
             CarPlayContentManager.shared.fetchTracksForPlaylist(playlist, completion: completion)
         }
@@ -493,6 +495,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     private func pushDrilldown(
         title: String,
         emptyText: String,
+        bulkActionParent: AppMediaItem,
         fetcher: @escaping (@escaping ([CPListItem]?) -> Void) -> Void
     ) {
         let template = CPListTemplate(title: title, sections: [])
@@ -507,11 +510,53 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
                     template.updateSections([emptyStateSection(text: emptyText)])
                 } else {
                     self.attachHandlers(to: items)
-                    template.updateSections([CPListSection(items: items)])
+                    let prefix = self.bulkActionRows(for: bulkActionParent)
+                    template.updateSections([CPListSection(items: prefix + items)])
                 }
             } else {
                 template.updateSections([CPListSection(items: [disconnectedRow()])])
             }
+        }
+    }
+
+    // MARK: - Bulk actions
+
+    private func bulkActionRows(for parent: AppMediaItem) -> [CPListItem] {
+        let playAll = CPListItem(
+            text: "Play All",
+            detailText: nil,
+            image: UIImage(systemName: "play.fill")
+        )
+        playAll.handler = { [weak self] _, completion in
+            self?.handleBulkAction(parent: parent, mode: .playAll)
+            completion()
+        }
+
+        let addAll = CPListItem(
+            text: "Add All to Queue",
+            detailText: nil,
+            image: UIImage(systemName: "text.badge.plus")
+        )
+        addAll.handler = { [weak self] _, completion in
+            self?.handleBulkAction(parent: parent, mode: .enqueueAll)
+            completion()
+        }
+
+        return [playAll, addAll]
+    }
+
+    private enum BulkAction { case playAll, enqueueAll }
+
+    private func handleBulkAction(parent: AppMediaItem, mode: BulkAction) {
+        guard isReady else { showOfflineAlert(); return }
+        switch mode {
+        case .playAll:
+            CarPlayContentManager.shared.playAll(parent)
+            playAndShowNowPlaying()
+        case .enqueueAll:
+            // Intentionally no Now Playing push: enqueue is non-disruptive,
+            // user stays on the drilldown to keep stacking adds.
+            CarPlayContentManager.shared.enqueueAll(parent)
         }
     }
 

--- a/iosApp/iosApp/CarPlay/SiriIntentHandler.swift
+++ b/iosApp/iosApp/CarPlay/SiriIntentHandler.swift
@@ -477,7 +477,7 @@ extension SiriIntentHandler: INPlayMediaIntentHandling {
         _ item: AppMediaItem,
         completion: @escaping (INPlayMediaIntentResponse) -> Void
     ) {
-        let dispatched = KmpHelper.shared.playOnLocalPlayer(item: item)
+        let dispatched = KmpHelper.shared.playOnLocalPlayer(item: item, option: .play)
         os_log("PlayMedia.dispatchPlay: name=%{public}@ dispatched=%{public}@",
                log: log, type: .info,
                item.displayName,


### PR DESCRIPTION
There was a discussion about this in the discord this morning, which reminded me I wanted to do this soonish anyway. While doing the thing, I pulled out the core of the localPlayer stuff into commonMain, at first just to make it easier to unit test without having all of the iOS overhead, but then I realized that Android Auto - while always forcing local player, correctly - did not also force-detach the local player from any existing grouping on the MA side. Now, maybe all of this group detaching we're doing in iOS isn't actually needed? And if so, this can get a lot simpler. But if it is, then the next PR would be to convert Android Auto to use the same LocalPlayerDispatch and have that business logic centralized.

Commit message:

Mirrors Android Auto. Drilling into an album, artist, or playlist now prepends two rows: 'Play All' (replace queue + jump to Now Playing) and 'Add All to Queue' (append, stay on drilldown).

The local-player dispatch helpers (unconditional detach + parametrized QueueOption) are extracted into commonMain so AA can adopt them in a follow-up — AA shares the same latent 'play promotes to group queue' behavior this branch fixes for iOS.

Drive-by: rename two pre-existing tests to drop '(' and '#' from their function names. Kotlin/Native rejects those in test identifiers, which was blocking the iOS test target from compiling.