### PR TITLE
fix(queue): load items when queue metadata lands, not on players-only emission

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -227,7 +227,6 @@ class MainDataSource(
 
     private var watchJob: Job? = null
     private var updateJob: Job? = null
-    private var queueItemsGateJob: Job? = null
 
     init {
         // Mirror optimistic-bump stamps into `_queueInfos` so the gate sees them.
@@ -1710,13 +1709,11 @@ class MainDataSource(
                         ?.let { localPlayerRepository.onServerQueueUpdate(it) }
                 }
         }
-        // Gate on queueInfo being merged into _playersData, not just on Data:
-        // the _queueInfos→_playersData combine is debounced, so a players-only
-        // emission (null queueInfo for all) can land first and make
-        // refreshAllPlayersQueueItems skip everyone. Cancel-and-replace bounds
-        // the gate to one — updatePlayersAndQueues re-runs on every reconnect.
-        queueItemsGateJob?.cancel()
-        queueItemsGateJob = launch {
+        launch {
+            // Gate on queueInfo being merged into _playersData, not just on Data:
+            // the _queueInfos→_playersData combine is debounced, so a players-only
+            // emission (null queueInfo for all) can land first and make
+            // refreshAllPlayersQueueItems skip everyone.
             _playersData.first { state ->
                 state is DataState.Data && state.data.any { it.queueInfo != null }
             }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -227,6 +227,7 @@ class MainDataSource(
 
     private var watchJob: Job? = null
     private var updateJob: Job? = null
+    private var queueItemsGateJob: Job? = null
 
     init {
         // Mirror optimistic-bump stamps into `_queueInfos` so the gate sees them.
@@ -1709,11 +1710,16 @@ class MainDataSource(
                         ?.let { localPlayerRepository.onServerQueueUpdate(it) }
                 }
         }
-        launch {
-            // Wait for the players+queues combine to land, then fetch items
-            // for every player. Single-shot per call — runtime queue changes
-            // are covered by QueueItemsUpdatedEvent.
-            _playersData.first { it is DataState.Data }
+        // Gate on queueInfo being merged into _playersData, not just on Data:
+        // the _queueInfos→_playersData combine is debounced, so a players-only
+        // emission (null queueInfo for all) can land first and make
+        // refreshAllPlayersQueueItems skip everyone. Cancel-and-replace bounds
+        // the gate to one — updatePlayersAndQueues re-runs on every reconnect.
+        queueItemsGateJob?.cancel()
+        queueItemsGateJob = launch {
+            _playersData.first { state ->
+                state is DataState.Data && state.data.any { it.queueInfo != null }
+            }
             refreshAllPlayersQueueItems()
         }
     }


### PR DESCRIPTION
This came up as I was testing some unrelated queue stuff. I would intermittently get a blank / empty queue on fresh launch even when I know the server had items in the queue for my device. As soon as I added something to the queue, everything else would appear. Turned out to be a race from the debounce that I was occasionally hitting.

Commit message:

The startup item fan-out gated on _playersData being Data, but the _queueInfos to _playersData combine is debounced: when players arrive more than EVENT_DEBOUNCE before queues, the first Data emission carries null queueInfo for every player, so refreshAllPlayersQueueItems skips them all and never retries. The queue then shows empty until something forces a refetch.

Gate on queueInfo actually being merged in, and cancel-and-replace the gate job so a never-resolving wait (zero-queue session) can't accumulate one suspended _playersData collector per reconnect.