### PR TITLE
Bump the iOS build version

### DIFF
--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>30</string>
+	<string>31</string>
 	<key>INIntentsSupported</key>
 	<array>
 		<string>INPlayMediaIntent</string>


### PR DESCRIPTION
We still do not have a working WebRTC library in iOS should this should not go to the external testflight group, but we can do a small internal-only test