### PR TITLE
refactor(aa): port Android Auto to shared LocalPlayerDispatch helpers

### DIFF
--- a/androidApp/src/main/kotlin/io/music_assistant/client/auto/AutoLibrary.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/auto/AutoLibrary.kt
@@ -15,6 +15,8 @@ import io.music_assistant.client.R
 import io.music_assistant.client.api.Answer
 import io.music_assistant.client.api.Request
 import io.music_assistant.client.api.ServiceClient
+import io.music_assistant.client.data.MainDataSource
+import io.music_assistant.client.data.executeLocalPlayerDispatch
 import io.music_assistant.client.data.factory.MediaItemFactory
 import io.music_assistant.client.data.model.client.ImageType
 import io.music_assistant.client.data.model.client.MediaType
@@ -26,6 +28,7 @@ import io.music_assistant.client.data.model.client.clientSorted
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.server.SearchResult
 import io.music_assistant.client.data.model.server.ServerMediaItem
+import io.music_assistant.client.data.planLocalPlayerDispatch
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.Timings
 import io.music_assistant.client.ui.compose.library.LibraryTabsViewModel
@@ -57,6 +60,7 @@ class AutoLibrary(
     private val apiClient: ServiceClient,
     private val settingsRepository: SettingsRepository,
     private val mediaItemFactory: MediaItemFactory,
+    private val mainDataSource: MainDataSource,
 ) {
     private val scope = CoroutineScope(Dispatchers.IO)
     private val searchFlow: MutableStateFlow<Pair<String, MediaBrowserServiceCompat.Result<List<MediaItem>>>?> =
@@ -388,7 +392,7 @@ class AutoLibrary(
         searchFlow.update { Pair(query, result) }
     }
 
-    fun searchAndPlay(query: String, extras: Bundle?, queueId: String) {
+    fun searchAndPlay(query: String, extras: Bundle?) {
         scope.launch {
             val ready = waitForCorrectState()
             if (!ready) {
@@ -419,7 +423,7 @@ class AutoLibrary(
 
                 @Suppress("DEPRECATION")
                 val genreExtra = extras?.getString(MediaStore.EXTRA_MEDIA_GENRE)
-                "searchAndPlay focus=$focus query=\"$query\" queueId=$queueId " +
+                "searchAndPlay focus=$focus query=\"$query\" " +
                         "extras{artist=$artistExtra album=$albumExtra title=$titleExtra " +
                         "playlist=$playlistExtra genre=$genreExtra}"
             }
@@ -428,49 +432,44 @@ class AutoLibrary(
                 MediaStore.Audio.Artists.ENTRY_CONTENT_TYPE ->
                     playArtist(
                         artistName = extras.getString(MediaStore.EXTRA_MEDIA_ARTIST) ?: query,
-                        queueId = queueId,
                     )
 
                 MediaStore.Audio.Albums.ENTRY_CONTENT_TYPE ->
                     playAlbum(
                         albumName = extras.getString(MediaStore.EXTRA_MEDIA_ALBUM) ?: query,
                         artistName = extras.getString(MediaStore.EXTRA_MEDIA_ARTIST),
-                        queueId = queueId,
                     )
 
                 MediaStore.Audio.Media.ENTRY_CONTENT_TYPE ->
                     playTrack(
                         title = extras.getString(MediaStore.EXTRA_MEDIA_TITLE) ?: query,
                         artistName = extras.getString(MediaStore.EXTRA_MEDIA_ARTIST),
-                        queueId = queueId,
                     )
 
                 MediaStore.Audio.Playlists.ENTRY_CONTENT_TYPE ->
                     playPlaylist(
                         playlistName = extras.getString(MediaStore.EXTRA_MEDIA_PLAYLIST) ?: query,
-                        queueId = queueId,
                     )
 
                 MediaStore.Audio.Genres.ENTRY_CONTENT_TYPE -> {
                     androidAutoLog.i { "Genre focus → unstructured search on genre keyword" }
                     playUnstructured(
                         query = extras.getString(MediaStore.EXTRA_MEDIA_GENRE) ?: query,
-                        queueId = queueId,
                     )
                 }
 
                 else -> if (query.isBlank()) {
                     androidAutoLog.i { "No focus + blank query → random favorites" }
-                    playRandomFavorites(queueId)
+                    playRandomFavorites()
                 } else {
                     androidAutoLog.i { "No focus + non-blank query → unstructured cascade" }
-                    playUnstructured(query, queueId)
+                    playUnstructured(query)
                 }
             }
         }
     }
 
-    private suspend fun playArtist(artistName: String, queueId: String) {
+    private suspend fun playArtist(artistName: String) {
         androidAutoLog.i { "playArtist(\"$artistName\")" }
         val sr = sendLogged("search ARTIST=\"$artistName\"") {
             Request.Library.search(
@@ -488,10 +487,10 @@ class AutoLibrary(
         androidAutoLog.i {
             "  → matched artist=${artist.name} item_id=${artist.itemId} provider=${artist.provider} uri=${artist.uri}"
         }
-        playArtistTracksShuffled(artist, queueId)
+        playArtistTracksShuffled(artist)
     }
 
-    private suspend fun playAlbum(albumName: String, artistName: String?, queueId: String) {
+    private suspend fun playAlbum(albumName: String, artistName: String?) {
         androidAutoLog.i { "playAlbum(\"$albumName\", artist=\"$artistName\")" }
         val combinedQuery = listOfNotNull(albumName, artistName).joinToString(" ")
         val sr = sendLogged("search ALBUM=\"$combinedQuery\"") {
@@ -513,10 +512,10 @@ class AutoLibrary(
             return
         }
         androidAutoLog.i { "  → matched album uri=$uri" }
-        playUris(listOf(uri), queueId)
+        playUris(listOf(uri))
     }
 
-    private suspend fun playTrack(title: String, artistName: String?, queueId: String) {
+    private suspend fun playTrack(title: String, artistName: String?) {
         androidAutoLog.i { "playTrack(\"$title\", artist=\"$artistName\")" }
         val combinedQuery = listOfNotNull(title, artistName).joinToString(" ")
         val sr = sendLogged("search TRACK=\"$combinedQuery\"") {
@@ -538,10 +537,10 @@ class AutoLibrary(
             return
         }
         androidAutoLog.i { "  → matched track uri=$uri" }
-        playUris(listOf(uri), queueId)
+        playUris(listOf(uri))
     }
 
-    private suspend fun playPlaylist(playlistName: String, queueId: String) {
+    private suspend fun playPlaylist(playlistName: String) {
         androidAutoLog.i { "playPlaylist(\"$playlistName\")" }
         val sr = sendLogged("search PLAYLIST=\"$playlistName\"") {
             Request.Library.search(
@@ -557,10 +556,10 @@ class AutoLibrary(
             return
         }
         androidAutoLog.i { "  → matched playlist uri=$uri" }
-        playUris(listOf(uri), queueId)
+        playUris(listOf(uri))
     }
 
-    private suspend fun playUnstructured(query: String, queueId: String) {
+    private suspend fun playUnstructured(query: String) {
         androidAutoLog.i { "playUnstructured(\"$query\")" }
         val sr = sendLogged("search UNSTRUCTURED=\"$query\"") {
             Request.Library.search(
@@ -590,38 +589,38 @@ class AutoLibrary(
         // is queued by its own URI.
         sr.tracks.firstOrNull()?.uri?.let {
             androidAutoLog.i { "  → picked TRACK uri=$it" }
-            playUris(listOf(it), queueId)
+            playUris(listOf(it))
             return
         }
         sr.artists.firstOrNull()?.let {
             androidAutoLog.i { "  → picked ARTIST name=${it.name} item_id=${it.itemId} provider=${it.provider}" }
-            playArtistTracksShuffled(it, queueId)
+            playArtistTracksShuffled(it)
             return
         }
         sr.albums.firstOrNull()?.uri?.let {
             androidAutoLog.i { "  → picked ALBUM uri=$it" }
-            playUris(listOf(it), queueId)
+            playUris(listOf(it))
             return
         }
         sr.playlists.firstOrNull()?.uri?.let {
             androidAutoLog.i { "  → picked PLAYLIST uri=$it" }
-            playUris(listOf(it), queueId)
+            playUris(listOf(it))
             return
         }
         sr.podcasts.firstOrNull()?.let {
             androidAutoLog.i { "  → picked PODCAST item_id=${it.itemId} provider=${it.provider}" }
-            playPodcastLatest(it, queueId)
+            playPodcastLatest(it)
             return
         }
         sr.radio.firstOrNull()?.uri?.let {
             androidAutoLog.i { "  → picked RADIO uri=$it" }
-            playUris(listOf(it), queueId)
+            playUris(listOf(it))
             return
         }
         androidAutoLog.i { "Unstructured search for \"$query\" produced zero hits across all media types." }
     }
 
-    private suspend fun playArtistTracksShuffled(artist: ServerMediaItem, queueId: String) {
+    private suspend fun playArtistTracksShuffled(artist: ServerMediaItem) {
         val trackResult =
             sendLogged("Artist.getTracks item_id=${artist.itemId} provider=${artist.provider}") {
                 Request.Artist.getTracks(artist.itemId, artist.provider)
@@ -643,10 +642,10 @@ class AutoLibrary(
             androidAutoLog.i { "Artist has no playable URIs (tracks empty AND artist.uri null)." }
             return
         }
-        playAndShuffle(media, queueId, shuffle = true)
+        playAndShuffle(media, shuffle = true)
     }
 
-    private suspend fun playPodcastLatest(podcast: ServerMediaItem, queueId: String) {
+    private suspend fun playPodcastLatest(podcast: ServerMediaItem) {
         val episodes =
             sendLogged("Podcast.getEpisodes item_id=${podcast.itemId} provider=${podcast.provider}") {
                 Request.Podcast.getEpisodes(podcast.itemId, podcast.provider)
@@ -659,10 +658,10 @@ class AutoLibrary(
             return
         }
         androidAutoLog.i { "  → playing podcast uri=$latestUri" }
-        playUris(listOf(latestUri), queueId)
+        playUris(listOf(latestUri))
     }
 
-    private suspend fun playRandomFavorites(queueId: String) {
+    private suspend fun playRandomFavorites() {
         androidAutoLog.i { "playRandomFavorites" }
         val favoriteUris = sendLogged("Track.list favorite=true limit=$RANDOM_POOL_SIZE") {
             Request.Track.list(favorite = true, limit = RANDOM_POOL_SIZE)
@@ -678,34 +677,55 @@ class AutoLibrary(
             androidAutoLog.i { "No favorites AND no recently-played tracks — random fallback has no pool." }
             return
         }
-        playAndShuffle(pool.shuffled(), queueId, shuffle = true)
+        playAndShuffle(pool.shuffled(), shuffle = true)
     }
 
-    private suspend fun playUris(media: List<String>, queueId: String) {
+    private suspend fun playUris(media: List<String>) {
         if (media.isEmpty()) {
             androidAutoLog.w { "playUris called with empty media list — no-op." }
             return
         }
-        androidAutoLog.i {
-            "Library.play REPLACE queueId=$queueId items=${media.size} first=${media.first()}"
-        }
-        sendLogged("Library.play (${media.size} items)") {
-            Request.Library.play(
-                media = media,
-                queueOrPlayerId = queueId,
-                option = QueueOption.REPLACE,
-                radioMode = false,
-            )
+        androidAutoLog.i { "Library.play REPLACE items=${media.size} first=${media.first()}" }
+        dispatchToLocalPlayer(media, QueueOption.REPLACE)
+    }
+
+    private suspend fun playAndShuffle(media: List<String>, shuffle: Boolean) {
+        playUris(media)
+        if (!shuffle) return
+        // setShuffle targets the queue playUris just populated. After dispatch's
+        // force-detach, the local player owns its own queue, so its id IS the queue id.
+        val localId = mainDataSource.localPlayer.value?.player?.id ?: return
+        androidAutoLog.i { "Queue.setShuffle enabled=true queueId=$localId" }
+        sendLogged("Queue.setShuffle enabled=true") {
+            Request.Queue.setShuffle(queueId = localId, enabled = true)
         }
     }
 
-    private suspend fun playAndShuffle(media: List<String>, queueId: String, shuffle: Boolean) {
-        playUris(media, queueId)
-        if (shuffle) {
-            androidAutoLog.i { "Queue.setShuffle enabled=true queueId=$queueId" }
-            sendLogged("Queue.setShuffle enabled=true") {
-                Request.Queue.setShuffle(queueId = queueId, enabled = true)
+    /**
+     * Dispatches [uris] to the local Sendspin player with [option], force-detaching
+     * from any sync group. AA users want audio out of the head unit they're sitting
+     * in, never mirrored to a house player.
+     */
+    private suspend fun dispatchToLocalPlayer(uris: List<String>, option: QueueOption) {
+        val player = mainDataSource.localPlayer.value?.player
+        val plan = planLocalPlayerDispatch(
+            localPlayerId = player?.id,
+            localPlayerSyncedTo = player?.syncedTo,
+            mediaUris = uris,
+            option = option,
+        )
+        if (plan == null) {
+            androidAutoLog.w {
+                "dispatchToLocalPlayer skipped — local player or media missing " +
+                        "(player=${player?.id} uris=${uris.size})"
             }
+            return
+        }
+        plan.detachFrom?.let { syncedToId ->
+            androidAutoLog.i { "dispatch($option): detaching ${plan.playerId} from $syncedToId" }
+        }
+        executeLocalPlayerDispatch(apiClient, plan) { label, error ->
+            androidAutoLog.w(error) { "$label RPC failed: ${error.message}" }
         }
     }
 
@@ -727,23 +747,15 @@ class AutoLibrary(
             },
         )
 
-    fun play(id: String, extras: Bundle?, queueId: String) {
-        id.split("__").getOrNull(1)?.let { uri ->
-            scope.launch {
-                apiClient.sendRequest(
-                    Request.Library.play(
-                        media = listOf(uri),
-                        queueOrPlayerId = queueId,
-                        option = extras?.getString(
-                            MediaIds.QUEUE_OPTION_KEY,
-                            QueueOption.REPLACE.name,
-                        )?.let { QueueOption.valueOf(it) }
-                            ?: QueueOption.REPLACE,
-                        radioMode = false,
-                    ),
-                )
-            }
-        }
+    fun play(id: String, extras: Bundle?) {
+        val uri = id.split("__").getOrNull(1) ?: return
+        // valueOf throws on unknown names — a stale media item or a malformed
+        // extras bundle would crash the service. Fall back to REPLACE silently.
+        val option = extras
+            ?.getString(MediaIds.QUEUE_OPTION_KEY, QueueOption.REPLACE.name)
+            ?.let { runCatching { QueueOption.valueOf(it) }.getOrNull() }
+            ?: QueueOption.REPLACE
+        scope.launch { dispatchToLocalPlayer(listOf(uri), option) }
     }
 
     private fun rootTabItem(tabName: String, tabId: String): MediaItem =

--- a/androidApp/src/main/kotlin/io/music_assistant/client/di/AppModule.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/di/AppModule.kt
@@ -6,6 +6,6 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
 fun appModule() = module {
-    single { AutoLibrary(androidContext(), get(), get(), get()) }
+    single { AutoLibrary(androidContext(), get(), get(), get(), get()) }
     single { SharedMediaSessionManager(androidContext()) }
 }

--- a/androidApp/src/main/kotlin/io/music_assistant/client/services/AndroidAutoPlaybackService.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/services/AndroidAutoPlaybackService.kt
@@ -157,15 +157,9 @@ class AndroidAutoPlaybackService : MediaBrowserServiceCompat() {
             }
 
             override fun onPlayFromMediaId(mediaId: String?, extras: Bundle?) {
-                currentPlayerData.value?.let { playerData ->
-                    mediaId?.let {
-                        library.play(
-                            it,
-                            extras,
-                            playerData.queueInfo?.id ?: playerData.player.id,
-                        )
-                    }
-                }
+                // No readiness wait (unlike onPlayFromSearch): browse tap can only fire
+                // after the user navigated to a media item, so the local player is up.
+                mediaId?.let { library.play(it, extras) }
             }
 
             override fun onPlayFromSearch(query: String?, extras: Bundle?) {
@@ -180,7 +174,7 @@ class AndroidAutoPlaybackService : MediaBrowserServiceCompat() {
                 // the service was just created, so currentPlayerData may still be null
                 // while auth + local-player initialization complete. Wait up to 10s.
                 // For the in-car AA path the player is already up, so the await is
-                // immediate. One symmetrical entry point for both surfaces.
+                // immediate.
                 scope.launch {
                     val playerData = withTimeoutOrNull(LOCAL_PLAYER_READY_TIMEOUT_MS) {
                         currentPlayerData.filterNotNull().first()
@@ -192,15 +186,8 @@ class AndroidAutoPlaybackService : MediaBrowserServiceCompat() {
                         }
                         return@launch
                     }
-                    val queueId = playerData.queueInfo?.id ?: playerData.player.id
-                    androidAutoLog.i {
-                        "Dispatching to AutoLibrary with queueId=$queueId (local player)"
-                    }
-                    library.searchAndPlay(
-                        query = query.orEmpty(),
-                        extras = extras,
-                        queueId = queueId,
-                    )
+                    androidAutoLog.i { "Dispatching to AutoLibrary (local player ready)" }
+                    library.searchAndPlay(query = query.orEmpty(), extras = extras)
                 }
             }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerDispatch.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerDispatch.kt
@@ -11,24 +11,24 @@ import io.music_assistant.client.data.model.client.QueueOption
  * the audio has to come out of.
  */
 
-internal data class LocalPlayerDispatchPlan(
+data class LocalPlayerDispatchPlan(
     val playerId: String,
-    val mediaUri: String,
+    val mediaUris: List<String>,
     val detachFrom: String?,
     val option: QueueOption,
 )
 
-/** Returns null when prerequisites (a local player, a media URI) are missing. */
-internal fun planLocalPlayerDispatch(
+/** Returns null when prerequisites (a local player, at least one URI) are missing. */
+fun planLocalPlayerDispatch(
     localPlayerId: String?,
     localPlayerSyncedTo: String?,
-    mediaUri: String?,
+    mediaUris: List<String>,
     option: QueueOption,
 ): LocalPlayerDispatchPlan? {
-    if (localPlayerId == null || mediaUri == null) return null
+    if (localPlayerId == null || mediaUris.isEmpty()) return null
     return LocalPlayerDispatchPlan(
         playerId = localPlayerId,
-        mediaUri = mediaUri,
+        mediaUris = mediaUris,
         detachFrom = localPlayerSyncedTo,
         option = option,
     )
@@ -40,7 +40,7 @@ internal fun planLocalPlayerDispatch(
  * [onRpcFailure] rather than try/catch: `sendRequest` is contractually
  * no-throw, and a catch-all would only break structured concurrency.
  */
-internal suspend fun executeLocalPlayerDispatch(
+suspend fun executeLocalPlayerDispatch(
     serviceClient: ServiceClient,
     plan: LocalPlayerDispatchPlan,
     onRpcFailure: (label: String, error: Throwable) -> Unit = { _, _ -> },
@@ -56,7 +56,7 @@ internal suspend fun executeLocalPlayerDispatch(
     }
     serviceClient.sendRequest(
         Request.Library.play(
-            media = listOf(plan.mediaUri),
+            media = plan.mediaUris,
             queueOrPlayerId = plan.playerId,
             option = plan.option,
             radioMode = false,

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/LocalPlayerDispatchTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/LocalPlayerDispatchTest.kt
@@ -33,21 +33,22 @@ class LocalPlayerDispatchTest {
         val plan = planLocalPlayerDispatch(
             localPlayerId = null,
             localPlayerSyncedTo = null,
-            mediaUri = "library://album/42",
+            mediaUris = listOf("library://album/42"),
             option = QueueOption.PLAY,
         )
         assertNull(plan)
     }
 
     @Test
-    fun planReturnsNullWhenMediaUriMissing() {
+    fun planReturnsNullWhenMediaUrisEmpty() {
         // Container items occasionally surface without a URI (mostly Genre,
-        // pre-synthesis). The planner must refuse rather than dispatch an
-        // empty media list and let MA error out remotely.
+        // pre-synthesis); voice-search paths can also reduce to nothing playable.
+        // The planner refuses rather than dispatch an empty media list and let
+        // MA error out remotely.
         val plan = planLocalPlayerDispatch(
             localPlayerId = "sendspin-local",
             localPlayerSyncedTo = null,
-            mediaUri = null,
+            mediaUris = emptyList(),
             option = QueueOption.PLAY,
         )
         assertNull(plan)
@@ -58,12 +59,12 @@ class LocalPlayerDispatchTest {
         val plan = planLocalPlayerDispatch(
             localPlayerId = "sendspin-local",
             localPlayerSyncedTo = null,
-            mediaUri = "library://album/42",
+            mediaUris = listOf("library://album/42"),
             option = QueueOption.REPLACE,
         )
         assertNotNull(plan)
         assertEquals("sendspin-local", plan.playerId)
-        assertEquals("library://album/42", plan.mediaUri)
+        assertEquals(listOf("library://album/42"), plan.mediaUris)
         assertEquals(QueueOption.REPLACE, plan.option)
         assertNull(plan.detachFrom)
     }
@@ -73,7 +74,7 @@ class LocalPlayerDispatchTest {
         val plan = planLocalPlayerDispatch(
             localPlayerId = "sendspin-local",
             localPlayerSyncedTo = "kitchen-group",
-            mediaUri = "library://playlist/1",
+            mediaUris = listOf("library://playlist/1"),
             option = QueueOption.ADD,
         )
         assertNotNull(plan)
@@ -92,7 +93,7 @@ class LocalPlayerDispatchTest {
             val plan = planLocalPlayerDispatch(
                 localPlayerId = "p",
                 localPlayerSyncedTo = null,
-                mediaUri = "uri",
+                mediaUris = listOf("uri"),
                 option = option,
             )
             assertEquals(option, plan?.option, "option=$option round-trip mismatch")
@@ -108,7 +109,7 @@ class LocalPlayerDispatchTest {
             client,
             LocalPlayerDispatchPlan(
                 playerId = "sendspin-local",
-                mediaUri = "library://album/42",
+                mediaUris = listOf("library://album/42"),
                 detachFrom = null,
                 option = QueueOption.PLAY,
             ),
@@ -128,7 +129,7 @@ class LocalPlayerDispatchTest {
             client,
             LocalPlayerDispatchPlan(
                 playerId = "sendspin-local",
-                mediaUri = "library://album/42",
+                mediaUris = listOf("library://album/42"),
                 detachFrom = "kitchen-group",
                 option = QueueOption.REPLACE,
             ),
@@ -145,7 +146,7 @@ class LocalPlayerDispatchTest {
             client,
             LocalPlayerDispatchPlan(
                 playerId = "sendspin-local",
-                mediaUri = "uri",
+                mediaUris = listOf("uri"),
                 detachFrom = "kitchen-group",
                 option = QueueOption.PLAY,
             ),
@@ -159,14 +160,14 @@ class LocalPlayerDispatchTest {
     }
 
     @Test
-    fun executePlayRequestCarriesMediaUriPlayerIdAndServerEncodedOption() = runBlocking {
+    fun executePlayRequestCarriesMediaUrisPlayerIdAndServerEncodedOption() = runBlocking {
         QueueOption.entries.forEach { option ->
             val client = RecordingClient()
             executeLocalPlayerDispatch(
                 client,
                 LocalPlayerDispatchPlan(
                     playerId = "sendspin-local",
-                    mediaUri = "library://album/42",
+                    mediaUris = listOf("library://album/42"),
                     detachFrom = null,
                     option = option,
                 ),
@@ -189,6 +190,29 @@ class LocalPlayerDispatchTest {
     }
 
     @Test
+    fun executePassesMultiUriBatchVerbatimAsServerMediaArray() = runBlocking {
+        // AA's pre-ordered batches must reach the server unchanged.
+        val uris = listOf(
+            "library://track/1",
+            "library://track/2",
+            "library://track/3",
+        )
+        val client = RecordingClient()
+        executeLocalPlayerDispatch(
+            client,
+            LocalPlayerDispatchPlan(
+                playerId = "sendspin-local",
+                mediaUris = uris,
+                detachFrom = null,
+                option = QueueOption.REPLACE,
+            ),
+        )
+        val media = client.sent.single().args
+            ?.get("media")?.jsonArray?.map { it.jsonPrimitive.content }
+        assertContentEquals(uris, media)
+    }
+
+    @Test
     fun executeStillFiresPlayWhenDetachRpcFails() = runBlocking {
         // sendRequest is contractually no-throw; failures land in Result.failure.
         // The play RPC must not be skipped just because detach failed — at worst
@@ -206,7 +230,7 @@ class LocalPlayerDispatchTest {
             client,
             LocalPlayerDispatchPlan(
                 playerId = "sendspin-local",
-                mediaUri = "uri",
+                mediaUris = listOf("uri"),
                 detachFrom = "kitchen-group",
                 option = QueueOption.PLAY,
             ),
@@ -231,7 +255,7 @@ class LocalPlayerDispatchTest {
             client,
             LocalPlayerDispatchPlan(
                 playerId = "p",
-                mediaUri = "u",
+                mediaUris = listOf("u"),
                 detachFrom = "g",
                 option = QueueOption.REPLACE,
             ),
@@ -256,7 +280,7 @@ class LocalPlayerDispatchTest {
             client,
             LocalPlayerDispatchPlan(
                 playerId = "p",
-                mediaUri = "u",
+                mediaUris = listOf("u"),
                 detachFrom = "g",
                 option = QueueOption.PLAY,
             ),

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
@@ -355,7 +355,7 @@ object KmpHelper : KoinComponent {
         val plan = planLocalPlayerDispatch(
             localPlayerId = player?.id,
             localPlayerSyncedTo = player?.syncedTo,
-            mediaUri = item.mediaUri,
+            mediaUris = listOfNotNull(item.mediaUri),
             option = option,
         ) ?: return false
         plan.detachFrom?.let { syncedToId ->


### PR DESCRIPTION
Alright, while doing this I figured out that on the Android side the play functions all took lists, where-as on iOS it was a single string. Changed the new functions to use lists (it's better!) and so had to update a bunch of the code I just added last commit. Such is life.

Didn't add the 'release' tags as I wasn't sure if you want to do hardware testing before releasing further.

AutoLibrary now injects MainDataSource and routes both play(id, extras) and playUris through the same plan/execute helpers iOS uses. Fixes the latent group-queue promotion bug: AA was passing
`queueInfo?.id ?: player.id` as the queueOrPlayerId, which resolved to the group's queue id when the local player was synced, and the server promoted playback to the group queue. AutoLibrary now resolves the local player at dispatch time and force-detaches from any sync group, matching iOS CarPlay.

The shared helpers grow from `mediaUri: String` to `mediaUris: List<String>` to carry AA's batches (voice search, shuffled favorites).

Visibility on the helpers widened from internal to public — composeApp and androidApp are separate Gradle modules and `internal` doesn't cross.