### PR TITLE
fix(logs): move log-share sanitize/write off the main thread

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/music_assistant/client/logging/LogSharer.android.kt
+++ b/composeApp/src/androidMain/kotlin/io/music_assistant/client/logging/LogSharer.android.kt
@@ -13,21 +13,24 @@ actual class LogSharer actual constructor(private val platformContext: PlatformC
     private fun logFile() = File(context.cacheDir, "ma_client_logs.txt")
     private fun crashLogFile() = File(context.cacheDir, "ma_crash_log.txt")
 
-    actual fun shareLogs(logText: String, chooserTitle: String) {
+    actual fun prepareLogShareFile(logText: String): String {
         val file = logFile()
         file.writeText(LogSanitizer.sanitize(logText))
-        shareFile(file, chooserTitle)
+        return file.absolutePath
     }
 
     actual fun hasCrashLog(): Boolean = crashLogFile().exists()
 
-    actual fun shareCrashLog(chooserTitle: String) {
+    actual fun prepareCrashLogShareFile(): String? {
         val file = crashLogFile()
-        if (file.exists()) {
-            val sanitizedFile = File(context.cacheDir, "ma_crash_log_share.txt")
-            sanitizedFile.writeText(LogSanitizer.sanitize(file.readText()))
-            shareFile(sanitizedFile, chooserTitle)
-        }
+        if (!file.exists()) return null
+        val sanitizedFile = File(context.cacheDir, "ma_crash_log_share.txt")
+        sanitizedFile.writeText(LogSanitizer.sanitize(file.readText()))
+        return sanitizedFile.absolutePath
+    }
+
+    actual fun presentShareFile(path: String, chooserTitle: String) {
+        shareFile(File(path), chooserTitle)
     }
 
     actual fun deleteCrashLog() {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/logging/LogSanitizer.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/logging/LogSanitizer.kt
@@ -22,8 +22,9 @@ object LogSanitizer {
             Regex("""\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"""),
             "[REDACTED_ID]",
         ),
-        // Email addresses
-        RedactionRule(Regex("""\b[\w.+-]+@[\w.-]+\.\w{2,}\b"""), "[REDACTED_EMAIL]"),
+        // Possessive local part (`++`): the class excludes '@', so backtracking
+        // it can never match — skips rescanning every '@'-less word run.
+        RedactionRule(Regex("""\b[\w.+-]++@[\w.-]+\.\w{2,}\b"""), "[REDACTED_EMAIL]"),
     )
 
     fun sanitize(text: String): String =

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/logging/LogSharer.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/logging/LogSharer.kt
@@ -4,9 +4,15 @@ package io.music_assistant.client.logging
 
 import io.music_assistant.client.player.PlatformContext
 
+/**
+ * Split so the caller can run the heavy [prepareLogShareFile] /
+ * [prepareCrashLogShareFile] (sanitize + write) off the main thread, then
+ * [presentShareFile] back on it — platform share UI must be presented on main.
+ */
 expect class LogSharer(platformContext: PlatformContext) {
-    fun shareLogs(logText: String, chooserTitle: String)
+    fun prepareLogShareFile(logText: String): String
+    fun prepareCrashLogShareFile(): String?
+    fun presentShareFile(path: String, chooserTitle: String)
     fun hasCrashLog(): Boolean
-    fun shareCrashLog(chooserTitle: String)
     fun deleteCrashLog()
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -151,6 +152,7 @@ fun SettingsScreen(goHome: () -> Unit, exitApp: () -> Unit) {
     val dataConnection = (sessionState as? SessionState.Connected)?.dataConnectionState
     val isAuthenticated = dataConnection == DataConnectionState.Authenticated
     val hasCrashLog by viewModel.hasCrashLog.collectAsStateWithLifecycle()
+    val isPreparingShare by viewModel.isPreparingShare.collectAsStateWithLifecycle()
 
     // Only allow back navigation when authenticated
     BackHandler(enabled = true) {
@@ -331,6 +333,7 @@ fun SettingsScreen(goHome: () -> Unit, exitApp: () -> Unit) {
                 MiscSection(
                     onShareLogs = { viewModel.shareLogs(shareLogsTitle) },
                     hasCrashLog = hasCrashLog,
+                    isPreparingShare = isPreparingShare,
                     onShareCrashLog = { viewModel.shareCrashLog(shareCrashLogsTitle) },
                     onDeleteCrashLog = { viewModel.deleteCrashLog() },
                 )
@@ -347,6 +350,7 @@ fun SettingsScreen(goHome: () -> Unit, exitApp: () -> Unit) {
 private fun MiscSection(
     onShareLogs: () -> Unit,
     hasCrashLog: Boolean,
+    isPreparingShare: Boolean,
     onShareCrashLog: () -> Unit,
     onDeleteCrashLog: () -> Unit,
 ) {
@@ -354,8 +358,16 @@ private fun MiscSection(
         SectionTitle(stringResource(Res.string.settings_misc))
         OutlinedButton(
             modifier = Modifier.fillMaxWidth(),
+            enabled = !isPreparingShare,
             onClick = onShareLogs,
         ) {
+            if (isPreparingShare) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(18.dp),
+                    strokeWidth = 2.dp,
+                )
+                Spacer(modifier = Modifier.size(8.dp))
+            }
             Text(stringResource(Res.string.settings_share_logs))
         }
         if (hasCrashLog) {
@@ -366,11 +378,15 @@ private fun MiscSection(
             ) {
                 OutlinedButton(
                     modifier = Modifier.weight(1f),
+                    enabled = !isPreparingShare,
                     onClick = onShareCrashLog,
                 ) {
                     Text(stringResource(Res.string.settings_share_crash_logs))
                 }
-                OutlinedButton(onClick = onDeleteCrashLog) {
+                OutlinedButton(
+                    enabled = !isPreparingShare,
+                    onClick = onDeleteCrashLog,
+                ) {
                     Icon(Icons.Default.Delete, contentDescription = stringResource(Res.string.cd_delete_crash_logs))
                 }
             }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsViewModel.kt
@@ -9,9 +9,11 @@ import io.music_assistant.client.logging.LogSharer
 import io.music_assistant.client.player.sendspin.audio.Codec
 import io.music_assistant.client.settings.ConnectionHistoryEntry
 import io.music_assistant.client.settings.SettingsRepository
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class SettingsViewModel(
     private val apiClient: ServiceClient,
@@ -24,12 +26,37 @@ class SettingsViewModel(
     private val _hasCrashLog = MutableStateFlow(logSharer.hasCrashLog())
     val hasCrashLog: StateFlow<Boolean> = _hasCrashLog
 
+    private val _isPreparingShare = MutableStateFlow(false)
+    val isPreparingShare: StateFlow<Boolean> = _isPreparingShare
+
     fun shareLogs(chooserTitle: String) {
-        logSharer.shareLogs(InMemoryLogWriter.getLogText(), chooserTitle)
+        if (_isPreparingShare.value) return
+        viewModelScope.launch {
+            _isPreparingShare.value = true
+            try {
+                val path = withContext(Dispatchers.Default) {
+                    logSharer.prepareLogShareFile(InMemoryLogWriter.getLogText())
+                }
+                logSharer.presentShareFile(path, chooserTitle)
+            } finally {
+                _isPreparingShare.value = false
+            }
+        }
     }
 
     fun shareCrashLog(chooserTitle: String) {
-        logSharer.shareCrashLog(chooserTitle)
+        if (_isPreparingShare.value) return
+        viewModelScope.launch {
+            _isPreparingShare.value = true
+            try {
+                val path = withContext(Dispatchers.Default) {
+                    logSharer.prepareCrashLogShareFile()
+                }
+                if (path != null) logSharer.presentShareFile(path, chooserTitle)
+            } finally {
+                _isPreparingShare.value = false
+            }
+        }
     }
 
     fun deleteCrashLog() {

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/logging/LogSanitizerTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/logging/LogSanitizerTest.kt
@@ -1,0 +1,31 @@
+package io.music_assistant.client.logging
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LogSanitizerTest {
+    @Test
+    fun `redacts a simple email address`() {
+        val secret = "user@example.com"
+        val out = LogSanitizer.sanitize("contact $secret for details")
+        assertFalse(out.contains(secret), "email leaked: $out")
+        assertTrue(out.contains("REDACTED_EMAIL"), "no redaction marker: $out")
+    }
+
+    @Test
+    fun `redacts an email with a complex local part`() {
+        // Exercises the possessive local-part quantifier.
+        val secret = "first.last+tag-x@sub.example.co.uk"
+        val out = LogSanitizer.sanitize("from=$secret done")
+        assertFalse(out.contains(secret), "email leaked: $out")
+        assertFalse(out.contains("@"), "address fragment leaked: $out")
+    }
+
+    @Test
+    fun `leaves text without sensitive data unchanged`() {
+        val line = "just a normal log line with several plain words"
+        assertEquals(line, LogSanitizer.sanitize(line))
+    }
+}

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/logging/LogSharer.ios.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/logging/LogSharer.ios.kt
@@ -19,26 +19,30 @@ actual class LogSharer actual constructor(@Suppress("UNUSED_PARAMETER") platform
     private fun logFilePath() = "${NSTemporaryDirectory()}ma_client_logs.txt"
     private fun crashLogFilePath() = "${NSTemporaryDirectory()}ma_crash_log.txt"
 
-    actual fun shareLogs(logText: String, @Suppress("UNUSED_PARAMETER") chooserTitle: String) {
+    actual fun prepareLogShareFile(logText: String): String {
         val path = logFilePath()
         writeTextToFile(LogSanitizer.sanitize(logText), path)
-        shareFile(path)
+        return path
     }
 
     actual fun hasCrashLog(): Boolean =
         NSFileManager.defaultManager.fileExistsAtPath(crashLogFilePath())
 
-    actual fun shareCrashLog(@Suppress("UNUSED_PARAMETER") chooserTitle: String) {
+    actual fun prepareCrashLogShareFile(): String? {
         val path = crashLogFilePath()
-        if (!NSFileManager.defaultManager.fileExistsAtPath(path)) return
+        if (!NSFileManager.defaultManager.fileExistsAtPath(path)) return null
         val rawText = NSString.create(
             contentsOfFile = path,
             encoding = NSUTF8StringEncoding,
             error = null,
-        )?.toString() ?: return
+        )?.toString() ?: return null
         val sanitizedPath = "${NSTemporaryDirectory()}ma_crash_log_share.txt"
         writeTextToFile(LogSanitizer.sanitize(rawText), sanitizedPath)
-        shareFile(sanitizedPath)
+        return sanitizedPath
+    }
+
+    actual fun presentShareFile(path: String, @Suppress("UNUSED_PARAMETER") chooserTitle: String) {
+        shareFile(path)
     }
 
     actual fun deleteCrashLog() {


### PR DESCRIPTION
While tracking down other logging stuff, I ran into the fact that the 'share logs / share crash logs' buttons were synchronous, and could take a fairly long time (over 10 seconds) to actually bring up the share sheet if you had multiple megabytes of logs in RAM with no indication that it was doing anything at all.

This was exacerbated by two unrelated things:
- A debug build is ~6x slower than a release build at processing text (woof)
- We had some extraneous server logs that were causing the excessive size, normally our logs aren't that big

But, in the interest of "If we *do* have some legitimately very large logs in the future, it should work well and be responsive", I would still like to move the actual log processing bits off the main thread so that we can add a little progress animation and feedback. Slightly tightened up one of the regexes for a small gain while I was in there, and added some tests.

Commit message:

Sharing logs ran the whole pipeline — snapshot, LogSanitizer.sanitize, and file write — synchronously on the main thread. On a large in-memory buffer the regex sanitize dominates and froze the UI with no feedback until the share sheet appeared.

Split LogSharer into background-safe prepare (sanitize + write, returns a path) and main-thread presentShareFile (platform share UI must present on main). SettingsViewModel runs prepare on Dispatchers.Default inside viewModelScope, presents back on main, and exposes isPreparingShare so the Misc section can disable the buttons and show a spinner while it works. A try/finally clears the flag on failure and a re-entrancy guard ignores double-taps.

Also make the email rule's local-part quantifier possessive ([\w.+-]++): the class excludes '@', so backtracking it can never match, which skips rescanning every '@'-less word run with no change to what gets redacted. Adds LogSanitizerTest covering redaction and the possessive path.