### PR TITLE
feat(ui): show "No network" banner while reconnecting offline

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-nl-rNL/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl-rNL/strings.xml
@@ -39,6 +39,7 @@
   <string name="auth_show_password">Wachtwoord tonen</string>
   <string name="auth_title">Authenticatie</string>
   <string name="auth_username">Gebruikersnaam</string>
+  <string name="banner_no_network">Geen netwerk beschikbaar</string>
   <string name="banner_reconnecting">Opnieuw verbinden… (poging %1$d)</string>
   <string name="bound_player_joined_to">%1$s is verbonden met %2$s\n(tik om te bekijken)</string>
   <string name="bound_player_part_of_group">%1$s is onderdeel van groep %2$s\n(tik om te bekijken)</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -39,6 +39,7 @@
   <string name="auth_show_password">Show password</string>
   <string name="auth_title">Authentication</string>
   <string name="auth_username">Username</string>
+  <string name="banner_no_network">No network available</string>
   <string name="banner_reconnecting">Reconnecting… (attempt %1$d)</string>
   <string name="bound_player_joined_to">%1$s is joined to %2$s\n(tap to view)</string>
   <string name="bound_player_part_of_group">%1$s is part of group %2$s\n(tap to view)</string>

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/ConnectionStatusBanner.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/ConnectionStatusBanner.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.music_assistant.client.api.ServiceClient
+import io.music_assistant.client.utils.NetworkMonitor
 import io.music_assistant.client.utils.SessionState
 import kotlinx.coroutines.delay
 import musicassistantclient.composeapp.generated.resources.*
@@ -40,19 +41,11 @@ fun ConnectionStatusBanner(
     delay: Long = 3000,
 ) {
     val serviceClient: ServiceClient = koinInject()
+    val networkMonitor: NetworkMonitor = koinInject()
     val sessionState by serviceClient.sessionState.collectAsStateWithLifecycle()
+    val isOnline by networkMonitor.isAvailable.collectAsStateWithLifecycle()
 
-    // Determine banner state
-    // Only show banner during reconnection attempts
-    // On max attempts reached, navigate to Settings instead (handled in AppNavigation)
-    val bannerState = when (sessionState) {
-        is SessionState.Reconnecting -> {
-            val attempt = (sessionState as SessionState.Reconnecting).attempt
-            BannerState.Reconnecting(attempt)
-        }
-
-        else -> null
-    }
+    val bannerState = reconnectionBannerState(sessionState, isOnline)
 
     // Delay visibility to not spam in cases reconnecting is fast
     var isVisible by remember { mutableStateOf(false) }
@@ -70,9 +63,14 @@ fun ConnectionStatusBanner(
         enter = expandVertically(),
         exit = shrinkVertically(),
     ) {
-        bannerState?.let { state ->
-            ReconnectingBanner(
-                attempt = state.attempt,
+        bannerState?.let { banner ->
+            StatusBanner(
+                text = when (banner) {
+                    is BannerState.Reconnecting ->
+                        stringResource(Res.string.banner_reconnecting, banner.attempt)
+
+                    BannerState.NoNetwork -> stringResource(Res.string.banner_no_network)
+                },
                 onCancel = { serviceClient.disconnectByUser() },
                 modifier = modifier,
             )
@@ -80,13 +78,23 @@ fun ConnectionStatusBanner(
     }
 }
 
-private sealed interface BannerState {
+internal sealed interface BannerState {
     data class Reconnecting(val attempt: Int) : BannerState
+    data object NoNetwork : BannerState
 }
 
+// While reconnecting, offline means the loop is parked waiting for network, not retrying.
+internal fun reconnectionBannerState(sessionState: SessionState, isOnline: Boolean): BannerState? =
+    when (sessionState) {
+        is SessionState.Reconnecting ->
+            if (isOnline) BannerState.Reconnecting(sessionState.attempt) else BannerState.NoNetwork
+
+        else -> null
+    }
+
 @Composable
-private fun ReconnectingBanner(
-    attempt: Int,
+private fun StatusBanner(
+    text: String,
     onCancel: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -111,7 +119,7 @@ private fun ReconnectingBanner(
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
                 )
                 Text(
-                    text = stringResource(Res.string.banner_reconnecting, attempt),
+                    text = text,
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
                 )

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/common/ConnectionStatusBannerTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/common/ConnectionStatusBannerTest.kt
@@ -1,0 +1,45 @@
+package io.music_assistant.client.ui.compose.common
+
+import io.music_assistant.client.api.ConnectionInfo
+import io.music_assistant.client.utils.SessionState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ConnectionStatusBannerTest {
+    private val connectionInfo = ConnectionInfo(host = "localhost", port = PORT, isTls = false)
+    private val reconnecting =
+        SessionState.Reconnecting.Direct(attempt = RECONNECT_ATTEMPT, connectionInfo = connectionInfo)
+
+    @Test
+    fun `reconnecting while online shows the reconnecting banner carrying its attempt`() {
+        assertEquals(
+            BannerState.Reconnecting(RECONNECT_ATTEMPT),
+            reconnectionBannerState(reconnecting, isOnline = true),
+        )
+    }
+
+    @Test
+    fun `reconnecting while offline shows the no network banner`() {
+        assertEquals(
+            BannerState.NoNetwork,
+            reconnectionBannerState(reconnecting, isOnline = false),
+        )
+    }
+
+    @Test
+    fun `offline while not reconnecting shows no banner`() {
+        val connected = SessionState.Connected.Direct(connectionInfo)
+        assertNull(reconnectionBannerState(connected, isOnline = false))
+    }
+
+    @Test
+    fun `online while not reconnecting shows no banner`() {
+        assertNull(reconnectionBannerState(SessionState.Disconnected.Initial, isOnline = true))
+    }
+
+    private companion object {
+        const val RECONNECT_ATTEMPT = 3
+        const val PORT = 8095
+    }
+}


### PR DESCRIPTION
While working on #487, specifically the bit where I was testing on my real devices, I noticed that when the network isn't available (i.e., the phone is in airplane mode, etc.) the banner at the top of the connection screen said it was attempting to connect, attempt 1, "forever". That made me think we had something without a timeout as it never ticked up to attempt 2. That wasn't the case - we properly just waited until we had a network to attempt *with* before actually doing anything, but it was a bit confusing. This PR changes it so that if we detect there is no network, we just say that. Also tested with physical devices, it now properly says "No network available" when that's the case then switches to 'Reconnecting (attempt N)' when it comes back.