### PR TITLE
chore(ios,logging): tag command source for diagnostics

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -898,7 +898,7 @@ class MainDataSource(
         // Go directly through MainDataSource via REST API
         mediaPlayerController.onRemoteCommand = { command ->
             localPlayer.value?.let { playerData ->
-                log.i { "Remote command from Control Center: $command" }
+                log.i { "Remote command: $command" }
                 when (command) {
                     "play" -> playerAction(playerData, PlayerAction.Play)
                     "pause" -> playerAction(playerData, PlayerAction.Pause)

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/player/MediaPlayerController.ios.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/player/MediaPlayerController.ios.kt
@@ -2,6 +2,7 @@
 
 package io.music_assistant.client.player
 
+import co.touchlab.kermit.Logger
 import io.music_assistant.client.player.sendspin.model.AudioCodec
 
 /**
@@ -12,6 +13,7 @@ import io.music_assistant.client.player.sendspin.model.AudioCodec
  * via libFLAC, swift-opus, and PCM passthrough.
  */
 actual class MediaPlayerController actual constructor(platformContext: PlatformContext) {
+    private val log = Logger.withTag("MediaPlayerController")
     private var isPrepared: Boolean = false
 
     // Callback for remote commands from Control Center
@@ -31,10 +33,10 @@ actual class MediaPlayerController actual constructor(platformContext: PlatformC
             player.prepareStream(codec.name.lowercase(), sampleRate, channels, bitDepth, codecHeader, listener)
             isPrepared = true
 
-            // Set up remote command handler for Control Center buttons
+            // Set up remote command handler for iOS-originated commands
             player.setRemoteCommandHandler(object : RemoteCommandHandler {
-                override fun onCommand(command: String) {
-                    println("🎵 MediaPlayerController: Remote command received: $command")
+                override fun onCommand(command: String, source: String) {
+                    log.i { "iOS command [$source]: $command" }
                     onRemoteCommand?.invoke(command)
                 }
             })

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/player/PlatformAudioPlayer.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/player/PlatformAudioPlayer.kt
@@ -58,10 +58,16 @@ interface PlatformAudioPlayer {
 }
 
 /**
- * Handler for remote commands from Control Center/Lock Screen
+ * Handler for player commands originating on the iOS side.
+ *
+ * `source` identifies who issued the command so logs can distinguish a genuine
+ * user action from an automatic one: "remote" (Control Center / lock screen),
+ * "interruption" (audio-session interruption began/ended), or "route_loss"
+ * (output device disappeared). It is diagnostic only — `command` alone drives
+ * playback.
  */
 interface RemoteCommandHandler {
-    fun onCommand(command: String)
+    fun onCommand(command: String, source: String)
 }
 
 /**

--- a/iosApp/NativeAudioController.swift
+++ b/iosApp/NativeAudioController.swift
@@ -80,7 +80,7 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
             if isPlaying {
                 pausedByInterruption = true
                 print("🎵 NativeAudioController: Pausing server playback due to interruption")
-                remoteCommandHandler?.onCommand(command: "pause")
+                remoteCommandHandler?.onCommand(command: "pause", source: "interruption")
             }
         case .ended:
             guard pausedByInterruption else { break }
@@ -92,7 +92,7 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
             // audio device exclusively.
             if !AVAudioSession.sharedInstance().secondaryAudioShouldBeSilencedHint {
                 print("🎵 NativeAudioController: Resuming server playback after interruption")
-                remoteCommandHandler?.onCommand(command: "play")
+                remoteCommandHandler?.onCommand(command: "play", source: "interruption")
             } else {
                 print("🎵 NativeAudioController: Another app holds audio — staying paused")
             }
@@ -133,7 +133,7 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
         bufferLock.lock()
         pcmBuffer.removeAll()
         bufferLock.unlock()
-        remoteCommandHandler?.onCommand(command: "pause")
+        remoteCommandHandler?.onCommand(command: "pause", source: "route_loss")
     }
 
     // MARK: - PlatformAudioPlayer Protocol
@@ -437,7 +437,7 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
 
         NowPlayingManager.shared.setCommandHandler { [weak self] command in
             print("🎵 NativeAudioController: Remote command: \(command)")
-            self?.remoteCommandHandler?.onCommand(command: command)
+            self?.remoteCommandHandler?.onCommand(command: command, source: "remote")
         }
     }
 }


### PR DESCRIPTION
Add a diagnostic "source" to RemoteCommandHandler.onCommand ("remote", "interruption", "route_loss") supplied at each Swift call site, log it through Kermit in MediaPlayerController so it reaches the shared buffer, and update the "Control Center" label in MainDataSource (the command can also come from interruptions, route loss, or Android's media session). Source is diagnostic only; command alone still drives playback, and onRemoteCommand's signature is unchanged so Android (which uses a different mechanism for tracking interruptions) doesn't need changing.