### PR TITLE
perf(logging): bound in-memory log buffer, gate verbose logs to debug builds

### DIFF
--- a/androidApp/src/main/kotlin/io/music_assistant/client/MyApplication.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/MyApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
+import android.content.pm.ApplicationInfo
 import io.music_assistant.client.di.androidModule
 import io.music_assistant.client.di.appModule
 import io.music_assistant.client.di.cleanupSingletons
@@ -17,7 +18,8 @@ import java.io.File
 class MyApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        initKoin(androidModule(), appModule()) {
+        val debuggable = (applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
+        initKoin(androidModule(), appModule(), verboseLogging = debuggable) {
             androidContext(this@MyApplication)
         }
         createNotificationChannel(this)

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -100,6 +100,7 @@ kotlin {
             implementation(libs.ktor.client.json)
 //            implementation(libs.ktor.client.logging)
             implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.kotlinx.atomicfu)
 
             api(libs.koin.core)
             implementation(libs.koin.compose)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/di/initKoin.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/di/initKoin.kt
@@ -1,6 +1,7 @@
 package io.music_assistant.client.di
 
 import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Severity
 import coil3.SingletonImageLoader
 import io.music_assistant.client.api.ServiceClient
 import io.music_assistant.client.imageloader.WebRTCImageFetcher
@@ -13,8 +14,13 @@ import org.koin.mp.KoinPlatform
 
 fun initKoin(
     vararg platformModules: Module,
+    verboseLogging: Boolean = false,
     config: KoinAppDeclaration? = null,
 ) {
+    // Release builds drop Debug/Verbose logs: the WebSocket layer emits ~4 debug
+    // lines/sec for the idle clock-sync heartbeat, which otherwise floods (and
+    // evicts useful entries from) InMemoryLogWriter for the entire session.
+    Logger.setMinSeverity(if (verboseLogging) Severity.Verbose else Severity.Info)
     Logger.addLogWriter(InMemoryLogWriter)
     startKoin {
         config?.invoke(this)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/logging/InMemoryLogWriter.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/logging/InMemoryLogWriter.kt
@@ -3,37 +3,29 @@ package io.music_assistant.client.logging
 import co.touchlab.kermit.LogWriter
 import co.touchlab.kermit.Severity
 import io.music_assistant.client.utils.currentTimeMillis
-import kotlin.concurrent.atomics.AtomicReference
-import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
-@OptIn(ExperimentalAtomicApi::class)
+/** Kermit [LogWriter] that retains recent log lines in memory for crash/share reports. */
 object InMemoryLogWriter : LogWriter() {
     private const val MAX_ENTRIES = 3000
-    private val bufferRef = AtomicReference(emptyList<String>())
+    private val buffer = LogRingBuffer(MAX_ENTRIES)
 
     override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
-        val line = buildString {
-            append(currentTimeMillis())
-            append(' ')
-            append(severity.name)
-            append('/')
-            append(tag)
-            append(": ")
-            append(message)
-            if (throwable != null) {
-                append('\n')
-                append(throwable.stackTraceToString())
-            }
-        }
-        while (true) {
-            val current = bufferRef.load()
-            val updated = current.toMutableList().apply {
-                if (size >= MAX_ENTRIES) removeAt(0)
-                add(line)
-            }
-            if (bufferRef.compareAndSet(current, updated)) break
-        }
+        buffer.add(
+            buildString {
+                append(currentTimeMillis())
+                append(' ')
+                append(severity.name)
+                append('/')
+                append(tag)
+                append(": ")
+                append(message)
+                if (throwable != null) {
+                    append('\n')
+                    append(throwable.stackTraceToString())
+                }
+            },
+        )
     }
 
-    fun getLogText(): String = bufferRef.load().joinToString("\n")
+    fun getLogText(): String = buffer.snapshot().joinToString("\n")
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/logging/LogRingBuffer.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/logging/LogRingBuffer.kt
@@ -1,0 +1,25 @@
+package io.music_assistant.client.logging
+
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
+
+/**
+ * Fixed-capacity, thread-safe buffer of recent log lines. Once full, [add] evicts
+ * the oldest. The lock is non-suspend because Kermit's [co.touchlab.kermit.LogWriter.log]
+ * is synchronous, ruling out a coroutines [kotlinx.coroutines.sync.Mutex].
+ */
+class LogRingBuffer(private val capacity: Int) {
+    init {
+        require(capacity > 0) { "capacity must be positive, was $capacity" }
+    }
+
+    private val lock = SynchronizedObject()
+    private val entries = ArrayDeque<String>(capacity)
+
+    fun add(line: String) = synchronized(lock) {
+        if (entries.size == capacity) entries.removeFirst()
+        entries.addLast(line)
+    }
+
+    fun snapshot(): List<String> = synchronized(lock) { entries.toList() }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/logging/LogRingBufferTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/logging/LogRingBufferTest.kt
@@ -1,0 +1,46 @@
+package io.music_assistant.client.logging
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class LogRingBufferTest {
+    @Test
+    fun `snapshot returns all lines in insertion order when below capacity`() {
+        val buffer = LogRingBuffer(capacity = 4)
+        val lines = listOf("a", "b", "c")
+        lines.forEach(buffer::add)
+        assertEquals(lines, buffer.snapshot())
+    }
+
+    @Test
+    fun `snapshot returns all lines when exactly at capacity`() {
+        val capacity = 4
+        val buffer = LogRingBuffer(capacity)
+        val lines = List(capacity) { "line-$it" }
+        lines.forEach(buffer::add)
+        assertEquals(lines, buffer.snapshot())
+    }
+
+    @Test
+    fun `snapshot keeps the most recent lines and evicts oldest when over capacity`() {
+        val capacity = 4
+        val buffer = LogRingBuffer(capacity)
+        val lines = List(capacity * 2 + 1) { "line-$it" }
+        lines.forEach(buffer::add)
+        assertEquals(lines.takeLast(capacity), buffer.snapshot())
+    }
+
+    @Test
+    fun `capacity of one retains only the last line`() {
+        val buffer = LogRingBuffer(capacity = 1)
+        listOf("first", "second", "third").forEach(buffer::add)
+        assertEquals(listOf("third"), buffer.snapshot())
+    }
+
+    @Test
+    fun `constructor rejects non-positive capacity`() {
+        assertFailsWith<IllegalArgumentException> { LogRingBuffer(capacity = 0) }
+        assertFailsWith<IllegalArgumentException> { LogRingBuffer(capacity = -1) }
+    }
+}

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/MainViewController.kt
@@ -1,4 +1,8 @@
-@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class, kotlinx.cinterop.BetaInteropApi::class)
+@file:OptIn(
+    kotlinx.cinterop.ExperimentalForeignApi::class,
+    kotlinx.cinterop.BetaInteropApi::class,
+    kotlin.experimental.ExperimentalNativeApi::class,
+)
 
 package io.music_assistant.client
 
@@ -15,6 +19,7 @@ import platform.Foundation.NSTemporaryDirectory
 import platform.Foundation.NSUTF8StringEncoding
 import platform.Foundation.create
 import platform.Foundation.writeToFile
+import kotlin.native.Platform
 
 /**
  * Idempotent KMP/Koin initialization. Called from two places:
@@ -35,7 +40,7 @@ fun bootstrapKmp() {
 }
 
 private val kmpBootstrap: Unit by lazy {
-    initKoin(iosModule())
+    initKoin(iosModule(), verboseLogging = Platform.isDebugBinary)
     cleanupStaleLogFile()
     installCrashHandler()
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ compose-multiplatform = "1.11.0"
 junit = "4.13.2"
 kermit = "2.1.0"
 kotlin = "2.3.21"
+kotlinx-atomicfu = "0.32.1"
 kotlinx-coroutines = "1.11.0"
 
 ktor = "3.5.0"
@@ -63,6 +64,7 @@ androidx-browser = { group = "androidx.browser", name = "browser", version.ref =
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 androidx-lifecycle-viewmodel = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
+kotlinx-atomicfu = { group = "org.jetbrains.kotlinx", name = "atomicfu", version.ref = "kotlinx-atomicfu" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }


### PR DESCRIPTION
I noticed this while investigating an OOMkill of the app in a debug build (pretty sure that's just a weird Xcode quirk, not an actual bug). As mentioned in Discord, it's not going to suddenly unlock turbo mode or anything but having up to 2 O(N) operations for in-memory logs (always one, two once we hit 3k log lines) is unnecessary. Now O(1). Also now gates verbose logs for debug builds only.

Commit message:

InMemoryLogWriter copied its entire backing list on every log call (toMutableList + removeAt(0)) — an O(n) allocation and shift per line at steady state, churning a fresh 3000-element list for each entry. Replace the storage with LogRingBuffer: a fixed-capacity, thread-safe ArrayDeque guarded by a non-suspend atomicfu lock, giving amortized O(1) appends and bounded retention with no per-write copy.

Also gate verbose logging behind debug builds. initKoin now sets Kermit's minSeverity to Verbose only for debug binaries (Platform.isDebugBinary on iOS, FLAG_DEBUGGABLE on Android) and Info otherwise, so release builds no longer emit the per-second WebSocket/clock-sync debug chatter.

Adds the kotlinx-atomicfu dependency for the multiplatform non-suspend lock, and unit tests covering the ring buffer's retention/eviction policy.