### PR TITLE
fix(ios,audio): resume after interruption unless another app holds audio

### DIFF
--- a/iosApp/NativeAudioController.swift
+++ b/iosApp/NativeAudioController.swift
@@ -85,15 +85,16 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
         case .ended:
             guard pausedByInterruption else { break }
             pausedByInterruption = false
-            // Honor iOS's resume hint: it's set for interruptions we should
-            // recover from (calls, Siri, alarms) and cleared when another app
-            // simply took over — so we never grab audio back the user moved
-            // elsewhere. Resuming routes through the "play" command's resumeSink.
-            let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt ?? 0
-            let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
-            if options.contains(.shouldResume) {
+            // We deliberately do not use .shouldResume here as it is not guaranteed
+            // to be set even in cases it should be. As per Apple, it's a hint not
+            // a contract. Instead we track for ourselves if we were interrupted,
+            // and once control is handed back, if another app is now using the
+            // audio device exclusively.
+            if !AVAudioSession.sharedInstance().secondaryAudioShouldBeSilencedHint {
                 print("🎵 NativeAudioController: Resuming server playback after interruption")
                 remoteCommandHandler?.onCommand(command: "play")
+            } else {
+                print("🎵 NativeAudioController: Another app holds audio — staying paused")
             }
         @unknown default:
             break


### PR DESCRIPTION
Gating post-interruption resume on AVAudioSession's .shouldResume stranded playback paused: the flag is only a hint (Apple's word) and is occasionally absent for transient interruptions like notification tones, so a WhatsApp alert could pause MA and never resume it.

Resume whenever interrupted playback ends, unless secondaryAudioShouldBe- SilencedHint reports another non-mixable app is now using the output — the one case where reclaiming audio would steal it from an app the user moved to. This still satisfies the intent of the previous code (don't grab audio back) without depending on an unreliable hint.