### PR TITLE
fix(ios,audio): preserve queued resume across backgrounded reconnect

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerRepository.kt
@@ -234,16 +234,13 @@ class LocalPlayerRepository(
 
     // --- Lifecycle ---
 
-    /** Drop the optimistic local-player UI state. Leaves the command queue intact —
-     *  a transient teardown (background, reconnect) must not discard intent that
-     *  [drainCommandQueue] is meant to replay on recovery. */
+    /** Full local-player reset: drop the optimistic UI state and any pending offline
+     *  commands. Called only on a genuine session reset (logout, terminal auth failure,
+     *  Sendspin disabled). NOT called on transient teardown — [MainDataSource.stopSendspin]
+     *  deliberately preserves both so [drainCommandQueue] can replay a queued resume once
+     *  the transport returns. */
     fun clearState() {
         _localPlayerData.update { null }
-    }
-
-    /** Discard pending offline commands. Only on a genuine session reset (logout,
-     *  terminal auth failure, Sendspin disabled) — never on transient teardown. */
-    fun clearCommandQueue() {
         launch { commandQueueMutex.withLock { commandQueue.clear() } }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerRepository.kt
@@ -234,8 +234,16 @@ class LocalPlayerRepository(
 
     // --- Lifecycle ---
 
+    /** Drop the optimistic local-player UI state. Leaves the command queue intact —
+     *  a transient teardown (background, reconnect) must not discard intent that
+     *  [drainCommandQueue] is meant to replay on recovery. */
     fun clearState() {
         _localPlayerData.update { null }
+    }
+
+    /** Discard pending offline commands. Only on a genuine session reset (logout,
+     *  terminal auth failure, Sendspin disabled) — never on transient teardown. */
+    fun clearCommandQueue() {
         launch { commandQueueMutex.withLock { commandQueue.clear() } }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -665,10 +665,10 @@ private data class PlayerBuildInputs(
                         localPlayerRepository.onInitialPlayersReceived(hasLocalPlayer = false)
                     } else {
                         stopSendspin()
-                        // User turned Sendspin off — the local player is gone for good,
-                        // so drop its UI state and any queued offline commands.
+                        // User turned Sendspin off — the local player is gone for good.
+                        // stopSendspin() no longer resets it (transient teardowns must
+                        // preserve a queued resume), so clear it explicitly here.
                         localPlayerRepository.clearState()
-                        localPlayerRepository.clearCommandQueue()
                     }
                 }
             }
@@ -930,7 +930,6 @@ private data class PlayerBuildInputs(
         _queueInfos.update { emptyList() }
         positionTracker.clear()
         localPlayerRepository.clearState()
-        localPlayerRepository.clearCommandQueue()
         // Note: _providersIcons deliberately NOT cleared (static data)
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -665,6 +665,10 @@ private data class PlayerBuildInputs(
                         localPlayerRepository.onInitialPlayersReceived(hasLocalPlayer = false)
                     } else {
                         stopSendspin()
+                        // User turned Sendspin off — the local player is gone for good,
+                        // so drop its UI state and any queued offline commands.
+                        localPlayerRepository.clearState()
+                        localPlayerRepository.clearCommandQueue()
                     }
                 }
             }
@@ -926,6 +930,7 @@ private data class PlayerBuildInputs(
         _queueInfos.update { emptyList() }
         positionTracker.clear()
         localPlayerRepository.clearState()
+        localPlayerRepository.clearCommandQueue()
         // Note: _providersIcons deliberately NOT cleared (static data)
     }
 
@@ -1135,8 +1140,11 @@ private data class PlayerBuildInputs(
             sendspinClient = null
         }
         _sendspinState.value = null
-        // Clear local player data immediately so the UI reflects the change
-        localPlayerRepository.clearState()
+        // Deliberately preserve local-player state and the offline command queue:
+        // most callers (background, reconnect, persistent error) are transient and
+        // rely on drainCommandQueue() replaying queued intent — e.g. a post-
+        // interruption resume — once the transport returns. Genuine resets clear
+        // them explicitly (clearAllData / Sendspin-disabled).
         // Fully release the shared audio pipeline (AudioTrack, decoder, etc.)
         // A fresh pipeline will be created on the next initSendspinIfEnabled()
         sendspinClientFactory.destroyPipeline()


### PR DESCRIPTION
I *believe* this closes https://github.com/music-assistant/mobile-app/issues/554 as I'm no longer able to reproduce it. But oofdah, it can get tricky with all these state machines running around... A *little* more verbose than usual in the comments just to help future-me remember what each bit is supposed to be in charge of.

Commit 5915037 correctly re-issues a "play" when an audio interruption ends, but on CarPlay the interruption-pause stops playback, iOS drops the now-idle socket, and the transport reconnects into Disconnected.Backgrounded. That path ran stopSendspin() -> clearState(), which wiped the offline command queue -- discarding the very resume that drainCommandQueue() is meant to replay on reconnect. The teardown and the recovery were fighting, and the teardown won.

Split the two concerns clearState() had conflated: clearState() now only drops the optimistic local-player UI state, and a new clearCommandQueue() discards pending intent. stopSendspin() becomes a pure transport/pipeline teardown that preserves both, so a queued resume survives a transient background/reconnect and drains when the socket returns. Genuine resets (clearAllData, Sendspin disabled) clear them explicitly. This also keeps localPlayerData non-null across the teardown, closing a secondary race where a late .ended dropped the resume at onRemoteCommand's null check.