### PR TITLE
Set up the app links and deep links

### DIFF
--- a/.well-known/README.md
+++ b/.well-known/README.md
@@ -1,0 +1,46 @@
+# `.well-known/` — App Links / Universal Links association files
+
+These files are **staging copies**. They do nothing in this repo. They must be
+served from the website that answers `https://www.music-assistant.io` (and the
+apex `music-assistant.io`), at exactly:
+
+| File | Must be reachable at | Content-Type |
+|---|---|---|
+| `assetlinks.json` | `https://www.music-assistant.io/.well-known/assetlinks.json` | `application/json` |
+| `apple-app-site-association` | `https://www.music-assistant.io/.well-known/apple-app-site-association` | `application/json` (no extension) |
+
+Requirements for both: HTTPS, HTTP 200, **no redirect**, valid cert. Serve from
+both `www.` and the apex if both hosts should resolve links.
+
+## `assetlinks.json` (Android App Links)
+
+`sha256_cert_fingerprints` lists the signing certs of the APKs users actually
+install. The value committed here is the **debug keystore** fingerprint
+(`~/.android/debug.keystore`) — the cert that signs the `selfSignedRelease`
+build distributed to users (see `androidApp/build.gradle.kts` and the ADI note
+in project memory).
+
+⚠️ **If the app is also installed from Google Play with Play App Signing**, Play
+re-signs the APK with a Play-managed key. That key's SHA256 is **not** the one
+below — copy it from Play Console → *Test and release* → *App integrity* → *App
+signing key certificate* and **add it to the array** (multiple fingerprints are
+allowed). Without it, Play-installed users won't get auto-verified links.
+
+Verify after hosting:
+`adb shell pm get-app-links io.music_assistant.client` → look for `verified`.
+Until then, Android also works via the manual toggle (Settings → Apps → Music
+Assistant → *Open by default* → *Add link*), which needs no file.
+
+## `apple-app-site-association` (iOS Universal Links)
+
+`appID` is `<TeamID>.<bundleId>` = `5J5R9QK64D.io.music-assistant.client`.
+`paths` is scoped to `/app/*` so the rest of the site is untouched.
+
+Two non-code prerequisites on the Apple side:
+1. The **Associated Domains** capability must be enabled on the App ID in the
+   Apple Developer portal, then the provisioning profile regenerated (the
+   `applinks:` entitlement in `iosApp/iosApp/CarPlay.entitlements` fails signing
+   otherwise).
+2. iOS has **no manual override** — until this file is live and fetched, the
+   `https://…/app/…` links open Safari instead of the app. Apple's CDN caches
+   the file, so reinstall the app to force a refetch during testing.

--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -1,0 +1,11 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "5J5R9QK64D.io.music-assistant.client",
+        "paths": ["/app/*"]
+      }
+    ]
+  }
+}

--- a/.well-known/assetlinks.json
+++ b/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "io.music_assistant.client",
+      "sha256_cert_fingerprints": [
+        "79:A9:D6:11:30:20:3E:3D:7A:D5:69:BF:F8:D6:43:4B:B0:35:10:C3:80:C5:9D:A8:FF:F4:9D:7F:C4:EF:88:01"
+      ]
+    }
+  }
+]

--- a/.well-known/assetlinks.json
+++ b/.well-known/assetlinks.json
@@ -5,7 +5,8 @@
       "namespace": "android_app",
       "package_name": "io.music_assistant.client",
       "sha256_cert_fingerprints": [
-        "79:A9:D6:11:30:20:3E:3D:7A:D5:69:BF:F8:D6:43:4B:B0:35:10:C3:80:C5:9D:A8:FF:F4:9D:7F:C4:EF:88:01"
+        "79:A9:D6:11:30:20:3E:3D:7A:D5:69:BF:F8:D6:43:4B:B0:35:10:C3:80:C5:9D:A8:FF:F4:9D:7F:C4:EF:88:01",
+        "B4:A2:9D:A8:82:7F:D5:A3:8F:DA:44:7B:07:CD:00:1C:AE:6B:BC:4D:36:10:A5:06:7E:F4:51:47:5D:A3:EB:27"
       ]
     }
   }

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -28,12 +28,13 @@
         <activity
             android:name=".MainActivity"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"
+            android:launchMode="singleTask"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-            <!-- Custom scheme callback -->
+            <!-- OAuth callback: musicassistant://auth/callback?code=... -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -42,6 +43,39 @@
                     android:scheme="musicassistant"
                     android:host="auth"
                     android:path="/callback" />
+            </intent-filter>
+            <!-- In-app page deep links: musicassistant://app/home|library|search -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="musicassistant"
+                    android:host="app" />
+            </intent-filter>
+            <!--
+                App Links: https://(www.)music-assistant.io/app/<page>. autoVerify
+                attempts Digital Asset Links verification against
+                /.well-known/assetlinks.json on the host. If that file can't be
+                hosted (domain not under our control) verification fails silently
+                and the link is NOT auto-claimed — the user opts in manually via
+                Settings → Apps → Music Assistant → Open by default → Add link.
+
+                Scoped to exactly "/app" and the "/app/" subtree so the site's
+                homepage and any other page (incl. lookalikes like /apps, /apple)
+                stay with the browser. assetlinks.json can't express paths — it is
+                a host-level grant — so this manifest scoping is what keeps the app
+                from shadowing the rest of the site.
+            -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" />
+                <data android:host="www.music-assistant.io" />
+                <data android:host="music-assistant.io" />
+                <data android:path="/app" />
+                <data android:pathPrefix="/app/" />
             </intent-filter>
             <!-- App Actions capability map (actions.intent.PLAY_MEDIA, etc.) -->
             <meta-data

--- a/androidApp/src/main/kotlin/io/music_assistant/client/MainActivity.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.lifecycle.asLiveData
 import co.touchlab.kermit.Logger
+import io.music_assistant.client.api.DeepLinkBus
 import io.music_assistant.client.auth.AuthenticationManager
 import io.music_assistant.client.auth.OAuthHandler
 import io.music_assistant.client.data.MainDataSource
@@ -20,6 +21,7 @@ import org.koin.android.ext.android.inject
 class MainActivity : ComponentActivity() {
     private val dataSource: MainDataSource by inject()
     private val authManager: AuthenticationManager by inject()
+    private val deepLinkBus: DeepLinkBus by inject()
     private val oauthHandler: OAuthHandler by lazy {
         OAuthHandler(this)
     }
@@ -36,8 +38,8 @@ class MainActivity : ComponentActivity() {
         // Provide OAuthHandler to AuthenticationManager
         authManager.oauthHandler = oauthHandler
 
-        // Handle OAuth callback if launched from deep link
-        handleOAuthCallback(intent)
+        // Handle OAuth callback / page deep link if launched from one
+        handleIncomingUri(intent)
 
         dataSource.isAnythingPlaying.asLiveData()
             .observe(this) {
@@ -65,25 +67,35 @@ class MainActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        handleOAuthCallback(intent)
+        // singleTask reuses this instance, so this path is now live (it was dead
+        // under the default standard launchMode). Keep getIntent() in sync.
+        setIntent(intent)
+        handleIncomingUri(intent)
     }
 
-    private fun handleOAuthCallback(intent: Intent?) {
+    /**
+     * Single dispatch point for incoming deep-link URIs. The OAuth callback is
+     * peeled off explicitly; everything else (musicassistant://app/<page> and
+     * the https App Link https://music-assistant.io/app/<page>) is forwarded to
+     * [DeepLinkBus], which self-filters and ignores anything it doesn't
+     * recognize. Only URIs matching a manifest intent-filter ever reach here.
+     */
+    private fun handleIncomingUri(intent: Intent?) {
         val data = intent?.data ?: return
         Logger.withTag("MainActivity").d("Deep link received: $data")
 
-        // Handle musicassistant://auth/callback?code=...
+        // musicassistant://auth/callback?code=...
         if (data.scheme == "musicassistant" && data.host == "auth" && data.path == "/callback") {
             val token = data.getQueryParameter("code")
-            Logger.withTag("MainActivity").d("Custom scheme callback - token: ${token != null}")
-
+            Logger.withTag("MainActivity").d("OAuth callback - token: ${token != null}")
             if (token != null) {
-                // Deliver token directly to AuthenticationManager
                 authManager.handleOAuthCallback(token)
             } else {
                 Logger.withTag("MainActivity").e("No token in OAuth callback")
             }
+            return
         }
+        deepLinkBus.handle(data.toString())
     }
 
     companion object {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/DeepLinkBus.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/DeepLinkBus.kt
@@ -1,0 +1,103 @@
+package io.music_assistant.client.api
+
+import io.ktor.http.Url
+import io.music_assistant.client.data.model.client.MediaType
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/** A page reachable via a `musicassistant://app/<page>` deep link. */
+sealed interface DeepLinkDestination {
+    data object Home : DeepLinkDestination
+
+    /** Library tab. [mediaType] null = tab root; set = a category list (`/library/<category>`). */
+    data class Library(val mediaType: MediaType? = null) : DeepLinkDestination
+
+    // Future: data class Search(query: String?) — wire query through the
+    // existing pendingSearch hoist in MainNavRoot when needed.
+    data object Search : DeepLinkDestination
+
+    /** Expand the players (now-playing) layout over the current tab. */
+    data object Players : DeepLinkDestination
+}
+
+/**
+ * App-wide carrier for in-app navigation deep links arriving from outside the
+ * Compose tree (Android Intents, iOS `onOpenURL` / Universal Links).
+ *
+ * Holds the *latest pending* destination in a retained [StateFlow] rather than a
+ * one-shot channel. This is deliberate: the consumer
+ * ([io.music_assistant.client.ui.compose.home.MainNavigationRoot]) can be
+ * composed, torn down, and re-composed during the cold-launch auth churn
+ * (Main → Settings → Main as `sessionState` resolves). A one-shot channel gets
+ * drained by the first, doomed instance and the rebuilt instance sees nothing.
+ * A retained value survives that churn: the consumer applies it only once it is
+ * authenticated and then calls [consume] to clear it, so it is honored exactly
+ * once by the instance that actually stays on screen.
+ */
+class DeepLinkBus {
+    private val _pending = MutableStateFlow<DeepLinkDestination?>(null)
+    val pending: StateFlow<DeepLinkDestination?> = _pending.asStateFlow()
+
+    /**
+     * Parses a page deep link and stores it as the pending destination. Accepts
+     * both forms:
+     *  - custom scheme:    `musicassistant://app/<page>`         (host == "app")
+     *  - App/Universal Link: `https://<domain>/app/<page>`       (first path segment == "app")
+     *
+     * The owning domain is enforced by the OS (Android intent-filter / iOS
+     * associated-domains), so we key only on the `app` marker and the page
+     * segment — keeping this layer domain-agnostic. Silently ignores anything
+     * that isn't a recognized page link (OAuth callbacks, unknown paths,
+     * unrelated URLs). Non-suspending; safe to call from any context.
+     */
+    fun handle(urlString: String) {
+        val url = runCatching { Url(urlString) }.getOrNull() ?: return
+        val segments = url.encodedPath.split('/').filter { it.isNotEmpty() }
+        val route = when {
+            url.host == "app" -> segments              // musicassistant://app/<route...>
+            segments.firstOrNull() == "app" -> segments.drop(1) // https://<domain>/app/<route...>
+            else -> return
+        }
+        val dest = when (route.firstOrNull() ?: "home") {  // bare ".../app" → home
+            "home" -> DeepLinkDestination.Home
+            "library" -> {
+                // /library → tab root; /library/<category> → that category list.
+                // A present-but-unknown category is rejected (whole link ignored)
+                // rather than silently landing on the tab root.
+                val sub = route.getOrNull(1)
+                DeepLinkDestination.Library(
+                    mediaType = if (sub == null) null else LIBRARY_ROUTES[sub] ?: return,
+                )
+            }
+            "search" -> DeepLinkDestination.Search
+            "players" -> DeepLinkDestination.Players
+            else -> return
+        }
+        _pending.value = dest
+    }
+
+    /** Clear [dest] once applied. No-op if a newer link superseded it meanwhile. */
+    fun consume(dest: DeepLinkDestination) {
+        _pending.compareAndSet(dest, null)
+    }
+
+    companion object {
+        /**
+         * Deep-link contract for `/library/<category>` segments. Intentionally
+         * an explicit table (not derived from a UI enum) so this layer stays
+         * UI-independent and the public URL names are stable. Plural by
+         * convention, matching the in-app category labels.
+         */
+        private val LIBRARY_ROUTES = mapOf(
+            "artists" to MediaType.ARTIST,
+            "albums" to MediaType.ALBUM,
+            "tracks" to MediaType.TRACK,
+            "playlists" to MediaType.PLAYLIST,
+            "audiobooks" to MediaType.AUDIOBOOK,
+            "podcasts" to MediaType.PODCAST,
+            "radios" to MediaType.RADIO,
+            "genres" to MediaType.GENRE,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/di/SharedModule.kt
@@ -1,5 +1,6 @@
 package io.music_assistant.client.di
 
+import io.music_assistant.client.api.DeepLinkBus
 import io.music_assistant.client.api.ErrorMessageBus
 import io.music_assistant.client.api.KtorServiceClient
 import io.music_assistant.client.api.ServiceClient
@@ -42,6 +43,7 @@ fun sharedModule(
         singleOf(::SettingsRepository)
         singleOf(::NetworkMonitor)
         singleOf(::ErrorMessageBus)
+        singleOf(::DeepLinkBus)
         singleOf(::ImageCacheInvalidator)
         singleOf(serviceClientConstructor) { bind<ServiceClient>() }
         singleOf(::LogSharer)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -37,6 +37,8 @@ import androidx.navigation3.runtime.rememberDecoratedNavEntries
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.savedstate.serialization.SavedStateConfiguration
+import io.music_assistant.client.api.DeepLinkBus
+import io.music_assistant.client.api.DeepLinkDestination
 import io.music_assistant.client.api.ErrorMessageBus
 import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.items.Album
@@ -70,6 +72,7 @@ import io.music_assistant.client.ui.compose.nav.createNavigationItem
 import io.music_assistant.client.ui.compose.search.GlobalSearchRequest
 import io.music_assistant.client.ui.compose.search.SearchScreen
 import io.music_assistant.client.ui.compose.search.SearchViewModel
+import io.music_assistant.client.utils.DataConnectionState
 import io.music_assistant.client.utils.SessionState
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.serialization.Serializable
@@ -98,6 +101,7 @@ fun MainNavigationRoot(
     val uriHandler = LocalUriHandler.current
     val toastState = rememberToastState()
     val errorBus: ErrorMessageBus = koinInject()
+    val deepLinkBus: DeepLinkBus = koinInject()
 
     LaunchedEffect(Unit) {
         homeScreenViewModel.links.collectLatest { url -> uriHandler.openUri(url) }
@@ -152,6 +156,46 @@ fun MainNavigationRoot(
         rememberMainNavBackStack(MainNav.Search),
     )
     val multiBackStack = remember { MultiBackStack(backStacks) }
+
+    // Apply a pending navigation deep link (musicassistant://app/<page> or the
+    // https App/Universal Link). The destination is retained upstream, and we
+    // gate on Authenticated + re-key on connectionState so that the transient
+    // pre-auth MainNavigationRoot instance — torn down during the cold-launch
+    // Main→Settings→Main churn — never consumes it; only the authenticated
+    // instance that stays on screen applies and clears it.
+    val pendingDeepLink by deepLinkBus.pending.collectAsStateWithLifecycle()
+    LaunchedEffect(pendingDeepLink, connectionState) {
+        val dest = pendingDeepLink ?: return@LaunchedEffect
+        val authenticated = (connectionState as? SessionState.Connected)
+            ?.dataConnectionState == DataConnectionState.Authenticated
+        if (!authenticated) return@LaunchedEffect
+        when (dest) {
+            DeepLinkDestination.Home -> {
+                multiBackStack.currentBackStack = 0
+                multiBackStack.resetCurrentBackStack()
+            }
+
+            is DeepLinkDestination.Library -> {
+                multiBackStack.currentBackStack = 1
+                multiBackStack.resetCurrentBackStack()
+                // /library/<category> → push the category list onto the Library tab.
+                dest.mediaType?.let { multiBackStack.add(MainNav.ItemList(it)) }
+            }
+
+            DeepLinkDestination.Search -> {
+                multiBackStack.currentBackStack = 2
+                multiBackStack.resetCurrentBackStack()
+            }
+
+            DeepLinkDestination.Players -> {
+                // Expand the now-playing layout over the current tab (the
+                // FloatingBar is global, so no tab switch needed). The pager
+                // renders its own empty state if no player is present.
+                playerExpanded = true
+            }
+        }
+        deepLinkBus.consume(dest)
+    }
 
     val navigationItems = listOf(
         multiBackStack.createNavigationItem(

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
@@ -7,6 +7,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.readRawBytes
 import io.ktor.http.Url
+import io.music_assistant.client.api.DeepLinkBus
 import io.music_assistant.client.api.Request
 import io.music_assistant.client.api.ServiceClient
 import io.music_assistant.client.auth.AuthenticationManager
@@ -57,6 +58,7 @@ object KmpHelper : KoinComponent {
     val mainDataSource: MainDataSource by inject()
     val serviceClient: ServiceClient by inject()
     val authManager: AuthenticationManager by inject()
+    private val deepLinkBus: DeepLinkBus by inject()
     private val mediaItemRepository: MediaItemRepository by inject()
     private val artworkHttpClient: HttpClient by inject(named("webrtcHttpClient"))
 
@@ -78,6 +80,13 @@ object KmpHelper : KoinComponent {
             ?.serverInfo
             ?.serverId
     }
+
+    /**
+     * Route a `musicassistant://app/<page>` URL into the navigation deep-link
+     * bus. Parsing/validation lives in [DeepLinkBus]; non-matching URLs are
+     * silently ignored.
+     */
+    fun handleDeepLink(urlString: String) = deepLinkBus.handle(urlString)
 
     // MARK: - External Consumer Lifecycle (CarPlay)
 

--- a/iosApp/iosApp/CarPlay.entitlements
+++ b/iosApp/iosApp/CarPlay.entitlements
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:www.music-assistant.io</string>
+		<string>applinks:music-assistant.io</string>
+	</array>
 	<key>com.apple.developer.carplay-audio</key>
 	<true/>
 	<key>com.apple.developer.siri</key>

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -28,27 +28,31 @@ enum KmpState {
     static let readyNotification = Notification.Name("KMPReadyNotification")
 }
 
-/// Buffers an OAuth callback URL when it arrives before Koin is initialized
-/// (cold-launch-from-deep-link). Replayed by ContentView.onAppear once
-/// KmpState.isReady == true. Accessed only from the main thread.
-enum PendingOAuthCallback {
+/// Buffers an incoming musicassistant:// URL when it arrives before Koin is
+/// initialized (cold-launch-from-deep-link). Replayed by ContentView.onAppear
+/// once KmpState.isReady == true. Accessed only from the main thread.
+enum PendingURL {
     static var url: URL?
 }
 
-/// Parses a musicassistant://auth/callback?code=... URL and hands the token
-/// to AuthenticationManager. Matches the shape Android's MainActivity parses
-/// in handleOAuthCallback (MainActivity.kt:64-80). Silently returns for URLs
-/// that don't match — we can't assume this app is the only handler of the
-/// scheme.
-func handleOAuthCallback(_ url: URL) {
-    guard url.scheme == "musicassistant",
-          url.host == "auth",
-          url.path == "/callback",
-          let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-          let code = components.queryItems?.first(where: { $0.name == "code" })?.value
-    else { return }
-
-    KmpHelper.shared.authManager.handleOAuthCallback(token: code)
+/// Single dispatch point for incoming deep links — mirrors Android's
+/// MainActivity.handleIncomingUri. Two entry forms reach here:
+///   - custom scheme  musicassistant://auth/callback   → OAuth (peeled off)
+///   - custom scheme  musicassistant://app/<page>       → DeepLinkBus
+///   - Universal Link https://…music-assistant.io/app/<page> → DeepLinkBus
+/// The OAuth callback is handled explicitly; everything else is forwarded to
+/// the shared DeepLinkBus, which self-filters and ignores anything it doesn't
+/// recognize.
+func handleIncomingURL(_ url: URL) {
+    if url.scheme == "musicassistant", url.host == "auth" {
+        guard url.path == "/callback",
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let code = components.queryItems?.first(where: { $0.name == "code" })?.value
+        else { return }
+        KmpHelper.shared.authManager.handleOAuthCallback(token: code)
+        return
+    }
+    KmpHelper.shared.handleDeepLink(urlString: url.absoluteString)
 }
 
 class AppDelegate: NSObject, UIApplicationDelegate {
@@ -146,16 +150,27 @@ struct iOSApp: App {
                     // requires a live scene, so can't move to `init()`.
                     KmpHelper.shared.authManager.oauthHandler = OAuthHandler()
 
-                    if let pending = PendingOAuthCallback.url {
-                        PendingOAuthCallback.url = nil
-                        handleOAuthCallback(pending)
+                    if let pending = PendingURL.url {
+                        PendingURL.url = nil
+                        handleIncomingURL(pending)
                     }
                 }
                 .onOpenURL { url in
+                    // Custom-scheme links (musicassistant://…).
                     if KmpState.isReady {
-                        handleOAuthCallback(url)
+                        handleIncomingURL(url)
                     } else {
-                        PendingOAuthCallback.url = url
+                        PendingURL.url = url
+                    }
+                }
+                .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
+                    // Universal Links (https://…music-assistant.io/app/…) arrive
+                    // as a web-browsing NSUserActivity, not via onOpenURL.
+                    guard let url = activity.webpageURL else { return }
+                    if KmpState.isReady {
+                        handleIncomingURL(url)
+                    } else {
+                        PendingURL.url = url
                     }
                 }
         }


### PR DESCRIPTION
Fixes #538 
Will require adding specific files to the domain.
Android app can be set up in settings to work with links.

Link to open: https://music-assistant.io/app/{path}

| URL suffix    | Result |
| ------------- | ------------- |
| /home   | Home tab  |
| /library · /library/{tracks,albums,artists,playlists,audiobooks,podcasts,radios,genres}  | Library root / category list
| /search | Search tab |
| /players  | Expand now-playing layout |

  