### PR TITLE
Shortcut to global search if lib search is empty

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -94,6 +94,7 @@
   <string name="library_empty">No items found</string>
   <string name="library_error">Error loading data</string>
   <string name="library_quick_search">Quick search</string>
+  <string name="library_search_global">Search everywhere</string>
   <string name="media_type_albums">Albums</string>
   <string name="media_type_artists">Artists</string>
   <string name="media_type_audiobooks">Audiobooks</string>

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -65,6 +65,7 @@ import io.music_assistant.client.ui.compose.nav.AdaptiveNavigationScaffold
 import io.music_assistant.client.ui.compose.nav.MultiBackStack
 import io.music_assistant.client.ui.compose.nav.NavigationItem
 import io.music_assistant.client.ui.compose.nav.createNavigationItem
+import io.music_assistant.client.ui.compose.search.GlobalSearchRequest
 import io.music_assistant.client.ui.compose.search.SearchScreen
 import io.music_assistant.client.ui.compose.search.SearchViewModel
 import io.music_assistant.client.utils.SessionState
@@ -261,6 +262,9 @@ private fun mainNavEntryProvider(
     homeScreenViewModel: HomeScreenViewModel,
     actionsViewModel: ActionsViewModel,
 ): (NavKey) -> NavEntry<NavKey> {
+    // Hoisted here (outlives the per-NavEntry SearchViewModel) to carry an empty-quick-search
+    // escalation from the library tab to the Search tab. Set by ItemList, consumed by SearchScreen.
+    var pendingSearch by remember { mutableStateOf<GlobalSearchRequest?>(null) }
     return entryProvider {
         entry<MainNav.Landing> {
             HomeScreen(
@@ -323,6 +327,11 @@ private fun mainNavEntryProvider(
                 contentPadding = contentPadding,
                 actionsViewModel = actionsViewModel,
                 onBack = { multiBackStack.removeLastOrNull() },
+                onGlobalSearch = { query ->
+                    pendingSearch = GlobalSearchRequest(query, it.mediaType)
+                    multiBackStack.currentBackStack = 2
+                    multiBackStack.resetCurrentBackStack()
+                },
                 onNavigateClick = { item ->
                     when (item) {
                         is Artist,
@@ -385,6 +394,8 @@ private fun mainNavEntryProvider(
                 },
                 contentPadding = contentPadding,
                 actionsViewModel = actionsViewModel,
+                pendingSearch = pendingSearch,
+                onSearchConsumed = { pendingSearch = null },
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemListScreen.kt
@@ -85,6 +85,7 @@ import musicassistantclient.composeapp.generated.resources.common_create
 import musicassistantclient.composeapp.generated.resources.library_empty
 import musicassistantclient.composeapp.generated.resources.library_error
 import musicassistantclient.composeapp.generated.resources.library_quick_search
+import musicassistantclient.composeapp.generated.resources.library_search_global
 import musicassistantclient.composeapp.generated.resources.media_type_albums
 import musicassistantclient.composeapp.generated.resources.media_type_artists
 import musicassistantclient.composeapp.generated.resources.media_type_audiobooks
@@ -104,6 +105,7 @@ fun ItemListScreen(
     contentPadding: PaddingValues,
     actionsViewModel: ActionsViewModel,
     onNavigateClick: (AppMediaItem) -> Unit,
+    onGlobalSearch: (query: String) -> Unit,
     onBack: () -> Unit,
 ) {
     val toastState = rememberToastState()
@@ -140,6 +142,8 @@ fun ItemListScreen(
             showCreatePlaylistDialog = showCreatePlaylistDialog,
             toastState = toastState,
             onNavigateClick = onNavigateClick,
+            onGlobalSearch = onGlobalSearch,
+            searchQuery = state.searchQuery,
             onPlayClick = itemListViewModel::onPlayClick,
             onCreatePlaylistClick = { showCreatePlaylistDialog = true },
             onLoadMore = { itemListViewModel.loadMore() },
@@ -316,6 +320,8 @@ private fun ItemList(
     showCreatePlaylistDialog: Boolean,
     toastState: ToastState,
     onNavigateClick: (AppMediaItem) -> Unit,
+    onGlobalSearch: (query: String) -> Unit,
+    searchQuery: String,
     onPlayClick: (AppMediaItem, QueueOption, Boolean) -> Unit,
     onCreatePlaylistClick: () -> Unit,
     onLoadMore: () -> Unit,
@@ -342,13 +348,13 @@ private fun ItemList(
                 when (val dataState = dataState) {
                     is DataState.Loading -> LoadingState()
                     is DataState.Error -> ErrorState()
-                    is DataState.NoData -> EmptyState()
+                    is DataState.NoData -> EmptyState(searchQuery, onGlobalSearch)
                     is DataState.Stale,
                     is DataState.Data,
                         -> {
                         val items = dataState.dataOrNull.orEmpty()
                         if (items.isEmpty()) {
-                            EmptyState()
+                            EmptyState(searchQuery, onGlobalSearch)
                         } else {
                             Column(modifier = Modifier.fillMaxSize()) {
                                 if (mediaType == MediaType.PLAYLIST) {
@@ -486,15 +492,34 @@ private fun ErrorState() {
 }
 
 @Composable
-private fun EmptyState() {
+private fun EmptyState(
+    searchQuery: String,
+    onGlobalSearch: (query: String) -> Unit,
+) {
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
     ) {
-        Text(
-            text = stringResource(Res.string.library_empty),
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = stringResource(Res.string.library_empty),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            // Offer escalation to global search only when an actual query yielded nothing.
+            if (searchQuery.isNotBlank()) {
+                OutlinedButton(onClick = { onGlobalSearch(searchQuery) }) {
+                    Icon(
+                        Icons.Default.Search,
+                        contentDescription = null,
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(stringResource(Res.string.library_search_global))
+                }
+            }
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
@@ -83,6 +83,8 @@ fun SearchScreen(
     onNavigateToItem: (String, MediaType, String) -> Unit,
     actionsViewModel: ActionsViewModel,
     contentPadding: PaddingValues,
+    pendingSearch: GlobalSearchRequest? = null,
+    onSearchConsumed: () -> Unit = {},
 ) {
     val state by searchViewModel.state.collectAsStateWithLifecycle()
     val toastState = rememberToastState()
@@ -90,6 +92,15 @@ fun SearchScreen(
     LaunchedEffect(Unit) {
         actionsViewModel.toasts.collect { toast ->
             toastState.showToast(toast)
+        }
+    }
+
+    // Escalation from an empty in-library quick search (state hoisted in MainNavigationRoot,
+    // which outlives the per-NavEntry SearchViewModel). Apply once, then clear.
+    LaunchedEffect(pendingSearch) {
+        pendingSearch?.let {
+            searchViewModel.applyGlobalSearch(it)
+            onSearchConsumed()
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchViewModel.kt
@@ -41,6 +41,14 @@ import org.jetbrains.compose.resources.StringResource
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
+/**
+ * Intent to escalate an empty in-library quick search to the global Search tab.
+ *
+ * @param mediaType the referring library's type, used to pre-select the matching filter chip;
+ *   null (or a type with no chip, e.g. GENRE) searches all types.
+ */
+data class GlobalSearchRequest(val query: String, val mediaType: MediaType?)
+
 @OptIn(FlowPreview::class, ExperimentalAtomicApi::class)
 class SearchViewModel(
     private val apiClient: ServiceClient,
@@ -95,6 +103,26 @@ class SearchViewModel(
                 (change.item as? Track)?.let { updateSearchResultsIfNeeded(it) }
             }
         }
+    }
+
+    /**
+     * Escalation from an empty in-library quick search: pre-fill the query, pre-select the
+     * referring library's filter chip, and run the search.
+     */
+    fun applyGlobalSearch(request: GlobalSearchRequest) {
+        _state.update { state ->
+            state.copy(
+                searchState = state.searchState.copy(
+                    query = request.query,
+                    mediaTypes = state.searchState.mediaTypes.map { mediaTypeSelect ->
+                        // Select only the referring type; an unmatched/null type (e.g. GENRE,
+                        // which has no chip) leaves all unselected → search all types.
+                        mediaTypeSelect.copy(isSelected = mediaTypeSelect.type == request.mediaType)
+                    },
+                ),
+            )
+        }
+        searchTrigger.tryEmit(Unit)
     }
 
     fun onQueryChanged(query: String) {


### PR DESCRIPTION
Fixes #456 

I deliberately didn't go Bus way - KISS. We can refactor later if global search is called from somewhere else.