### PR TITLE
feat(carplay): localize CarPlay strings via shared catalog (#542)

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
+  <string name="action_add_all_to_queue">Add all to queue</string>
   <string name="action_add_to_library">Add to library</string>
   <string name="action_add_to_playlist">Add to playlist</string>
   <string name="action_add_to_queue">Add to queue</string>
+  <string name="action_browse">Browse</string>
   <string name="action_favorite">Favorite</string>
   <string name="action_go_to_album">Go to album</string>
   <string name="action_go_to_artist">Go to artist</string>
@@ -10,15 +12,18 @@
   <string name="action_insert_next_and_play">Add next and play</string>
   <string name="action_mark_played">Mark as played</string>
   <string name="action_mark_unplayed">Mark as unplayed</string>
+  <string name="action_ok">OK</string>
   <string name="action_pause">Pause</string>
   <string name="action_customize">Customize…</string>
   <string name="action_play">Play</string>
+  <string name="action_play_all">Play all</string>
   <string name="action_play_next">Play next</string>
   <string name="action_play_now">Play now</string>
   <string name="action_remove_from_library">Remove from library</string>
   <string name="action_remove_from_playlist">Remove from playlist</string>
   <string name="action_start_radio">Start radio</string>
   <string name="action_unfavorite">Unfavorite</string>
+  <string name="albums_by_artist">Albums by %1$s</string>
   <string name="clickctx_album">Album</string>
   <string name="clickctx_artist">Artist</string>
   <string name="clickctx_detail">Play button</string>
@@ -54,6 +59,7 @@
   <string name="bound_player_part_of_group">%1$s is part of group %2$s\n(tap to view)</string>
   <string name="bound_player_playing_with">%1$s is playing with %2$s\n(tap to view)</string>
   <string name="bound_player_playing_with_group">%1$s is playing with group %2$s\n(tap to view)</string>
+  <string name="browse_subtitle">Artists, Albums, Tracks &amp; more</string>
   <string name="cd_add_playlist">Add playlist</string>
   <string name="cd_add_to_group">Add to group</string>
   <string name="cd_applied">Applied</string>
@@ -87,6 +93,7 @@
   <string name="common_create">Create</string>
   <string name="common_delete">Delete</string>
   <string name="common_done">Done</string>
+  <string name="connection_lost">Disconnected — reconnecting…</string>
   <string name="dsp_enable">Enable DSP</string>
   <string name="dsp_error">Failed to load DSP configuration</string>
   <string name="dsp_presets">Presets</string>
@@ -114,6 +121,7 @@
   <string name="library_error">Error loading data</string>
   <string name="library_quick_search">Quick search</string>
   <string name="library_search_global">Search everywhere</string>
+  <string name="loading">Loading…</string>
   <string name="media_type_albums">Albums</string>
   <string name="media_type_artists">Artists</string>
   <string name="media_type_audiobooks">Audiobooks</string>
@@ -129,6 +137,7 @@
   <string name="nav_library">Library</string>
   <string name="nav_search">Search</string>
   <string name="nav_settings">Settings</string>
+  <string name="not_connected_retry">Not connected — try again when reconnected</string>
   <string name="players_dsp_settings">DSP settings</string>
   <string name="players_group_settings">Group settings</string>
   <string name="players_group_volume">%1$s group volume</string>

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/carplay/CarPlayStrings.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/carplay/CarPlayStrings.kt
@@ -1,0 +1,78 @@
+package io.music_assistant.client.carplay
+
+import musicassistantclient.composeapp.generated.resources.Res
+import musicassistantclient.composeapp.generated.resources.action_add_all_to_queue
+import musicassistantclient.composeapp.generated.resources.action_browse
+import musicassistantclient.composeapp.generated.resources.action_ok
+import musicassistantclient.composeapp.generated.resources.action_play_all
+import musicassistantclient.composeapp.generated.resources.albums_by_artist
+import musicassistantclient.composeapp.generated.resources.browse_subtitle
+import musicassistantclient.composeapp.generated.resources.connection_lost
+import musicassistantclient.composeapp.generated.resources.library_empty
+import musicassistantclient.composeapp.generated.resources.loading
+import musicassistantclient.composeapp.generated.resources.media_type_albums
+import musicassistantclient.composeapp.generated.resources.media_type_artists
+import musicassistantclient.composeapp.generated.resources.media_type_audiobooks
+import musicassistantclient.composeapp.generated.resources.media_type_playlists
+import musicassistantclient.composeapp.generated.resources.media_type_podcasts
+import musicassistantclient.composeapp.generated.resources.media_type_radio
+import musicassistantclient.composeapp.generated.resources.media_type_tracks
+import musicassistantclient.composeapp.generated.resources.nav_library
+import musicassistantclient.composeapp.generated.resources.not_connected_retry
+import org.jetbrains.compose.resources.getString
+
+/**
+ * CarPlay UI strings resolved once for the active locale from the shared
+ * Compose string catalog — the same Lokalise-managed source the rest of the
+ * app uses. This keeps CarPlay in lockstep with app translations instead of
+ * shipping a separate iOS string store. Swift reads the fields synchronously
+ * after [load] completes (template titles are immutable once constructed, so
+ * they must be known before the first template is built).
+ */
+class CarPlayStrings internal constructor(
+    val library: String,
+    val browse: String,
+    val browseSubtitle: String,
+    val loading: String,
+    val empty: String,
+    val playAll: String,
+    val addAllToQueue: String,
+    val ok: String,
+    val offlineAlert: String,
+    val disconnected: String,
+    val artists: String,
+    val albums: String,
+    val tracks: String,
+    val playlists: String,
+    val audiobooks: String,
+    val podcasts: String,
+    val radio: String,
+    private val albumsByArtistTemplate: String,
+) {
+    /** Localized "Albums by <artist>" drilldown title. */
+    fun albumsByArtist(name: String): String =
+        albumsByArtistTemplate.replace("%1\$s", name)
+
+    companion object {
+        suspend fun load(): CarPlayStrings = CarPlayStrings(
+            library = getString(Res.string.nav_library),
+            browse = getString(Res.string.action_browse),
+            browseSubtitle = getString(Res.string.browse_subtitle),
+            loading = getString(Res.string.loading),
+            empty = getString(Res.string.library_empty),
+            playAll = getString(Res.string.action_play_all),
+            addAllToQueue = getString(Res.string.action_add_all_to_queue),
+            ok = getString(Res.string.action_ok),
+            offlineAlert = getString(Res.string.not_connected_retry),
+            disconnected = getString(Res.string.connection_lost),
+            artists = getString(Res.string.media_type_artists),
+            albums = getString(Res.string.media_type_albums),
+            tracks = getString(Res.string.media_type_tracks),
+            playlists = getString(Res.string.media_type_playlists),
+            audiobooks = getString(Res.string.media_type_audiobooks),
+            podcasts = getString(Res.string.media_type_podcasts),
+            radio = getString(Res.string.media_type_radio),
+            albumsByArtistTemplate = getString(Res.string.albums_by_artist),
+        )
+    }
+}

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
@@ -11,6 +11,7 @@ import io.music_assistant.client.api.DeepLinkBus
 import io.music_assistant.client.api.Request
 import io.music_assistant.client.api.ServiceClient
 import io.music_assistant.client.auth.AuthenticationManager
+import io.music_assistant.client.carplay.CarPlayStrings
 import io.music_assistant.client.data.MainDataSource
 import io.music_assistant.client.data.executeLocalPlayerDispatch
 import io.music_assistant.client.data.model.client.MediaType
@@ -89,6 +90,16 @@ object KmpHelper : KoinComponent {
     fun handleDeepLink(urlString: String) = deepLinkBus.handle(urlString)
 
     // MARK: - External Consumer Lifecycle (CarPlay)
+
+    /**
+     * Resolve CarPlay UI strings for the current locale off the shared Compose
+     * catalog. Async because the resource read is suspending; CarPlay defers
+     * building its first template until [completion] fires so immutable
+     * template titles are never blank.
+     */
+    fun loadCarPlayStrings(completion: (CarPlayStrings) -> Unit) {
+        mainScope.launch { completion(CarPlayStrings.load()) }
+    }
 
     fun onExternalConsumerActive() = serviceClient.onExternalConsumerActive()
     fun onExternalConsumerInactive() = serviceClient.onExternalConsumerInactive()

--- a/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
+++ b/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
@@ -19,6 +19,10 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     private var isReady: Bool = false
     private var readinessSubscription: Cancellable?
 
+    // Localized CarPlay strings, resolved from the shared Compose catalog once
+    // per connect (see didConnect). Always set before any template is built.
+    private var strings: CarPlayStrings?
+
     // Weakly held so a connectivity restore can re-fire the homepage fetch
     // without retaining the template after CarPlay disconnects.
     private weak var libraryTemplate: CPListTemplate?
@@ -43,13 +47,20 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
         recommendationsFetchGen = 0
         isReady = false
         KmpHelper.shared.onExternalConsumerActive()
-        // The initial fetch is driven from handleReadinessChange's first
-        // emission, not from setupTemplates — see createLibraryTemplate.
+        // Resolve localized strings before building templates: CarPlay template
+        // titles are immutable after construction, so the active-locale strings
+        // must be known up front. Subscribing to readiness inside the completion
+        // preserves the subscribe-before-setupTemplates ordering that drives the
+        // initial Library fetch (see handleReadinessChange / createLibraryTemplate).
         // `(Boolean) -> Unit` from Kotlin exposes as `KotlinBoolean`; unbox.
-        readinessSubscription = KmpHelper.shared.observeReadiness { [weak self] ready in
-            self?.handleReadinessChange(ready.boolValue)
+        KmpHelper.shared.loadCarPlayStrings { [weak self] loaded in
+            guard let self = self, self.interfaceController != nil else { return }
+            self.strings = loaded
+            self.readinessSubscription = KmpHelper.shared.observeReadiness { [weak self] ready in
+                self?.handleReadinessChange(ready.boolValue)
+            }
+            self.setupTemplates()
         }
-        setupTemplates()
     }
 
     func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene, didDisconnectInterfaceController interfaceController: CPInterfaceController) {
@@ -108,12 +119,13 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     /// Idempotent — CarPlay throws on stacked presentations.
     private func showOfflineAlert() {
         guard let interfaceController = interfaceController,
+              let strings = strings,
               interfaceController.presentedTemplate == nil
         else { return }
         let alert = CPAlertTemplate(
-            titleVariants: ["Not connected — try again when reconnected"],
+            titleVariants: [strings.offlineAlert],
             actions: [
-                CPAlertAction(title: "OK", style: .default) { [weak self] _ in
+                CPAlertAction(title: strings.ok, style: .default) { [weak self] _ in
                     self?.interfaceController?.dismissTemplate(animated: true, completion: nil)
                 }
             ]
@@ -125,7 +137,8 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     /// the local player gains a track (subscription-based because the
     /// local-player value is cleared on backgrounded disconnect).
     private func setupTemplates() {
-        let libraryTemplate = createLibraryTemplate()
+        guard let strings = strings else { return }
+        let libraryTemplate = createLibraryTemplate(strings)
         interfaceController?.setRootTemplate(libraryTemplate, animated: true) { [weak self] _, _ in
             self?.subscribeToLocalPlayerForInitialPush()
         }
@@ -154,17 +167,6 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     }
 
     // MARK: - UI Construction
-
-    // Match Material Design icons from HomeScreen.kt LibraryRow
-    private static let categoryIcons: [(name: String, symbol: String)] = [
-        ("Artists", "mic.fill"),                          // Icons.Default.Mic
-        ("Albums", "opticaldisc.fill"),                   // Icons.Default.Album
-        ("Tracks", "music.note"),                         // Icons.Default.MusicNote
-        ("Playlists", "list.bullet.rectangle.fill"),      // Icons.AutoMirrored.Filled.FeaturedPlayList
-        ("Audiobooks", "book.fill"),                      // Icons.AutoMirrored.Filled.MenuBook
-        ("Podcasts", "antenna.radiowaves.left.and.right"), // Icons.Default.Podcasts
-        ("Radio", "radio.fill"),                          // Icons.Default.Radio
-    ]
 
     // App theme colors from Color.kt, adaptive for light/dark mode
     // Light: primaryContainer ≈ #E0DEFF, primary = #575992
@@ -218,10 +220,10 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
         return asset.image(with: UITraitCollection.current)
     }
 
-    private func createLibraryTemplate() -> CPListTemplate {
+    private func createLibraryTemplate(_ strings: CarPlayStrings) -> CPListTemplate {
         // "Browse" item pushes a CPGridTemplate with all categories
         let browseIcon = Self.dynamicCategoryImage(symbol: "square.grid.2x2.fill", size: CPListItem.maximumImageSize)
-        let browseItem = CPListItem(text: "Browse", detailText: "Artists, Albums, Tracks & more", image: browseIcon)
+        let browseItem = CPListItem(text: strings.browse, detailText: strings.browseSubtitle, image: browseIcon)
         browseItem.handler = { [weak self] _, completion in
             self?.pushBrowseGrid()
             completion()
@@ -234,14 +236,14 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
         )
 
         // Section 2+: Recommendation folders (starts with loading placeholder)
-        let loadingItem = CPListItem(text: "Loading...", detailText: nil)
+        let loadingItem = CPListItem(text: strings.loading, detailText: nil)
         let loadingSection = CPListSection(
             items: [loadingItem],
             header: nil,
             sectionIndexTitle: nil
         )
 
-        let libraryList = CPListTemplate(title: "Library", sections: [browseSection, loadingSection])
+        let libraryList = CPListTemplate(title: strings.library, sections: [browseSection, loadingSection])
 
         // Weak refs feed `refreshLibraryOnReconnect`, which is the sole
         // path that fires `loadRecommendations` — including the initial
@@ -255,6 +257,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     // MARK: - Data Loading Helpers
 
     private func loadRecommendations(for template: CPListTemplate, browseSection: CPListSection) {
+        guard let strings = strings else { return }
         recommendationsFetchGen += 1
         let myGen = recommendationsFetchGen
         os_log("CP: loadRecommendations gen=%{public}d", log: cpLog, type: .default, myGen)
@@ -274,7 +277,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
             guard let folders = folders else {
                 template.updateSections([
                     browseSection,
-                    CPListSection(items: [self.disconnectedRow()], header: nil, sectionIndexTitle: nil),
+                    CPListSection(items: [self.disconnectedRow(strings)], header: nil, sectionIndexTitle: nil),
                 ])
                 return
             }
@@ -282,7 +285,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
             if folders.isEmpty {
                 template.updateSections([
                     browseSection,
-                    self.emptyStateSection(text: "No recommendations"),
+                    self.emptyStateSection(text: strings.empty),
                 ])
                 return
             }
@@ -357,24 +360,27 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
         // Gate at entry. The grid template's category fetchers would otherwise
         // spin indefinitely on a dead transport.
         guard isReady else { showOfflineAlert(); return }
+        guard let strings = strings else { return }
         let imageSize = CGSize(width: 100, height: 100)
         let manager = CarPlayContentManager.shared
-        let categories: [(title: String, fetcher: (@escaping ([CPListItem]?) -> Void) -> Void)] = [
-            ("Artists",    manager.fetchArtists),
-            ("Albums",     manager.fetchAlbums),
-            ("Tracks",     manager.fetchTracks),
-            ("Playlists",  manager.fetchPlaylists),
-            ("Audiobooks", manager.fetchAudiobooks),
-            ("Podcasts",   manager.fetchPodcasts),
-            ("Radio",      manager.fetchRadioStations),
+        // Symbols match Material Design icons from HomeScreen.kt LibraryRow;
+        // titles come from the shared catalog so they follow the app locale.
+        let categories: [(title: String, symbol: String, fetcher: (@escaping ([CPListItem]?) -> Void) -> Void)] = [
+            (strings.artists,    "mic.fill",                          manager.fetchArtists),       // Icons.Default.Mic
+            (strings.albums,     "opticaldisc.fill",                  manager.fetchAlbums),        // Icons.Default.Album
+            (strings.tracks,     "music.note",                        manager.fetchTracks),        // Icons.Default.MusicNote
+            (strings.playlists,  "list.bullet.rectangle.fill",        manager.fetchPlaylists),     // Icons.AutoMirrored.Filled.FeaturedPlayList
+            (strings.audiobooks, "book.fill",                         manager.fetchAudiobooks),    // Icons.AutoMirrored.Filled.MenuBook
+            (strings.podcasts,   "antenna.radiowaves.left.and.right", manager.fetchPodcasts),      // Icons.Default.Podcasts
+            (strings.radio,      "radio.fill",                        manager.fetchRadioStations), // Icons.Default.Radio
         ]
-        let buttons = zip(Self.categoryIcons, categories).map { icon, category -> CPGridButton in
-            let image = Self.dynamicCategoryImage(symbol: icon.symbol, size: imageSize)
-            return CPGridButton(titleVariants: [icon.name], image: image) { [weak self] _ in
+        let buttons = categories.map { category -> CPGridButton in
+            let image = Self.dynamicCategoryImage(symbol: category.symbol, size: imageSize)
+            return CPGridButton(titleVariants: [category.title], image: image) { [weak self] _ in
                 self?.pushCategoryTemplate(title: category.title, fetcher: category.fetcher)
             }
         }
-        let gridTemplate = CPGridTemplate(title: "Browse", gridButtons: buttons)
+        let gridTemplate = CPGridTemplate(title: strings.browse, gridButtons: buttons)
         self.interfaceController?.pushTemplate(gridTemplate, animated: true, completion: nil)
     }
 
@@ -384,8 +390,9 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
         title: String,
         fetcher: (@escaping ([CPListItem]?) -> Void) -> Void
     ) {
+        guard let strings = strings else { return }
         let template = CPListTemplate(title: title, sections: [])
-        let loadingItem = CPListItem(text: "Loading...", detailText: nil)
+        let loadingItem = CPListItem(text: strings.loading, detailText: nil)
         template.updateSections([CPListSection(items: [loadingItem])])
 
         self.interfaceController?.pushTemplate(template, animated: true, completion: nil)
@@ -394,13 +401,13 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
             guard let self = self else { return }
             if let items = items {
                 if items.isEmpty {
-                    template.updateSections([emptyStateSection(text: "No \(title.lowercased())")])
+                    template.updateSections([self.emptyStateSection(text: strings.empty)])
                 } else {
                     self.attachHandlers(to: items)
                     template.updateSections([CPListSection(items: items)])
                 }
             } else {
-                template.updateSections([CPListSection(items: [disconnectedRow()])])
+                template.updateSections([CPListSection(items: [self.disconnectedRow(strings)])])
             }
         }
     }
@@ -461,9 +468,9 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     // MARK: - Drilldown push helpers
 
     private func pushAlbumsForArtist(_ artist: Artist) {
+        guard let strings = strings else { return }
         pushDrilldown(
-            title: "Albums by \(artist.displayName)",
-            emptyText: "No albums for \(artist.displayName)",
+            title: strings.albumsByArtist(name: artist.displayName),
             bulkActionParent: artist
         ) { completion in
             CarPlayContentManager.shared.fetchAlbumsForArtist(artist, completion: completion)
@@ -473,7 +480,6 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     private func pushTracksForAlbum(_ album: Album) {
         pushDrilldown(
             title: album.displayName,
-            emptyText: "No tracks in this album",
             bulkActionParent: album
         ) { completion in
             CarPlayContentManager.shared.fetchTracksForAlbum(album, completion: completion)
@@ -483,7 +489,6 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     private func pushTracksForPlaylist(_ playlist: Playlist) {
         pushDrilldown(
             title: playlist.displayName,
-            emptyText: "No tracks in this playlist",
             bulkActionParent: playlist
         ) { completion in
             CarPlayContentManager.shared.fetchTracksForPlaylist(playlist, completion: completion)
@@ -494,12 +499,12 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     /// empty-state on `[]`, disconnected row on `nil` (timeout).
     private func pushDrilldown(
         title: String,
-        emptyText: String,
         bulkActionParent: AppMediaItem,
         fetcher: @escaping (@escaping ([CPListItem]?) -> Void) -> Void
     ) {
+        guard let strings = strings else { return }
         let template = CPListTemplate(title: title, sections: [])
-        let loadingItem = CPListItem(text: "Loading...", detailText: nil)
+        let loadingItem = CPListItem(text: strings.loading, detailText: nil)
         template.updateSections([CPListSection(items: [loadingItem])])
         self.interfaceController?.pushTemplate(template, animated: true, completion: nil)
 
@@ -507,14 +512,14 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
             guard let self = self else { return }
             if let items = items {
                 if items.isEmpty {
-                    template.updateSections([emptyStateSection(text: emptyText)])
+                    template.updateSections([self.emptyStateSection(text: strings.empty)])
                 } else {
                     self.attachHandlers(to: items)
                     let prefix = self.bulkActionRows(for: bulkActionParent)
                     template.updateSections([CPListSection(items: prefix + items)])
                 }
             } else {
-                template.updateSections([CPListSection(items: [disconnectedRow()])])
+                template.updateSections([CPListSection(items: [self.disconnectedRow(strings)])])
             }
         }
     }
@@ -522,8 +527,9 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     // MARK: - Bulk actions
 
     private func bulkActionRows(for parent: AppMediaItem) -> [CPListItem] {
+        guard let strings = strings else { return [] }
         let playAll = CPListItem(
-            text: "Play All",
+            text: strings.playAll,
             detailText: nil,
             image: UIImage(systemName: "play.fill")
         )
@@ -533,7 +539,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
         }
 
         let addAll = CPListItem(
-            text: "Add All to Queue",
+            text: strings.addAllToQueue,
             detailText: nil,
             image: UIImage(systemName: "text.badge.plus")
         )
@@ -571,9 +577,9 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
 
     /// Non-tappable row — fetcher timed out. Library auto-recovers via the
     /// readiness sub; drilldowns require the user to back out and re-enter.
-    private func disconnectedRow() -> CPListItem {
+    private func disconnectedRow(_ strings: CarPlayStrings) -> CPListItem {
         let item = CPListItem(
-            text: "Disconnected — reconnecting…",
+            text: strings.disconnected,
             detailText: nil,
             image: UIImage(systemName: "wifi.exclamationmark")
         )


### PR DESCRIPTION
CarPlay UI was hardcoded in English regardless of app language. Route all CarPlay strings through the shared Compose string catalog (the same values/strings.xml Lokalise manages) so CarPlay follows the same translations as the rest of the app, with no second translation pipeline.

A new CarPlayStrings resolver (iosMain) reads strings for the active locale via getString; KmpHelper exposes it to Swift, which defers its first template build until the strings load because CarPlay template titles are immutable once constructed. Reuses existing media_type_*/nav_library/library_empty keys and adds 9 neutral, interface-agnostic keys so the upcoming Android Auto work can reuse them where applicable.

Closes https://github.com/music-assistant/mobile-app/issues/542