### PR TITLE
Fix home screen hang on Int overflow of media item position

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/factory/MediaItemFactory.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/factory/MediaItemFactory.kt
@@ -78,7 +78,7 @@ class MediaItemFactory(
                 album = album?.let { create(it) as? Album },
                 discNumber = discNumber,
                 trackNumber = trackNumber,
-                position = position,
+                position = position?.takeIf { it in 0L..Int.MAX_VALUE.toLong() }?.toInt(),
                 version = version,
             )
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerMediaItem.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerMediaItem.kt
@@ -33,7 +33,7 @@ data class ServerMediaItem(
     // Album
     @SerialName("version") val version: String? = null,
     // @SerialName("external_ids") val externalIds: List<List<String>>? = null,
-    @SerialName("position") val position: Int? = null,
+    @SerialName("position") val position: Long? = null,
     @SerialName("year") val year: Int? = null,
     @SerialName("artists") val artists: List<ServerMediaItem>? = null,
     // @SerialName("album_type") val albumType: AlbumType? = null,

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/ServerMediaItemSerializationTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/ServerMediaItemSerializationTest.kt
@@ -1,0 +1,51 @@
+package io.music_assistant.client.data.model.server
+
+import io.music_assistant.client.data.factory.MediaItemFactory
+import io.music_assistant.client.data.model.client.MediaType
+import io.music_assistant.client.data.model.client.items.Track
+import io.music_assistant.client.utils.myJson
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * [ServerMediaItem.position] must decode as Long across the full server range,
+ * and only a plausible album ordinal may reach [Track.position] — an
+ * out-of-Int-range value is dropped, never wrapped by `toInt()`.
+ */
+class ServerMediaItemSerializationTest {
+    private val factory = MediaItemFactory(FakeClient())
+
+    private val outOfRangePosition = -1_727_938_860_000L
+    private val validAlbumPosition = 3L
+
+    private fun trackJson(position: Long) = """
+        {"item_id":"t1","provider":"library","name":"Track",
+         "media_type":"${MediaType.TRACK.serverValue}","position":$position}
+    """.trimIndent()
+
+    @Test
+    fun decodesOutOfRangePositionWithoutOverflow() {
+        val item = myJson.decodeFromString<ServerMediaItem>(trackJson(outOfRangePosition))
+
+        assertEquals(outOfRangePosition, item.position)
+    }
+
+    @Test
+    fun factoryDropsOutOfRangeTrackPosition() {
+        val track = factory.create(
+            myJson.decodeFromString<ServerMediaItem>(trackJson(outOfRangePosition)),
+        ) as Track
+
+        assertNull(track.position, "Implausible position must be dropped, not wrapped via toInt()")
+    }
+
+    @Test
+    fun factoryKeepsValidTrackPosition() {
+        val track = factory.create(
+            myJson.decodeFromString<ServerMediaItem>(trackJson(validAlbumPosition)),
+        ) as Track
+
+        assertEquals(validAlbumPosition.toInt(), track.position)
+    }
+}


### PR DESCRIPTION
ServerMediaItem.position was typed Int but the server's range is Long; an out-of-Int value failed the entire music/recommendations decode, leaving the home screen stuck loading. Widen the field to Long and narrow at the domain boundary so only a value that fits a track ordinal reaches Track.position, dropping anything out of range rather than wrapping it via toInt().