### PR TITLE
refactor: clean up Kotlin warnings and adjacent smells

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -17,6 +17,13 @@ compose.resources {
 }
 
 kotlin {
+    // expect/actual classes are still marked Beta (KT-61573) but the design is
+    // stable and widely used across this codebase. Suppress the per-declaration
+    // warnings rather than littering @OptIn annotations.
+    compilerOptions {
+        freeCompilerArgs.add("-Xexpect-actual-classes")
+    }
+
     androidLibrary {
         namespace = "io.music_assistant.client.shared"
         compileSdk = libs.versions.android.compileSdk.get().toInt()

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Answer.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Answer.kt
@@ -5,13 +5,14 @@ import io.music_assistant.client.utils.myJson
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonPrimitive
 
 data class Answer(
     val json: JsonObject,
 ) {
-    val messageId: String? = json["message_id"]?.jsonPrimitive?.content
+    val messageId: String? = json["message_id"]?.jsonPrimitive?.contentOrNull
     val result: JsonElement? = json["result"]
 
     /**

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -55,6 +55,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonPrimitive
 import org.koin.core.component.KoinComponent
@@ -746,7 +747,7 @@ class KtorServiceClient(
 
             if (response.getOrNull()?.json?.containsKey("error_code") == true) {
                 val errorMessage =
-                    response.getOrNull()?.json["error"]?.jsonPrimitive?.content
+                    response.getOrNull()?.json["error"]?.jsonPrimitive?.contentOrNull
                         ?: "Authentication failed"
                 clearCurrentServerToken()
                 setAuthFailed(errorMessage)
@@ -825,7 +826,7 @@ class KtorServiceClient(
             }
             if (response.getOrNull()?.json?.containsKey("error_code") == true) {
                 val errorMessage =
-                    response.getOrNull()?.json["error"]?.jsonPrimitive?.content
+                    response.getOrNull()?.json["error"]?.jsonPrimitive?.contentOrNull
                         ?: "Authentication failed"
                 clearCurrentServerToken()
                 setAuthFailed(errorMessage)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -543,7 +543,7 @@ class KtorServiceClient(
 
                         is TransportState.Failed -> {
                             _sessionState.update { SessionState.Disconnected.Error(transportState.error) }
-                            logger.i { "Transport→Failed → Disconnected.Error: ${transportState.error?.message}" }
+                            logger.i { "Transport→Failed → Disconnected.Error: ${transportState.error.message}" }
                         }
 
                         TransportState.Disconnected -> {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/RpcEngine.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/RpcEngine.kt
@@ -55,7 +55,7 @@ class RpcEngine(
      * an event or other message.
      */
     fun handleResponse(message: JsonObject): Boolean {
-        val messageId = message["message_id"]?.jsonPrimitive?.content ?: return false
+        val messageId = message["message_id"]?.jsonPrimitive?.contentOrNull ?: return false
         val isPartial = message["partial"]?.jsonPrimitive?.boolean == true
 
         if (isPartial) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/connection/SendspinWsHandler.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/connection/SendspinWsHandler.kt
@@ -123,10 +123,6 @@ class SendspinWsHandler(
                         is Frame.Ping, is Frame.Pong -> {
                             // Handled automatically by Ktor
                         }
-
-                        else -> {
-                            // Ignore other frame types
-                        }
                     }
                 }
             } catch (e: Exception) {
@@ -137,8 +133,7 @@ class SendspinWsHandler(
                 }
 
                 // Network error - auto-reconnect!
-                Logger.withTag("WebSocketHandler")
-                    .e { "❌ WS ERROR: ${e.message} - will auto-reconnect" }
+                logger.e(e) { "WS error - will auto-reconnect" }
                 _connectionState.value = WebSocketState.Reconnecting(reconnectAttempts)
 
                 attemptReconnect()

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/connection/SendspinWsHandler.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/connection/SendspinWsHandler.kt
@@ -97,6 +97,11 @@ class SendspinWsHandler(
         }
     }
 
+    // Ktor's Frame is `expect sealed`: the metadata compile can't prove the
+    // when below is exhaustive without an `else`, but the platform compiles
+    // resolve Frame to a concrete sealed and flag the `else` as redundant.
+    // Suppress that warning here so both compiles stay clean.
+    @Suppress("REDUNDANT_ELSE_IN_WHEN")
     private fun startListening(wsSession: DefaultClientWebSocketSession) {
         listenerJob?.cancel()
         listenerJob = launch {
@@ -123,6 +128,8 @@ class SendspinWsHandler(
                         is Frame.Ping, is Frame.Pong -> {
                             // Handled automatically by Ktor
                         }
+
+                        else -> Unit
                     }
                 }
             } catch (e: Exception) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/protocol/MessageDispatcher.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/protocol/MessageDispatcher.kt
@@ -134,8 +134,8 @@ class MessageDispatcher(
 
         try {
             val json = myJson.parseToJsonElement(text).jsonObject
-            val type = json["type"]?.jsonPrimitive?.content
-                ?: throw IllegalArgumentException("Message missing 'type' field")
+            val type = json["type"]?.jsonPrimitive?.contentOrNull
+                ?: throw IllegalArgumentException("Message missing or null 'type' field")
 
             when (type) {
                 "auth_ok" -> {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/auth/AuthenticationViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/auth/AuthenticationViewModel.kt
@@ -33,72 +33,46 @@ class AuthenticationViewModel(
     val password = MutableStateFlow("")
 
     init {
-        // Trigger initial load if already connected and awaiting auth
+        // sessionState is a StateFlow → emits its current value to the new collector
+        // immediately, so this single launch covers both initial-state handling and
+        // subsequent transitions.
         viewModelScope.launch {
-            val currentState = sessionState.value
-            if (currentState is SessionState.Connected) {
-                val dataConnectionState = currentState.dataConnectionState
-                if (dataConnectionState is DataConnectionState.AwaitingAuth) {
-                    // Only load providers if we're not in a failed state
-                    when (dataConnectionState.authProcessState) {
-                        is AuthProcessState.Failed -> {
-                            // Don't reload providers when auth failed
-                        }
-
-                        else -> {
-                            loadProviders()
-                        }
-                    }
-                }
-            }
-        }
-
-        // Auto-fetch providers when connected and awaiting auth
-        viewModelScope.launch {
-            sessionState.collect { state ->
-                Logger.d("AuthVM") { "SessionState changed: ${state::class.simpleName}" }
-                when (state) {
-                    is SessionState.Connected -> {
-                        val dataConnectionState = state.dataConnectionState
-                        Logger.d("AuthVM") { "DataConnectionState: ${dataConnectionState::class.simpleName}" }
-                        if (dataConnectionState is DataConnectionState.AwaitingAuth) {
-                            Logger.d("AuthVM") { "AwaitingAuth - checking auth process state" }
-                            // Only load providers if we're not in a failed state
-                            // (to avoid overriding error messages)
-                            when (dataConnectionState.authProcessState) {
-                                is AuthProcessState.Failed -> {
-                                    Logger.d("AuthVM") { "Auth failed - not reloading providers" }
-                                    // Don't reload providers when auth failed - keep the error visible
-                                }
-
-                                else -> {
-                                    Logger.d("AuthVM") { "Calling loadProviders()" }
-                                    loadProviders()
-                                }
-                            }
-                        }
-                    }
-
-                    is SessionState.Disconnected -> {
-                        // Clear providers when disconnected so next connection loads fresh
-                        // This ensures switching between WebRTC (builtin only) and Direct (all providers) works correctly
-                        Logger.d("AuthVM") { "Disconnected - clearing providers and cancelling pending load" }
-                        loadProvidersJob?.cancel()
-                        loadProvidersJob = null
-                        loadingForWebRTC = null
-                        _providers.update { emptyList() }
-                    }
-
-                    else -> {
-                        // Connecting, Reconnecting - do nothing
-                    }
-                }
-            }
+            sessionState.collect(::handleSessionState)
         }
     }
 
+    private fun handleSessionState(state: SessionState) {
+        log.d { "SessionState changed: ${state::class.simpleName}" }
+        when (state) {
+            is SessionState.Connected -> onConnected(state.dataConnectionState)
+            is SessionState.Disconnected -> onDisconnected()
+            else -> { /* Connecting, Reconnecting — no action */ }
+        }
+    }
+
+    private fun onConnected(dataConnectionState: DataConnectionState) {
+        log.d { "DataConnectionState: ${dataConnectionState::class.simpleName}" }
+        if (dataConnectionState !is DataConnectionState.AwaitingAuth) return
+        // Skip reload on Failed so we don't overwrite the displayed error.
+        if (dataConnectionState.authProcessState is AuthProcessState.Failed) {
+            log.d { "Auth failed - not reloading providers" }
+            return
+        }
+        log.d { "AwaitingAuth - loading providers" }
+        loadProviders()
+    }
+
+    private fun onDisconnected() {
+        // Clear providers so the next connection (WebRTC ↔ Direct) refetches.
+        log.d { "Disconnected - clearing providers and cancelling pending load" }
+        loadProvidersJob?.cancel()
+        loadProvidersJob = null
+        loadingForWebRTC = null
+        _providers.update { emptyList() }
+    }
+
     fun loadProviders() {
-        Logger.d("AuthVM") { "loadProviders() called, current providers count: ${_providers.value.size}" }
+        log.d { "loadProviders() called, current providers count: ${_providers.value.size}" }
 
         // Don't reload if we already have providers (to avoid overriding error states)
         if (_providers.value.isNotEmpty()) {
@@ -110,13 +84,13 @@ class AuthenticationViewModel(
 
         // If a job is running for the SAME connection type, skip (avoid redundant calls)
         if (loadProvidersJob?.isActive == true && loadingForWebRTC == isWebRTC) {
-            Logger.d("AuthVM") { "Provider loading already in progress for same connection type, skipping" }
+            log.d { "Provider loading already in progress for same connection type, skipping" }
             return
         }
 
         // Cancel if connection type changed (WebRTC ↔ Direct) - old result would be wrong
         if (loadProvidersJob?.isActive == true && loadingForWebRTC != isWebRTC) {
-            Logger.d("AuthVM") { "Connection type changed, cancelling previous load" }
+            log.d { "Connection type changed, cancelling previous load" }
             loadProvidersJob?.cancel()
             loadProvidersJob = null
         }
@@ -125,7 +99,7 @@ class AuthenticationViewModel(
 
         if (isWebRTC) {
             // For WebRTC, skip API call - only builtin auth works (OAuth requires HTTP redirects)
-            Logger.d("AuthVM") { "WebRTC connection - using builtin provider directly (skip API call)" }
+            log.d { "WebRTC connection - using builtin provider directly (skip API call)" }
             val builtinProvider = AuthProvider(
                 id = "builtin",
                 type = "builtin",
@@ -139,16 +113,16 @@ class AuthenticationViewModel(
         }
 
         // For direct connections, fetch all providers from server
-        Logger.d("AuthVM") { "Direct connection - fetching providers from server" }
+        log.d { "Direct connection - fetching providers from server" }
         loadProvidersJob = viewModelScope.launch {
             try {
                 authManager.getProviders()
                     .onSuccess { providerList ->
-                        Logger.d("AuthVM") { "Received ${providerList.size} providers: ${providerList.map { it.id }}" }
+                        log.d { "Received ${providerList.size} providers: ${providerList.map { it.id }}" }
                         _providers.update { providerList }
                     }
                     .onFailure { error ->
-                        Logger.e("AuthVM", error) { "Failed to load providers" }
+                        log.e(error) { "Failed to load providers" }
                     }
             } finally {
                 // Clear job reference when done (success or failure)
@@ -185,5 +159,9 @@ class AuthenticationViewModel(
             // AuthenticationManager handles both flag setting and token clearing
             authManager.logout()
         }
+    }
+
+    private companion object {
+        private val log = Logger.withTag("AuthVM")
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/auth/AuthenticationViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/auth/AuthenticationViewModel.kt
@@ -33,46 +33,72 @@ class AuthenticationViewModel(
     val password = MutableStateFlow("")
 
     init {
-        // sessionState is a StateFlow → emits its current value to the new collector
-        // immediately, so this single launch covers both initial-state handling and
-        // subsequent transitions.
+        // Trigger initial load if already connected and awaiting auth
         viewModelScope.launch {
-            sessionState.collect(::handleSessionState)
-        }
-    }
+            val currentState = sessionState.value
+            if (currentState is SessionState.Connected) {
+                val dataConnectionState = currentState.dataConnectionState
+                if (dataConnectionState is DataConnectionState.AwaitingAuth) {
+                    // Only load providers if we're not in a failed state
+                    when (dataConnectionState.authProcessState) {
+                        is AuthProcessState.Failed -> {
+                            // Don't reload providers when auth failed
+                        }
 
-    private fun handleSessionState(state: SessionState) {
-        log.d { "SessionState changed: ${state::class.simpleName}" }
-        when (state) {
-            is SessionState.Connected -> onConnected(state.dataConnectionState)
-            is SessionState.Disconnected -> onDisconnected()
-            else -> { /* Connecting, Reconnecting — no action */ }
+                        else -> {
+                            loadProviders()
+                        }
+                    }
+                }
+            }
         }
-    }
 
-    private fun onConnected(dataConnectionState: DataConnectionState) {
-        log.d { "DataConnectionState: ${dataConnectionState::class.simpleName}" }
-        if (dataConnectionState !is DataConnectionState.AwaitingAuth) return
-        // Skip reload on Failed so we don't overwrite the displayed error.
-        if (dataConnectionState.authProcessState is AuthProcessState.Failed) {
-            log.d { "Auth failed - not reloading providers" }
-            return
+        // Auto-fetch providers when connected and awaiting auth
+        viewModelScope.launch {
+            sessionState.collect { state ->
+                Logger.d("AuthVM") { "SessionState changed: ${state::class.simpleName}" }
+                when (state) {
+                    is SessionState.Connected -> {
+                        val dataConnectionState = state.dataConnectionState
+                        Logger.d("AuthVM") { "DataConnectionState: ${dataConnectionState::class.simpleName}" }
+                        if (dataConnectionState is DataConnectionState.AwaitingAuth) {
+                            Logger.d("AuthVM") { "AwaitingAuth - checking auth process state" }
+                            // Only load providers if we're not in a failed state
+                            // (to avoid overriding error messages)
+                            when (dataConnectionState.authProcessState) {
+                                is AuthProcessState.Failed -> {
+                                    Logger.d("AuthVM") { "Auth failed - not reloading providers" }
+                                    // Don't reload providers when auth failed - keep the error visible
+                                }
+
+                                else -> {
+                                    Logger.d("AuthVM") { "Calling loadProviders()" }
+                                    loadProviders()
+                                }
+                            }
+                        }
+                    }
+
+                    is SessionState.Disconnected -> {
+                        // Clear providers when disconnected so next connection loads fresh
+                        // This ensures switching between WebRTC (builtin only) and Direct (all providers) works correctly
+                        Logger.d("AuthVM") { "Disconnected - clearing providers and cancelling pending load" }
+                        loadProvidersJob?.cancel()
+                        loadProvidersJob = null
+                        loadingForWebRTC = null
+                        _providers.update { emptyList() }
+                    }
+
+                    else -> {
+                        // Connecting, Reconnecting - do nothing
+                    }
+                }
+            }
         }
-        log.d { "AwaitingAuth - loading providers" }
-        loadProviders()
-    }
-
-    private fun onDisconnected() {
-        // Clear providers so the next connection (WebRTC ↔ Direct) refetches.
-        log.d { "Disconnected - clearing providers and cancelling pending load" }
-        loadProvidersJob?.cancel()
-        loadProvidersJob = null
-        loadingForWebRTC = null
-        _providers.update { emptyList() }
     }
 
     fun loadProviders() {
-        log.d { "loadProviders() called, current providers count: ${_providers.value.size}" }
+        Logger.d("AuthVM") { "loadProviders() called, current providers count: ${_providers.value.size}" }
 
         // Don't reload if we already have providers (to avoid overriding error states)
         if (_providers.value.isNotEmpty()) {
@@ -84,13 +110,13 @@ class AuthenticationViewModel(
 
         // If a job is running for the SAME connection type, skip (avoid redundant calls)
         if (loadProvidersJob?.isActive == true && loadingForWebRTC == isWebRTC) {
-            log.d { "Provider loading already in progress for same connection type, skipping" }
+            Logger.d("AuthVM") { "Provider loading already in progress for same connection type, skipping" }
             return
         }
 
         // Cancel if connection type changed (WebRTC ↔ Direct) - old result would be wrong
         if (loadProvidersJob?.isActive == true && loadingForWebRTC != isWebRTC) {
-            log.d { "Connection type changed, cancelling previous load" }
+            Logger.d("AuthVM") { "Connection type changed, cancelling previous load" }
             loadProvidersJob?.cancel()
             loadProvidersJob = null
         }
@@ -99,7 +125,7 @@ class AuthenticationViewModel(
 
         if (isWebRTC) {
             // For WebRTC, skip API call - only builtin auth works (OAuth requires HTTP redirects)
-            log.d { "WebRTC connection - using builtin provider directly (skip API call)" }
+            Logger.d("AuthVM") { "WebRTC connection - using builtin provider directly (skip API call)" }
             val builtinProvider = AuthProvider(
                 id = "builtin",
                 type = "builtin",
@@ -113,16 +139,16 @@ class AuthenticationViewModel(
         }
 
         // For direct connections, fetch all providers from server
-        log.d { "Direct connection - fetching providers from server" }
+        Logger.d("AuthVM") { "Direct connection - fetching providers from server" }
         loadProvidersJob = viewModelScope.launch {
             try {
                 authManager.getProviders()
                     .onSuccess { providerList ->
-                        log.d { "Received ${providerList.size} providers: ${providerList.map { it.id }}" }
+                        Logger.d("AuthVM") { "Received ${providerList.size} providers: ${providerList.map { it.id }}" }
                         _providers.update { providerList }
                     }
                     .onFailure { error ->
-                        log.e(error) { "Failed to load providers" }
+                        Logger.e("AuthVM", error) { "Failed to load providers" }
                     }
             } finally {
                 // Clear job reference when done (success or failure)
@@ -159,9 +185,5 @@ class AuthenticationViewModel(
             // AuthenticationManager handles both flag setting and token clearing
             authManager.logout()
         }
-    }
-
-    private companion object {
-        private val log = Logger.withTag("AuthVM")
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/DataState.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/DataState.kt
@@ -20,3 +20,19 @@ enum class StaleReason {
     RECONNECTING,          // Auto-reconnect in progress (transient)
     PERSISTENT_ERROR,      // Max attempts exhausted (manual action needed)
 }
+
+/**
+ * Returns the payload for the two payload-carrying states ([DataState.Data], [DataState.Stale])
+ * and `null` for [DataState.Loading], [DataState.Error], [DataState.NoData].
+ *
+ * Use this to avoid duplicating the `is Data → data; is Stale → data` disambiguation at call sites.
+ */
+val <T> DataState<T>.dataOrNull: T?
+    get() = when (this) {
+        is DataState.Data -> data
+        is DataState.Stale -> data
+        is DataState.Loading,
+        is DataState.Error,
+        is DataState.NoData,
+            -> null
+    }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/CollapsibleQueue.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/CollapsibleQueue.kt
@@ -61,6 +61,7 @@ import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.data.model.client.items.image
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.action.QueueAction
+import io.music_assistant.client.ui.compose.common.dataOrNull
 import io.music_assistant.client.ui.compose.common.icons.PlayIcon
 import io.music_assistant.client.ui.compose.common.icons.TrackIcon
 import io.music_assistant.client.ui.compose.common.items.AddToPlaylistDialog
@@ -207,17 +208,8 @@ fun Queue(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         } ?: run {
-            // Handle both Data and Stale states - both contain valid queue data
-            val queueData = when (queue) {
-                is DataState.Data -> queue.data
-                is DataState.Stale -> queue.data
-                else -> return@run
-            }
-            val items = when (val itemsState = queueData.items) {
-                is DataState.Data -> itemsState.data
-                is DataState.Stale -> itemsState.data
-                else -> return@run
-            }
+            val queueData = queue.dataOrNull ?: return@run
+            val items = queueData.items.dataOrNull ?: return@run
 
             if (items.isEmpty()) {
                 Column(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemListScreen.kt
@@ -67,6 +67,7 @@ import io.music_assistant.client.ui.compose.common.SortChip
 import io.music_assistant.client.ui.compose.common.ToastHost
 import io.music_assistant.client.ui.compose.common.ToastState
 import io.music_assistant.client.ui.compose.common.clearFocusOnScroll
+import io.music_assistant.client.ui.compose.common.dataOrNull
 import io.music_assistant.client.ui.compose.common.items.LibraryActions
 import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import io.music_assistant.client.ui.compose.common.items.ProgressActions
@@ -346,12 +347,7 @@ private fun ItemList(
                     is DataState.Stale,
                     is DataState.Data,
                         -> {
-                        // Handle both Data and Stale - both contain valid library data
-                        val items = when (dataState) {
-                            is DataState.Data -> dataState.data
-                            is DataState.Stale -> dataState.data
-                            else -> emptyList()
-                        }
+                        val items = dataState.dataOrNull.orEmpty()
                         if (items.isEmpty()) {
                             EmptyState()
                         } else {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/WindowClass.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/WindowClass.kt
@@ -1,34 +1,26 @@
 package io.music_assistant.client.utils
 
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
 import androidx.window.core.layout.WindowSizeClass
 
 object WindowClass {
     @Composable
-    fun isAtLeastExpanded(): Boolean {
-        val windowSizeClass =
-            currentWindowAdaptiveInfo(supportLargeAndXLargeWidth = true).windowSizeClass
-        return windowSizeClass
-            .isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND)
-    }
+    fun isAtLeastExpanded(): Boolean =
+        isAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND)
 
     @Composable
-    fun isAtLeastLarge(): Boolean {
-        val windowSizeClass =
-            currentWindowAdaptiveInfo(supportLargeAndXLargeWidth = true).windowSizeClass
-        return windowSizeClass
-            .isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_LARGE_LOWER_BOUND)
-    }
+    fun isAtLeastLarge(): Boolean =
+        isAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_LARGE_LOWER_BOUND)
 
     @Composable
-    fun isAtLeastMedium(): Boolean {
-        val windowSizeClass =
-            currentWindowAdaptiveInfo(supportLargeAndXLargeWidth = true).windowSizeClass
-        return windowSizeClass
-            .isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND)
-    }
+    fun isAtLeastMedium(): Boolean =
+        isAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND)
+
+    @Composable
+    private fun isAtLeastBreakpoint(widthDp: Int): Boolean =
+        currentWindowAdaptiveInfoV2().windowSizeClass.isWidthAtLeastBreakpoint(widthDp)
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/webrtc/SignalingMessageSerializer.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/webrtc/SignalingMessageSerializer.kt
@@ -5,6 +5,7 @@ import io.music_assistant.client.webrtc.model.SignalingMessage
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.json.JsonContentPolymorphicSerializer
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
@@ -15,15 +16,18 @@ import kotlinx.serialization.json.jsonPrimitive
  * This is required because the signaling protocol uses a "type" discriminator field
  * rather than kotlinx.serialization's default class discriminator.
  *
- * Forward compatible: Unknown message types are deserialized as Unknown instead of crashing.
+ * Forward compatible: unrecognized `type` values are deserialized as [SignalingMessage.Unknown]
+ * instead of crashing, so a server that introduces new message types stays decodable.
+ * Missing or null `type` is a protocol violation (Unknown itself requires a non-null type)
+ * and throws — the caller in SignalingClient catches and logs it per-message.
  */
 object SignalingMessageSerializer :
     JsonContentPolymorphicSerializer<SignalingMessage>(SignalingMessage::class) {
     private val logger = Logger.withTag("SignalingMessageSerializer")
 
     override fun selectDeserializer(element: JsonElement): DeserializationStrategy<SignalingMessage> {
-        val type = element.jsonObject["type"]?.jsonPrimitive?.content
-            ?: throw IllegalArgumentException("Missing 'type' field in signaling message")
+        val type = element.jsonObject["type"]?.jsonPrimitive?.contentOrNull
+            ?: throw IllegalArgumentException("Signaling message missing or null 'type' field")
 
         return when (type) {
             "connect-request" -> SignalingMessage.ConnectRequest.serializer()

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/webrtc/model/SignalingMessage.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/webrtc/model/SignalingMessage.kt
@@ -11,7 +11,7 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 
 /**
  * Messages exchanged with the WebRTC signaling server.
@@ -162,13 +162,14 @@ sealed interface SignalingMessage {
  * The public signaling server sends a single string, while Nabu Casa sends an array.
  */
 private object FlexibleUrlListSerializer : KSerializer<List<String>> {
+    @OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
     override val descriptor: SerialDescriptor = listSerialDescriptor(serialDescriptor<String>())
 
     override fun deserialize(decoder: Decoder): List<String> {
         val jsonDecoder = decoder as JsonDecoder
         return when (val element = jsonDecoder.decodeJsonElement()) {
-            is JsonArray -> element.map { it.jsonPrimitive.content }
-            is JsonPrimitive -> listOf(element.content)
+            is JsonArray -> element.mapNotNull { (it as? JsonPrimitive)?.contentOrNull }
+            is JsonPrimitive -> listOfNotNull(element.contentOrNull)
             else -> emptyList()
         }
     }

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/MainViewController.kt
@@ -1,4 +1,4 @@
-@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class, kotlinx.cinterop.BetaInteropApi::class)
 
 package io.music_assistant.client
 

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
@@ -5,7 +5,7 @@ package io.music_assistant.client.di
 import co.touchlab.kermit.Logger
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
-import io.ktor.client.statement.readBytes
+import io.ktor.client.statement.readRawBytes
 import io.ktor.http.Url
 import io.music_assistant.client.api.Request
 import io.music_assistant.client.api.ServiceClient
@@ -123,7 +123,7 @@ object KmpHelper : KoinComponent {
         }
         urlString.startsWith("http://") || urlString.startsWith("https://") -> {
             val response = artworkHttpClient.get(urlString)
-            response.readBytes().takeIf { response.status.value in 200..299 }
+            response.readRawBytes().takeIf { response.status.value in 200..299 }
         }
         else -> null
     }

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/logging/LogSharer.ios.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/logging/LogSharer.ios.kt
@@ -1,5 +1,4 @@
-@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
-@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class, kotlinx.cinterop.BetaInteropApi::class)
 
 package io.music_assistant.client.logging
 
@@ -31,12 +30,15 @@ actual class LogSharer actual constructor(@Suppress("UNUSED_PARAMETER") platform
 
     actual fun shareCrashLog(@Suppress("UNUSED_PARAMETER") chooserTitle: String) {
         val path = crashLogFilePath()
-        if (NSFileManager.defaultManager.fileExistsAtPath(path)) {
-            val sanitizedPath = "${NSTemporaryDirectory()}ma_crash_log_share.txt"
-            val rawText = NSString.create(contentsOfFile = path, encoding = NSUTF8StringEncoding, error = null) as? String ?: return
-            writeTextToFile(LogSanitizer.sanitize(rawText), sanitizedPath)
-            shareFile(sanitizedPath)
-        }
+        if (!NSFileManager.defaultManager.fileExistsAtPath(path)) return
+        val rawText = NSString.create(
+            contentsOfFile = path,
+            encoding = NSUTF8StringEncoding,
+            error = null,
+        )?.toString() ?: return
+        val sanitizedPath = "${NSTemporaryDirectory()}ma_crash_log_share.txt"
+        writeTextToFile(LogSanitizer.sanitize(rawText), sanitizedPath)
+        shareFile(sanitizedPath)
     }
 
     actual fun deleteCrashLog() {


### PR DESCRIPTION
I finally had the time / bandwidth to dig through and figure out what all of the warnings during compilation were. Was able to fix most of them. Some of this isn't technically 'just' fixing compilation warnings, but came as a result of looking at the code that was generating the warning(s) and figuring out different approaches (that also happen to compile cleanly). Basically, trying to leave the codebase better than I found it. There shouldn't be any actual functional changes here, just cleanups.

Commit message:

Warnings: 33 → 2 (the remaining two are unfixable upstream — Compose Multiplatform's ObjC export of PathSegment.Type and the smallBinary debug-build info message). Detekt and Xcode build are clean.

Build / opt-ins / API renames
- composeApp build.gradle.kts: add '-Xexpect-actual-classes' to silence the 8 KT-61573 Beta warnings globally.
- KmpHelper.ios.kt: Ktor readBytes() → readRawBytes() (renamed API).
- SignalingMessage.kt: @OptIn(ExperimentalSerializationApi) on the list descriptor.
- MainViewController.kt, LogSharer.ios.kt: add BetaInteropApi to the file-level @OptIn (covers NSString.create cinterop calls).
- LogSharer.ios.kt: drop now-redundant @file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_…") (compiler flag covers it); fix impossible 'as? String' cast — go through NSString.toString().
- KtorServiceClient.kt: drop unnecessary '?.' on non-null TransportState.Failed.error.
- SendspinWsHandler.kt, ItemListScreen.kt: remove redundant 'else' branches from two exhaustive 'when's.

Architectural cleanups
- AuthenticationViewModel: hoist Logger.withTag('AuthVM') into a private companion object (one Logger per class, not per VM instance); collapse duplicate init block (StateFlow's initial replay covers it); extract handleSessionState/onConnected/onDisconnected helpers. The init goes from ~60 lines of nested branches to a single collect(::handleSessionState).
- SendspinWsHandler: the inline Logger.withTag('WebSocketHandler') on network errors was creating a per-call Logger AND using a wrong tag AND dropping the throwable. Consolidated onto the file-level logger and pass the exception.
- WindowClass: DRY the three isAtLeast* Composables behind a private isAtLeastBreakpoint(widthDp) helper; migrate to currentWindowAdaptiveInfoV2().
- DataState.kt: new 'val <T> DataState<T>.dataOrNull: T?' extension that returns the payload for Data/Stale, null for Loading/Error/NoData — eliminates the duplicated 'is Data → data; is Stale → data' pattern scattered across the UI. Apply it in ItemListScreen (List type → '.orEmpty()') and CollapsibleQueue ('?: return@run' replaces the inner disambiguating whens).
- FlexibleUrlListSerializer (SignalingMessage.kt): use 'contentOrNull'
  + 'mapNotNull { (it as? JsonPrimitive)?.contentOrNull }' so a null or non-string element in the signaling payload no longer hard-throws.
- LogSharer.shareCrashLog: invert the file-exists guard to early return for shallower indentation; format the NSString.create call across lines for readability.