### PR TITLE
refactor(auth): rewrite AuthenticationViewModel as a flatMapLatest pipeline

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -132,6 +132,9 @@ kotlin {
 
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.turbine)
+            implementation(libs.settings.multiplatform.test)
         }
 
         iosMain.dependencies {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/auth/AuthCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/auth/AuthCoordinator.kt
@@ -1,0 +1,23 @@
+package io.music_assistant.client.auth
+
+import io.music_assistant.client.data.model.server.AuthProvider
+import kotlinx.coroutines.flow.StateFlow
+
+/** Surface of [AuthenticationManager] consumed by UI viewmodels. */
+interface AuthCoordinator {
+    val authState: StateFlow<AuthState>
+
+    suspend fun getProviders(): Result<List<AuthProvider>>
+
+    suspend fun loginWithCredentials(
+        providerId: String,
+        username: String,
+        password: String,
+    ): Result<Unit>
+
+    suspend fun getOAuthUrl(providerId: String, returnUrl: String): Result<String>
+
+    fun startOAuthFlow(oauthUrl: String): Result<Unit>
+
+    suspend fun logout(): Result<Unit>
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/auth/AuthenticationManager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/auth/AuthenticationManager.kt
@@ -13,6 +13,7 @@ import io.music_assistant.client.utils.DataConnectionState
 import io.music_assistant.client.utils.SessionState
 import io.music_assistant.client.utils.mainDispatcher
 import io.music_assistant.client.utils.resultAs
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
@@ -36,11 +37,11 @@ private val log = Logger.withTag("AuthMgr")
 class AuthenticationManager(
     private val serviceClient: ServiceClient,
     private val settings: SettingsRepository,
-) {
+) : AuthCoordinator {
     private val scope = CoroutineScope(SupervisorJob() + mainDispatcher)
 
     private val _authState = MutableStateFlow<AuthState>(AuthState.Idle)
-    val authState: StateFlow<AuthState> = _authState.asStateFlow()
+    override val authState: StateFlow<AuthState> = _authState.asStateFlow()
 
     // OAuthHandler will be set by platform (e.g., MainActivity on Android)
     var oauthHandler: OAuthHandler? = null
@@ -139,7 +140,7 @@ class AuthenticationManager(
         }
     }
 
-    suspend fun getProviders(): Result<List<AuthProvider>> {
+    override suspend fun getProviders(): Result<List<AuthProvider>> {
         return try {
             _authState.value = AuthState.Loading
             val response = serviceClient.sendRequest(Request.Auth.providers())
@@ -158,6 +159,12 @@ class AuthenticationManager(
                 _authState.value = AuthState.Error(error)
                 Result.failure(Exception(error))
             }
+        } catch (e: CancellationException) {
+            // Coroutine cancellation (e.g. AuthenticationViewModel's flatMapLatest
+            // switching loads on a session-state change) must propagate, not be
+            // swallowed by the broad catch below — otherwise it would spuriously
+            // drive authState to Error on every disconnect/connection-type switch.
+            throw e
         } catch (e: Exception) {
             val error = e.message ?: "Exception fetching providers"
             _authState.value = AuthState.Error(error)
@@ -166,7 +173,7 @@ class AuthenticationManager(
     }
 
     @Suppress("UnusedParameter") // providerId reserved — current server login API doesn't yet route per-provider
-    suspend fun loginWithCredentials(
+    override suspend fun loginWithCredentials(
         providerId: String,
         username: String,
         password: String,
@@ -176,6 +183,8 @@ class AuthenticationManager(
             _authState.value = AuthState.Loading
             serviceClient.login(username, password)
             Result.success(Unit)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             val error = e.message ?: "Login failed"
             _authState.value = AuthState.Error(error)
@@ -183,7 +192,7 @@ class AuthenticationManager(
         }
     }
 
-    suspend fun getOAuthUrl(providerId: String, returnUrl: String): Result<String> {
+    override suspend fun getOAuthUrl(providerId: String, returnUrl: String): Result<String> {
         return try {
             val response = serviceClient.sendRequest(
                 Request.Auth.authorizationUrl(providerId, returnUrl),
@@ -196,12 +205,14 @@ class AuthenticationManager(
             response.resultAs<OauthUrl>()?.let { oauthUrl ->
                 Result.success(oauthUrl.url)
             } ?: Result.failure(Exception("Failed to parse OAuth URL"))
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
     }
 
-    fun startOAuthFlow(oauthUrl: String): Result<Unit> {
+    override fun startOAuthFlow(oauthUrl: String): Result<Unit> {
         val handler = oauthHandler
         if (handler == null) {
             val error = "OAuth not supported on this platform"
@@ -243,6 +254,8 @@ class AuthenticationManager(
             }
             try {
                 serviceClient.authorize(token, isAutoLogin = false)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Logger.e(e) { "Authorization failed" }
                 _authState.value = AuthState.Error(e.message ?: "Authorization failed")
@@ -253,12 +266,14 @@ class AuthenticationManager(
     private suspend fun authorizeWithSavedToken(token: String) {
         try {
             serviceClient.authorize(token, isAutoLogin = true)
+        } catch (e: CancellationException) {
+            throw e
         } catch (_: Exception) {
             // Silent failure - user will see auth UI
         }
     }
 
-    suspend fun logout(): Result<Unit> {
+    override suspend fun logout(): Result<Unit> {
         return try {
             // Set flag FIRST, before any async operations
             _isLoggingOut.value = true

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/di/SharedModule.kt
@@ -3,6 +3,7 @@ package io.music_assistant.client.di
 import io.music_assistant.client.api.ErrorMessageBus
 import io.music_assistant.client.api.KtorServiceClient
 import io.music_assistant.client.api.ServiceClient
+import io.music_assistant.client.auth.AuthCoordinator
 import io.music_assistant.client.auth.AuthenticationManager
 import io.music_assistant.client.data.LocalPlayerRepository
 import io.music_assistant.client.data.MainDataSource
@@ -50,6 +51,8 @@ fun sharedModule(
                 get(),
             )
         }  // Eager - needs to start monitoring immediately
+        // Expose the AuthCoordinator surface for viewmodels; same singleton instance.
+        single<AuthCoordinator> { get<AuthenticationManager>() }
         singleOf(::MediaPlayerController)  // Used by MainDataSource for Sendspin
         singleOf(::SendspinClientFactory)   // Factory for creating Sendspin clients
         singleOf(::LocalPlayerRepository)   // Optimistic local player state
@@ -62,7 +65,12 @@ fun sharedModule(
         viewModelOf(::ThemeViewModel)
         factory { ActionsViewModel(get(), get(), get()) }
         factory { SettingsViewModel(get(), get(), get()) }
-        factory { AuthenticationViewModel(get(), get()) }
+        factory {
+            AuthenticationViewModel(
+                auth = get(),
+                sessionStateFlow = get<ServiceClient>().sessionState,
+            )
+        }
         factory { LibraryCategoriesViewModel(get()) }
         factory { params -> ItemListViewModel(params[0], get(), get(), get(), get()) }
         factory { params ->

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/auth/AuthenticationViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/auth/AuthenticationViewModel.kt
@@ -3,187 +3,117 @@ package io.music_assistant.client.ui.compose.auth
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
-import io.music_assistant.client.api.ServiceClient
-import io.music_assistant.client.auth.AuthenticationManager
+import io.music_assistant.client.auth.AuthCoordinator
 import io.music_assistant.client.data.model.server.AuthProvider
 import io.music_assistant.client.utils.AuthProcessState
 import io.music_assistant.client.utils.DataConnectionState
 import io.music_assistant.client.utils.SessionState
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
+/** Drives the authentication UI. */
+@OptIn(ExperimentalCoroutinesApi::class)
 class AuthenticationViewModel(
-    private val authManager: AuthenticationManager,
-    serviceClient: ServiceClient,
+    private val auth: AuthCoordinator,
+    sessionStateFlow: StateFlow<SessionState>,
 ) : ViewModel() {
-    private val _providers = MutableStateFlow<List<AuthProvider>>(emptyList())
-    val providers: StateFlow<List<AuthProvider>> = _providers.asStateFlow()
-
-    private var loadProvidersJob: Job? = null
-    private var loadingForWebRTC: Boolean? = null
-
-    val authState = authManager.authState
-    val sessionState = serviceClient.sessionState
+    val authState = auth.authState
 
     val username = MutableStateFlow("")
     val password = MutableStateFlow("")
 
-    init {
-        // Trigger initial load if already connected and awaiting auth
-        viewModelScope.launch {
-            val currentState = sessionState.value
-            if (currentState is SessionState.Connected) {
-                val dataConnectionState = currentState.dataConnectionState
-                if (dataConnectionState is DataConnectionState.AwaitingAuth) {
-                    // Only load providers if we're not in a failed state
-                    when (dataConnectionState.authProcessState) {
-                        is AuthProcessState.Failed -> {
-                            // Don't reload providers when auth failed
-                        }
+    // Capacity = 1 so the UI's Retry tap always lands even if the upstream
+    // is mid-emission. We don't replay — late subscribers don't get stale retries.
+    private val retryTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
-                        else -> {
-                            loadProviders()
-                        }
-                    }
-                }
-            }
-        }
+    val providers: StateFlow<List<AuthProvider>> = merge(
+        sessionStateFlow.map(::autoSource).filterNotNull().distinctUntilChanged(),
+        retryTrigger.mapNotNull { retrySource(sessionStateFlow.value) },
+    )
+        .flatMapLatest(::loadFlow)
+        .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
-        // Auto-fetch providers when connected and awaiting auth
-        viewModelScope.launch {
-            sessionState.collect { state ->
-                Logger.d("AuthVM") { "SessionState changed: ${state::class.simpleName}" }
-                when (state) {
-                    is SessionState.Connected -> {
-                        val dataConnectionState = state.dataConnectionState
-                        Logger.d("AuthVM") { "DataConnectionState: ${dataConnectionState::class.simpleName}" }
-                        if (dataConnectionState is DataConnectionState.AwaitingAuth) {
-                            Logger.d("AuthVM") { "AwaitingAuth - checking auth process state" }
-                            // Only load providers if we're not in a failed state
-                            // (to avoid overriding error messages)
-                            when (dataConnectionState.authProcessState) {
-                                is AuthProcessState.Failed -> {
-                                    Logger.d("AuthVM") { "Auth failed - not reloading providers" }
-                                    // Don't reload providers when auth failed - keep the error visible
-                                }
-
-                                else -> {
-                                    Logger.d("AuthVM") { "Calling loadProviders()" }
-                                    loadProviders()
-                                }
-                            }
-                        }
-                    }
-
-                    is SessionState.Disconnected -> {
-                        // Clear providers when disconnected so next connection loads fresh
-                        // This ensures switching between WebRTC (builtin only) and Direct (all providers) works correctly
-                        Logger.d("AuthVM") { "Disconnected - clearing providers and cancelling pending load" }
-                        loadProvidersJob?.cancel()
-                        loadProvidersJob = null
-                        loadingForWebRTC = null
-                        _providers.update { emptyList() }
-                    }
-
-                    else -> {
-                        // Connecting, Reconnecting - do nothing
-                    }
-                }
-            }
-        }
-    }
-
+    /** Forces a fresh providers load. Used by the Retry button after a failed initial fetch. */
     fun loadProviders() {
-        Logger.d("AuthVM") { "loadProviders() called, current providers count: ${_providers.value.size}" }
-
-        // Don't reload if we already have providers (to avoid overriding error states)
-        if (_providers.value.isNotEmpty()) {
-            return
-        }
-
-        val currentState = sessionState.value
-        val isWebRTC = currentState is SessionState.Connected.WebRTC
-
-        // If a job is running for the SAME connection type, skip (avoid redundant calls)
-        if (loadProvidersJob?.isActive == true && loadingForWebRTC == isWebRTC) {
-            Logger.d("AuthVM") { "Provider loading already in progress for same connection type, skipping" }
-            return
-        }
-
-        // Cancel if connection type changed (WebRTC ↔ Direct) - old result would be wrong
-        if (loadProvidersJob?.isActive == true && loadingForWebRTC != isWebRTC) {
-            Logger.d("AuthVM") { "Connection type changed, cancelling previous load" }
-            loadProvidersJob?.cancel()
-            loadProvidersJob = null
-        }
-
-        loadingForWebRTC = isWebRTC
-
-        if (isWebRTC) {
-            // For WebRTC, skip API call - only builtin auth works (OAuth requires HTTP redirects)
-            Logger.d("AuthVM") { "WebRTC connection - using builtin provider directly (skip API call)" }
-            val builtinProvider = AuthProvider(
-                id = "builtin",
-                type = "builtin",
-                requiresRedirect = false,
-            )
-            _providers.update { listOf(builtinProvider) }
-            // Clear job reference since we're done (synchronous)
-            loadProvidersJob = null
-            loadingForWebRTC = null
-            return
-        }
-
-        // For direct connections, fetch all providers from server
-        Logger.d("AuthVM") { "Direct connection - fetching providers from server" }
-        loadProvidersJob = viewModelScope.launch {
-            try {
-                authManager.getProviders()
-                    .onSuccess { providerList ->
-                        Logger.d("AuthVM") { "Received ${providerList.size} providers: ${providerList.map { it.id }}" }
-                        _providers.update { providerList }
-                    }
-                    .onFailure { error ->
-                        Logger.e("AuthVM", error) { "Failed to load providers" }
-                    }
-            } finally {
-                // Clear job reference when done (success or failure)
-                loadProvidersJob = null
-                loadingForWebRTC = null
-            }
-        }
+        retryTrigger.tryEmit(Unit)
     }
 
     fun login(provider: AuthProvider) {
         viewModelScope.launch {
             when (provider.type) {
-                "builtin" -> {
-                    authManager.loginWithCredentials(
-                        provider.id,
-                        username.value,
-                        password.value,
-                    )
-                }
-
-                else -> {
-                    // OAuth or other redirect-based auth
-                    // Use custom URL scheme for reliable deep linking
-                    val returnUrl = "musicassistant://auth/callback"
-                    authManager.getOAuthUrl(provider.id, returnUrl)
-                        .onSuccess { url -> authManager.startOAuthFlow(url) }
-                }
+                "builtin" -> auth.loginWithCredentials(provider.id, username.value, password.value)
+                else -> auth.getOAuthUrl(provider.id, OAUTH_RETURN_URL)
+                    .onSuccess { url -> auth.startOAuthFlow(url) }
             }
         }
     }
 
     fun logout() {
-        viewModelScope.launch {
-            // AuthenticationManager handles both flag setting and token clearing
-            authManager.logout()
+        viewModelScope.launch { auth.logout() }
+    }
+
+    /**
+     * Projection for the auto path. Returns null to mean "keep the previous
+     * emission" — used for transitional states (Connecting/Reconnecting) and
+     * for AwaitingAuth(Failed) where we want to preserve the displayed error
+     * rather than blow the provider list away.
+     */
+    private fun autoSource(state: SessionState): ProvidersSource? = when (state) {
+        is SessionState.Disconnected -> ProvidersSource.Empty
+        is SessionState.Connected -> when (val dcs = state.dataConnectionState) {
+            !is DataConnectionState.AwaitingAuth -> null
+            else -> when {
+                dcs.authProcessState is AuthProcessState.Failed -> null
+                state is SessionState.Connected.WebRTC -> ProvidersSource.Builtin
+                else -> ProvidersSource.FromApi
+            }
         }
+        else -> null
+    }
+
+    /**
+     * Projection for the retry path. Identical to [autoSource] except it
+     * bypasses the Failed-auth guard — Retry is an explicit user signal that
+     * we should try again even when the auto-path would have suppressed.
+     */
+    private fun retrySource(state: SessionState): ProvidersSource? = when (state) {
+        is SessionState.Connected.WebRTC -> ProvidersSource.Builtin
+        is SessionState.Connected -> ProvidersSource.FromApi
+        else -> null
+    }
+
+    private fun loadFlow(source: ProvidersSource) = when (source) {
+        ProvidersSource.Empty -> flowOf(emptyList())
+        ProvidersSource.Builtin -> flowOf(listOf(BUILTIN_PROVIDER))
+        ProvidersSource.FromApi -> flow {
+            auth.getProviders()
+                .onSuccess { emit(it) }
+                .onFailure { log.e(it) { "Failed to load providers" } }
+        }
+    }
+
+    private enum class ProvidersSource { Empty, Builtin, FromApi }
+
+    private companion object {
+        private val log = Logger.withTag("AuthVM")
+        private const val OAUTH_RETURN_URL = "musicassistant://auth/callback"
+        private val BUILTIN_PROVIDER = AuthProvider(
+            id = "builtin",
+            type = "builtin",
+            requiresRedirect = false,
+        )
     }
 }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/auth/AuthenticationManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/auth/AuthenticationManagerTest.kt
@@ -1,0 +1,161 @@
+package io.music_assistant.client.auth
+
+import com.russhwolf.settings.MapSettings
+import io.music_assistant.client.api.Answer
+import io.music_assistant.client.api.ConnectionInfo
+import io.music_assistant.client.api.Request
+import io.music_assistant.client.api.ServiceClient
+import io.music_assistant.client.data.model.server.events.Event
+import io.music_assistant.client.settings.SettingsRepository
+import io.music_assistant.client.utils.SessionState
+import io.music_assistant.client.webrtc.DataChannelWrapper
+import io.music_assistant.client.webrtc.WebRTCHttpProxy
+import io.music_assistant.client.webrtc.model.RemoteId
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Guards the cancellation contract that [io.music_assistant.client.ui.compose.auth.AuthenticationViewModel]
+ * depends on. The viewmodel loads providers inside a `flatMapLatest`, so a
+ * session-state change (disconnect, Direct↔WebRTC switch) cancels the
+ * in-flight [AuthenticationManager.getProviders] coroutine as a matter of
+ * routine. Because `CancellationException` is an [Exception], the manager's
+ * broad `catch (e: Exception)` blocks would otherwise swallow it — surfacing a
+ * spurious [AuthState.Error] (getProviders, login) or an absorbed failure
+ * Result (getOAuthUrl) instead of letting the coroutine cancel. Each cancellable
+ * suspend entry point is verified here.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AuthenticationManagerTest {
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `getProviders rethrows cancellation instead of driving authState to Error`() = runTest {
+        val client = FakeServiceClient()
+        val manager = AuthenticationManager(client, SettingsRepository(MapSettings()))
+        try {
+            val job = launch { manager.getProviders() }
+            runCurrent() // getProviders sets Loading, then suspends inside sendRequest
+
+            assertEquals(
+                AuthState.Loading,
+                manager.authState.value,
+                "Precondition: an in-flight getProviders() shows Loading",
+            )
+
+            job.cancel()
+            runCurrent() // deliver the cancellation into the suspended sendRequest
+
+            assertTrue(
+                manager.authState.value !is AuthState.Error,
+                "Cancelling an in-flight getProviders() must not be swallowed into a " +
+                    "spurious AuthState.Error",
+            )
+            assertTrue(job.isCancelled, "The cancellation must propagate, not be absorbed")
+        } finally {
+            manager.close()
+        }
+    }
+
+    @Test
+    fun `loginWithCredentials rethrows cancellation instead of driving authState to Error`() = runTest {
+        val client = FakeServiceClient()
+        val manager = AuthenticationManager(client, SettingsRepository(MapSettings()))
+        try {
+            val job = launch { manager.loginWithCredentials("builtin", "user", "pass") }
+            runCurrent() // login sets Loading, then suspends inside serviceClient.login
+
+            job.cancel()
+            runCurrent()
+
+            assertTrue(
+                manager.authState.value !is AuthState.Error,
+                "Cancelling an in-flight login must not be swallowed into a spurious AuthState.Error",
+            )
+            assertTrue(job.isCancelled, "The cancellation must propagate, not be absorbed")
+        } finally {
+            manager.close()
+        }
+    }
+
+    @Test
+    fun `getOAuthUrl rethrows cancellation instead of completing with a failure result`() = runTest {
+        val client = FakeServiceClient()
+        val manager = AuthenticationManager(client, SettingsRepository(MapSettings()))
+        try {
+            // getOAuthUrl never touches authState, and job.isCancelled is true whether
+            // or not the body swallows the cancellation — so the discriminator is the
+            // return value: a propagated cancellation yields no Result at all, while a
+            // swallowed one is absorbed into Result.failure and assigned here.
+            var result: Result<String>? = null
+            val job = launch { result = manager.getOAuthUrl("spotify", "musicassistant://auth/callback") }
+            runCurrent() // suspends inside serviceClient.sendRequest
+
+            job.cancel()
+            runCurrent()
+
+            assertNull(
+                result,
+                "Cancellation must propagate; getOAuthUrl must not absorb it into a failure Result",
+            )
+        } finally {
+            manager.close()
+        }
+    }
+}
+
+/**
+ * Minimal [ServiceClient] for manager tests. [sendRequest] parks via
+ * [awaitCancellation] so a caller can be cancelled mid-request; the session
+ * stays Disconnected so the manager's init monitor does nothing.
+ */
+private class FakeServiceClient : ServiceClient {
+    override val sessionState = MutableStateFlow<SessionState>(SessionState.Disconnected.Initial)
+    override val isReadyForCommands = MutableStateFlow(false)
+    override val serverBaseUrl = MutableStateFlow<String?>(null)
+    override val webRTCHttpProxy: WebRTCHttpProxy? = null
+    override val events: Flow<Event<out Any>> = emptyFlow()
+    override val webrtcSendspinChannel: DataChannelWrapper? = null
+    override val foregroundEvents: Flow<Unit> = emptyFlow()
+
+    override suspend fun sendRequest(request: Request): Result<Answer> = awaitCancellation()
+    override suspend fun login(username: String, password: String): Unit = awaitCancellation()
+    override suspend fun authorize(token: String, isAutoLogin: Boolean) = Unit
+    override fun logout() = Unit
+    override fun resolveImageUrl(path: String, provider: String, isRemotelyAccessible: Boolean): String? = null
+    override fun rebaseServerImageUrl(rawUrl: String): String? = null
+    override fun forceWebRTCReconnect() = Unit
+    override fun onAppForeground() = Unit
+    override fun onAppBackground() = Unit
+    override fun disconnectByUser() = Unit
+    override fun connect(connection: ConnectionInfo) = Unit
+    override fun connectWebRTC(remoteId: RemoteId) = Unit
+    override fun onExternalConsumerActive() = Unit
+    override fun onPlaybackActive() = Unit
+    override fun onExternalConsumerInactive() = Unit
+    override fun onPlaybackInactive() = Unit
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/auth/AuthenticationViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/auth/AuthenticationViewModelTest.kt
@@ -1,0 +1,468 @@
+package io.music_assistant.client.ui.compose.auth
+
+import app.cash.turbine.test
+import io.music_assistant.client.api.ConnectionInfo
+import io.music_assistant.client.auth.AuthCoordinator
+import io.music_assistant.client.auth.AuthState
+import io.music_assistant.client.data.model.server.AuthProvider
+import io.music_assistant.client.data.model.server.ServerInfo
+import io.music_assistant.client.data.model.server.User
+import io.music_assistant.client.utils.AuthProcessState
+import io.music_assistant.client.utils.ConnectionData
+import io.music_assistant.client.utils.SessionState
+import io.music_assistant.client.webrtc.model.RemoteId
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Specifies the reactive contract of [AuthenticationViewModel].
+ *
+ * The viewmodel projects a list of [AuthProvider] from session-state
+ * transitions and a manual retry trigger. These tests pin down the
+ * projection rules and — crucially — the cancellation semantics that
+ * the old imperative implementation got wrong: a mid-fetch disconnect
+ * used to be able to leave a stale provider list around. With
+ * `flatMapLatest` the race is structurally impossible; the cancellation
+ * tests below prove that.
+ *
+ * Dispatcher strategy: [UnconfinedTestDispatcher] for `Dispatchers.Main`
+ * (which `viewModelScope` delegates to) — every launched coroutine
+ * resumes eagerly, so flow propagation is synchronous from the test's
+ * point of view. The only real waits are explicit [CompletableDeferred]
+ * gates that pin a fetch in mid-suspension while we drive session-state
+ * changes underneath.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AuthenticationViewModelTest {
+    private lateinit var sessionState: MutableStateFlow<SessionState>
+    private lateinit var auth: FakeAuthCoordinator
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        sessionState = MutableStateFlow(SessionState.Disconnected.Initial)
+        auth = FakeAuthCoordinator()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun viewModel(): AuthenticationViewModel =
+        AuthenticationViewModel(auth, sessionState)
+
+    // region Auto-load projection
+
+    @Test
+    fun `initial Disconnected state yields empty providers`() = runTest {
+        viewModel().providers.test {
+            assertEquals(emptyList(), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(0, auth.getProvidersCalls, "Disconnected must not hit the API")
+    }
+
+    @Test
+    fun `transition to Direct AwaitingAuth fetches providers from the API`() = runTest {
+        auth.providersResult = Result.success(REMOTE_PROVIDERS)
+
+        viewModel().providers.test {
+            assertEquals(emptyList(), awaitItem())
+
+            sessionState.value = connectedDirect(AuthProcessState.NotStarted)
+
+            assertEquals(REMOTE_PROVIDERS, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(1, auth.getProvidersCalls)
+    }
+
+    @Test
+    fun `transition to WebRTC AwaitingAuth emits the synthetic builtin provider without an API call`() = runTest {
+        viewModel().providers.test {
+            assertEquals(emptyList(), awaitItem())
+
+            sessionState.value = connectedWebRTC(AuthProcessState.NotStarted)
+
+            assertEquals(listOf(BUILTIN_PROVIDER_FIXTURE), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(0, auth.getProvidersCalls, "WebRTC must not hit the API; builtin is synthetic")
+    }
+
+    @Test
+    fun `transitional Connecting and Reconnecting states do not clear providers`() = runTest {
+        auth.providersResult = Result.success(REMOTE_PROVIDERS)
+
+        viewModel().providers.test {
+            assertEquals(emptyList(), awaitItem())
+
+            sessionState.value = connectedDirect(AuthProcessState.NotStarted)
+            assertEquals(REMOTE_PROVIDERS, awaitItem())
+
+            sessionState.value = SessionState.Connecting
+            expectNoEvents()
+
+            sessionState.value = SessionState.Reconnecting.Direct(
+                attempt = 1,
+                connectionInfo = DIRECT_CONNECTION_INFO,
+                connectionData = ConnectionData(serverInfo = SERVER_INFO),
+            )
+            expectNoEvents()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `AwaitingAuth Failed preserves the displayed provider list without refetch`() = runTest {
+        auth.providersResult = Result.success(REMOTE_PROVIDERS)
+
+        viewModel().providers.test {
+            assertEquals(emptyList(), awaitItem())
+
+            sessionState.value = connectedDirect(AuthProcessState.NotStarted)
+            assertEquals(REMOTE_PROVIDERS, awaitItem())
+
+            sessionState.value = connectedDirect(AuthProcessState.Failed("wrong creds"))
+            expectNoEvents()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(1, auth.getProvidersCalls, "Failed-auth must not retry on its own")
+    }
+
+    @Test
+    fun `transition to Authenticated leaves the provider list intact`() = runTest {
+        auth.providersResult = Result.success(REMOTE_PROVIDERS)
+
+        viewModel().providers.test {
+            assertEquals(emptyList(), awaitItem())
+
+            sessionState.value = connectedDirect(AuthProcessState.NotStarted)
+            assertEquals(REMOTE_PROVIDERS, awaitItem())
+
+            // serverInfo + user populated → dataConnectionState resolves to Authenticated.
+            sessionState.value = connectedDirectWith(
+                ConnectionData(serverInfo = SERVER_INFO, user = USER_FIXTURE),
+            )
+            expectNoEvents()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // endregion
+
+    // region Cancellation semantics — the structural race fix
+
+    @Test
+    fun `disconnect during in-flight fetch cancels and never emits the stale result`() = runTest {
+        val gate = CompletableDeferred<Unit>()
+        auth.providersGate = gate
+        auth.providersResult = Result.success(REMOTE_PROVIDERS)
+
+        viewModel().providers.test {
+            assertEquals(emptyList(), awaitItem())
+
+            // Trigger a fetch that suspends on the gate.
+            sessionState.value = connectedDirect(AuthProcessState.NotStarted)
+            expectNoEvents()
+            assertEquals(1, auth.getProvidersCalls)
+
+            // Disconnect while the fetch is still suspended. Providers was
+            // emptyList → no observable emission, but the in-flight load is
+            // structurally cancelled by flatMapLatest.
+            sessionState.value = SessionState.Disconnected.Error(reason = null)
+            expectNoEvents()
+
+            // Release the now-cancelled gate. The old (pre-refactor) code
+            // would have emitted REMOTE_PROVIDERS here; the new code MUST NOT.
+            gate.complete(Unit)
+            expectNoEvents()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `connection-type switch from Direct to WebRTC cancels the API fetch and emits the builtin provider`() = runTest {
+        val gate = CompletableDeferred<Unit>()
+        auth.providersGate = gate
+        auth.providersResult = Result.success(REMOTE_PROVIDERS)
+
+        viewModel().providers.test {
+            assertEquals(emptyList(), awaitItem())
+
+            sessionState.value = connectedDirect(AuthProcessState.NotStarted)
+            expectNoEvents()
+            assertEquals(1, auth.getProvidersCalls)
+
+            // Switch connection type mid-fetch. The pending Direct fetch must
+            // be cancelled and the WebRTC builtin emitted instead.
+            sessionState.value = connectedWebRTC(AuthProcessState.NotStarted)
+            assertEquals(listOf(BUILTIN_PROVIDER_FIXTURE), awaitItem())
+
+            // Releasing the (cancelled) gate must not leak REMOTE_PROVIDERS.
+            gate.complete(Unit)
+            expectNoEvents()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // endregion
+
+    // region Retry trigger
+
+    @Test
+    fun `loadProviders triggers a fresh API fetch when the auto path is suppressed by Failed-auth`() = runTest {
+        val firstPage = listOf(REMOTE_PROVIDERS.first())
+        val secondPage = REMOTE_PROVIDERS
+
+        auth.providersResult = Result.success(firstPage)
+
+        val vm = viewModel()
+        vm.providers.test {
+            assertEquals(emptyList(), awaitItem())
+
+            sessionState.value = connectedDirect(AuthProcessState.NotStarted)
+            assertEquals(firstPage, awaitItem())
+
+            // Enter Failed-auth: auto path would suppress further fetches.
+            sessionState.value = connectedDirect(AuthProcessState.Failed("nope"))
+            expectNoEvents()
+
+            // User clicks Retry — explicit override of the Failed-auth guard.
+            auth.providersResult = Result.success(secondPage)
+            vm.loadProviders()
+            assertEquals(secondPage, awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(2, auth.getProvidersCalls)
+    }
+
+    @Test
+    fun `loadProviders while disconnected does nothing`() = runTest {
+        val vm = viewModel()
+        vm.providers.test {
+            assertEquals(emptyList(), awaitItem())
+
+            vm.loadProviders()
+            expectNoEvents()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(0, auth.getProvidersCalls, "Retry must no-op when there is no session to load against")
+    }
+
+    @Test
+    fun `rapid retries collapse to only the latest result`() = runTest {
+        val firstGate = CompletableDeferred<Unit>()
+        val secondGate = CompletableDeferred<Unit>()
+        val firstPage = listOf(REMOTE_PROVIDERS.first())
+        val secondPage = REMOTE_PROVIDERS
+
+        auth.providersGate = firstGate
+        auth.providersResult = Result.success(firstPage)
+
+        val vm = viewModel()
+        vm.providers.test {
+            assertEquals(emptyList(), awaitItem())
+
+            sessionState.value = connectedDirect(AuthProcessState.NotStarted)
+            expectNoEvents()  // first fetch is gated
+
+            // Swap behavior for the retry attempt.
+            auth.providersGate = secondGate
+            auth.providersResult = Result.success(secondPage)
+            vm.loadProviders()
+
+            // Releasing the (cancelled) first gate must NOT emit firstPage.
+            firstGate.complete(Unit)
+            expectNoEvents()
+
+            // Releasing the second gate emits the second-page result.
+            secondGate.complete(Unit)
+            assertEquals(secondPage, awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // endregion
+
+    // region Error path
+
+    @Test
+    fun `API failure logs and leaves the provider list at its prior value`() = runTest {
+        auth.providersResult = Result.failure(RuntimeException("boom"))
+
+        viewModel().providers.test {
+            assertEquals(emptyList(), awaitItem())
+
+            sessionState.value = connectedDirect(AuthProcessState.NotStarted)
+            // loadFlow does not emit on failure; previous emission (emptyList) stays.
+            expectNoEvents()
+            assertEquals(1, auth.getProvidersCalls)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // endregion
+
+    // region Side-effect delegations
+
+    @Test
+    fun `login with builtin provider delegates to AuthCoordinator with current credentials`() = runTest {
+        val vm = viewModel()
+        vm.username.value = "alice"
+        vm.password.value = "hunter2"
+
+        vm.login(BUILTIN_PROVIDER_FIXTURE)
+
+        assertEquals(
+            listOf(LoginCall(providerId = "builtin", username = "alice", password = "hunter2")),
+            auth.loginCalls,
+        )
+    }
+
+    @Test
+    fun `login with redirect-based provider fetches OAuth URL and starts the flow`() = runTest {
+        val haProvider = AuthProvider(id = "homeassistant", type = "homeassistant", requiresRedirect = true)
+        auth.oauthUrl = Result.success("https://oauth.example/")
+
+        val vm = viewModel()
+        vm.login(haProvider)
+
+        assertEquals(listOf("homeassistant" to "musicassistant://auth/callback"), auth.oauthRequests)
+        assertEquals(listOf("https://oauth.example/"), auth.startedOAuthUrls)
+        assertTrue(auth.loginCalls.isEmpty(), "OAuth flow must not also try credential login")
+    }
+
+    @Test
+    fun `logout delegates to AuthCoordinator`() = runTest {
+        val vm = viewModel()
+        vm.logout()
+
+        assertEquals(1, auth.logoutCalls)
+    }
+
+    // endregion
+
+    // region Fixtures and helpers
+
+    private fun connectedDirect(authProcessState: AuthProcessState) = SessionState.Connected.Direct(
+        connectionInfo = DIRECT_CONNECTION_INFO,
+        connectionData = ConnectionData(serverInfo = SERVER_INFO, authProcessState = authProcessState),
+    )
+
+    private fun connectedDirectWith(connectionData: ConnectionData) = SessionState.Connected.Direct(
+        connectionInfo = DIRECT_CONNECTION_INFO,
+        connectionData = connectionData,
+    )
+
+    private fun connectedWebRTC(authProcessState: AuthProcessState) = SessionState.Connected.WebRTC(
+        remoteId = WEBRTC_REMOTE_ID,
+        connectionData = ConnectionData(serverInfo = SERVER_INFO, authProcessState = authProcessState),
+    )
+
+    private companion object {
+        private val DIRECT_CONNECTION_INFO = ConnectionInfo(host = "fixture.local", port = 8095, isTls = false)
+        private val SERVER_INFO = ServerInfo(serverId = "fixture-server")
+        private val WEBRTC_REMOTE_ID = RemoteId("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+        private val USER_FIXTURE = User(userId = "u1", username = "alice")
+
+        private val BUILTIN_PROVIDER_FIXTURE = AuthProvider(
+            id = "builtin",
+            type = "builtin",
+            requiresRedirect = false,
+        )
+        private val REMOTE_PROVIDERS = listOf(
+            BUILTIN_PROVIDER_FIXTURE,
+            AuthProvider(id = "homeassistant", type = "homeassistant", requiresRedirect = true),
+        )
+    }
+
+    // endregion
+}
+
+private data class LoginCall(val providerId: String, val username: String, val password: String)
+
+/**
+ * Fake [AuthCoordinator] with knobs and call counters. Methods that the
+ * viewmodel doesn't currently invoke return a benign default rather than
+ * throwing, so adding a test that exercises them doesn't require
+ * pre-emptive plumbing here.
+ */
+private class FakeAuthCoordinator : AuthCoordinator {
+    private val _authState = MutableStateFlow<AuthState>(AuthState.Idle)
+    override val authState: StateFlow<AuthState> = _authState
+
+    var providersResult: Result<List<AuthProvider>> = Result.success(emptyList())
+
+    /**
+     * Optional gate. If non-null, [getProviders] awaits it before returning
+     * [providersResult]. Lets tests pin down cancellation behaviour by
+     * holding a fetch open while session state changes underneath.
+     */
+    var providersGate: CompletableDeferred<Unit>? = null
+
+    var getProvidersCalls: Int = 0
+        private set
+
+    override suspend fun getProviders(): Result<List<AuthProvider>> {
+        getProvidersCalls++
+        providersGate?.await()
+        return providersResult
+    }
+
+    val loginCalls = mutableListOf<LoginCall>()
+
+    override suspend fun loginWithCredentials(
+        providerId: String,
+        username: String,
+        password: String,
+    ): Result<Unit> {
+        loginCalls += LoginCall(providerId, username, password)
+        return Result.success(Unit)
+    }
+
+    var oauthUrl: Result<String> = Result.success("https://default.example/")
+    val oauthRequests = mutableListOf<Pair<String, String>>()
+
+    override suspend fun getOAuthUrl(providerId: String, returnUrl: String): Result<String> {
+        oauthRequests += providerId to returnUrl
+        return oauthUrl
+    }
+
+    val startedOAuthUrls = mutableListOf<String>()
+
+    override fun startOAuthFlow(oauthUrl: String): Result<Unit> {
+        startedOAuthUrls += oauthUrl
+        return Result.success(Unit)
+    }
+
+    var logoutCalls: Int = 0
+        private set
+
+    override suspend fun logout(): Result<Unit> {
+        logoutCalls++
+        return Result.success(Unit)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ easyqrscan = "0.7.1"
 androidx-compose-ui-test = "1.11.2"
 robolectric = "4.16.1"
 detekt = "1.23.8"
+turbine = "1.2.1"
 
 
 [libraries]
@@ -64,6 +65,8 @@ androidx-lifecycle-viewmodel = { group = "org.jetbrains.androidx.lifecycle", nam
 androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
@@ -96,6 +99,7 @@ icons-fontawesome = { module = "br.com.devsrsouza.compose.icons:font-awesome", v
 icons-tabler = { module = "br.com.devsrsouza.compose.icons:tabler-icons", version.ref = "fontIconsVersion" }
 
 settings-multiplatform = { module = "com.russhwolf:multiplatform-settings-no-arg", version.ref = "settingsMultiplatform" }
+settings-multiplatform-test = { module = "com.russhwolf:multiplatform-settings-test", version.ref = "settingsMultiplatform" }
 reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reorderable" }
 concentus = { module = "io.github.jaredmdobson:concentus", version.ref = "concentus" }
 kmpalette-core = { module = "com.kmpalette:kmpalette-core", version.ref = "kmpalette" }


### PR DESCRIPTION
Separated out from #470 because it was going to be a bigger effort, this finishes the effort to get us down to only two compile-time warnings, while also refactoring and cleaning up AuthenticationManager. Tested on my Android phone, it seems to work great. If this refactoring *isn't* what you meant when you said "I'm a bit worried about this class" @formatBCE then I apologize. 😄

Commit message:

Replaces the procedural loadProvidersJob/loadingForWebRTC state machine with a reactive providers flow over sessionState + a retry trigger. flatMapLatest cancels any in-flight load on state change, closing the disconnect-vs-stale-result race the old code had (reviewer flagged this class on #470).

Extracts AuthCoordinator from AuthenticationManager so the VM depends on a narrow interface, not the manager (whose init spawns an auto-login coroutine that can't be unit-tested).

Because flatMapLatest now cancels suspend calls routinely, hardens all five cancellable suspend entry points in AuthenticationManager (getProviders, loginWithCredentials, getOAuthUrl, handleOAuthCallback, authorizeWithSavedToken) to rethrow CancellationException ahead of their broad catch -- otherwise cancellation is swallowed into a spurious AuthState.Error or an absorbed failure Result. startOAuthFlow and logout are exempt: no suspension point, so no cancellation to catch.

Adds kotlinx-coroutines-test, Turbine, and multiplatform-settings-test. 18 tests cover the projection, the structural race fix, retry semantics, the error path, login/OAuth/logout, and the cancellation contract on the three reachable suspend entry points (each verified red without the fix).