### PR TITLE
fix(ios,sendspin): preserve audiobook resume across transient backgrounded teardown

### DIFF
--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -511,7 +511,6 @@ class FakeServiceClient(private val settingsRepository: SettingsRepository) : Se
     }
 
     override fun onPlaybackActive() {
-        TODO("Not yet implemented")
     }
 
     override fun onExternalConsumerInactive() {
@@ -519,7 +518,6 @@ class FakeServiceClient(private val settingsRepository: SettingsRepository) : Se
     }
 
     override fun onPlaybackInactive() {
-        TODO("Not yet implemented")
     }
 
     fun addToLibrary(vararg items: ServerMediaItem) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -46,6 +46,7 @@ import io.music_assistant.client.player.sendspin.SendspinClientFactory
 import io.music_assistant.client.player.sendspin.SendspinError
 import io.music_assistant.client.player.sendspin.SendspinState
 import io.music_assistant.client.player.sendspin.WebRTCSendspinChannelExhausted
+import io.music_assistant.client.player.sendspin.model.GoodbyeReason
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.Timings
 import io.music_assistant.client.ui.compose.common.DataState
@@ -453,7 +454,7 @@ class MainDataSource(
 
                             if (isTerminalAuthFailure) {
                                 // Auth permanently failed — stop everything
-                                stopSendspin()
+                                stopSendspin(GoodbyeReason.Shutdown)
                                 clearAllData()
                             } else {
                                 // Transient: AwaitingServerInfo or auth in progress.
@@ -512,7 +513,7 @@ class MainDataSource(
 
                     SessionState.Connecting -> {
                         log.i { "Connecting - stopping Sendspin" }
-                        stopSendspin()
+                        stopSendspin(GoodbyeReason.Restart)
                         updateJob?.cancel()
                         updateJob = null
                         watchJob?.cancel()
@@ -538,7 +539,7 @@ class MainDataSource(
                             SessionState.Disconnected.ByUser -> {
                                 // Intentional logout - clear everything
                                 log.i { "Disconnected by user - clearing all data" }
-                                stopSendspin()
+                                stopSendspin(GoodbyeReason.UserRequest)
                                 clearAllData()
                                 updateJob?.cancel()
                                 updateJob = null
@@ -570,7 +571,7 @@ class MainDataSource(
                                         }
 
                                         // Stop Sendspin (can't stream without connection)
-                                        stopSendspin()
+                                        stopSendspin(GoodbyeReason.Restart)
                                     }
 
                                     is DataState.Loading, is DataState.NoData, is DataState.Error -> {
@@ -611,7 +612,7 @@ class MainDataSource(
                                     }
                                 }
 
-                                stopSendspin()
+                                stopSendspin(GoodbyeReason.Restart)
                                 updateJob?.cancel()
                                 updateJob = null
                                 watchJob?.cancel()
@@ -621,7 +622,7 @@ class MainDataSource(
                             SessionState.Disconnected.Initial, SessionState.Disconnected.NoServerData -> {
                                 // App startup or no server configured - clear all
                                 log.i { "Disconnected (${sessionState::class.simpleName}) - clearing data" }
-                                stopSendspin()
+                                stopSendspin(GoodbyeReason.Shutdown)
                                 clearAllData()
                                 updateJob?.cancel()
                                 updateJob = null
@@ -664,7 +665,7 @@ class MainDataSource(
                         // before Sendspin fully connects and server confirms the player
                         localPlayerRepository.onInitialPlayersReceived(hasLocalPlayer = false)
                     } else {
-                        stopSendspin()
+                        stopSendspin(GoodbyeReason.UserRequest)
                         // User turned Sendspin off — the local player is gone for good.
                         // stopSendspin() no longer resets it (transient teardowns must
                         // preserve a queued resume), so clear it explicitly here.
@@ -737,6 +738,16 @@ class MainDataSource(
                         )
                     }
                 }
+        }
+        // Arms `hasActivePlayback` so backgrounding mid-playback doesn't tear down
+        // Sendspin (goodbye=shutdown → audio stops, server cold-resumes. Driven off
+        // logical `isPlaying`, which survives the transient transport blip — unlike
+        // the Sendspin sync state.
+        launch {
+            localPlayer
+                .map { it?.player?.isPlaying == true }
+                .distinctUntilChanged()
+                .collect { if (it) apiClient.onPlaybackActive() else apiClient.onPlaybackInactive() }
         }
     }
 
@@ -984,7 +995,7 @@ class MainDataSource(
 
                 is SendspinState.Idle -> Unit
             }
-            existing.stop()
+            existing.stop(GoodbyeReason.Restart)
             existing.close()
         }
 
@@ -1126,13 +1137,13 @@ class MainDataSource(
      * Stop Sendspin player if running.
      * Destroys the shared audio pipeline so the AudioTrack is fully released.
      */
-    private suspend fun stopSendspin() = sendspinMutex.withLock {
+    private suspend fun stopSendspin(reason: GoodbyeReason) = sendspinMutex.withLock {
         // Cancel monitor jobs FIRST to prevent old state transitions from leaking
         cancelSendspinMonitorJobs()
         sendspinRetryCount = 0
         sendspinClient?.let { client ->
             try {
-                client.stop()
+                client.stop(reason)
                 client.close()
             } catch (e: Exception) {
                 log.e(e) { "Error stopping Sendspin client" }
@@ -1964,7 +1975,7 @@ class MainDataSource(
     fun onAppClosed() {
         if (!isAnythingPlaying.value) {
             log.i { "App closed with no active playback — stopping Sendspin" }
-            launch { stopSendspin() }
+            launch { stopSendspin(GoodbyeReason.Shutdown) }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/SendspinClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/SendspinClient.kt
@@ -4,6 +4,7 @@ import co.touchlab.kermit.Logger
 import io.music_assistant.client.player.MediaPlayerController
 import io.music_assistant.client.player.sendspin.audio.AudioPipeline
 import io.music_assistant.client.player.sendspin.model.CommandValue
+import io.music_assistant.client.player.sendspin.model.GoodbyeReason
 import io.music_assistant.client.player.sendspin.model.PlayerStateValue
 import io.music_assistant.client.player.sendspin.model.ServerCommandMessage
 import io.music_assistant.client.player.sendspin.model.StreamMetadataPayload
@@ -372,7 +373,7 @@ class SendspinClient(
         messageDispatcher?.sendCommand(command, value)
     }
 
-    suspend fun stop() {
+    suspend fun stop(reason: GoodbyeReason) {
         val current = _state.value
         // Stop state reporting
         stateReporter?.stop()
@@ -383,7 +384,7 @@ class SendspinClient(
             current is SendspinState.Synchronized
         ) {
             try {
-                messageDispatcher?.sendGoodbye("shutdown")
+                messageDispatcher?.sendGoodbye(reason)
                 delay(100) // Give it time to send
             } catch (e: Exception) {
                 logger.e(e) { "Error sending goodbye" }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/model/Messages.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/model/Messages.kt
@@ -359,3 +359,15 @@ data class ClientGoodbyeMessage(
 data class GoodbyePayload(
     val reason: String? = null,
 )
+
+/**
+ * Wire reasons for `client/goodbye`, mirroring aiosendspin's `GoodbyeReason`.
+ * The server acts on this: [Shutdown]/[UserRequest] trigger immediate session
+ * teardown, while [Restart] is a warm, reconnect-friendly disconnect (30s grace)
+ * that preserves queue/resume state.
+ */
+enum class GoodbyeReason(val wire: String) {
+    Shutdown("shutdown"),
+    Restart("restart"),
+    UserRequest("user_request"),
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/protocol/MessageDispatcher.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/protocol/MessageDispatcher.kt
@@ -17,6 +17,7 @@ import io.music_assistant.client.player.sendspin.model.ClientTimePayload
 import io.music_assistant.client.player.sendspin.model.CommandPayload
 import io.music_assistant.client.player.sendspin.model.CommandValue
 import io.music_assistant.client.player.sendspin.model.GoodbyePayload
+import io.music_assistant.client.player.sendspin.model.GoodbyeReason
 import io.music_assistant.client.player.sendspin.model.GroupUpdateMessage
 import io.music_assistant.client.player.sendspin.model.PlayerStateObject
 import io.music_assistant.client.player.sendspin.model.PlayerStateValue
@@ -246,10 +247,10 @@ class MessageDispatcher(
         transport.sendText(json)
     }
 
-    suspend fun sendGoodbye(reason: String) {
-        logger.i { "Sending client/goodbye: $reason" }
+    suspend fun sendGoodbye(reason: GoodbyeReason) {
+        logger.i { "Sending client/goodbye: ${reason.wire}" }
         val message = ClientGoodbyeMessage(
-            payload = GoodbyePayload(reason = reason),
+            payload = GoodbyePayload(reason = reason.wire),
         )
         val json = myJson.encodeToString(message)
         transport.sendText(json)


### PR DESCRIPTION
I'm chasing a bug where sometimes I'll "lose" several minutes of progress in my audiobook if I leave the mobile app and come back. During that investigation I noticed that we were sending client/goodbye("shutdown") in some situations where we definitely weren't "done", but that would cause the MA sendspin server to immediately drop our connection. The sendspin-correct way to say "I'll be right back" is client/goodbye("restart"). I went through and fixed up all of the various paths to be correct, I believe. Hopefully this helps with some of the MA server providers (like Audiobookshelf) that use that as a heuristic about what to do / how to track progress. But at least gets us closer to sendspin protocol compatibility.

Commit message:

When the app was backgrounded and the transport briefly dropped (e.g. a network blip on cellular/VPN), the local Sendspin player was torn down and sent client/goodbye("shutdown"). The server treats SHUTDOWN as immediate cleanup and discards the queue/role state, so on reconnect playback would cold-resume from the last position persisted to Audiobookshelf — losing minutes of in-session progress (for example).

Two complementary fixes:
- Wire the existing (but never-called) onPlaybackActive/onPlaybackInactive hooks off localPlayer.isPlaying, so a transient transport drop while backgrounded and playing no longer takes the hard-teardown branch; it reconnects instead and keeps audio playing from buffer.
- Send a truthful client/goodbye reason. Transient teardowns (background, reconnect, client re-init, persistent error) now send RESTART, which the server treats as a warm disconnect with a 30s grace that preserves session state; user-driven teardowns send USER_REQUEST, genuine shutdowns send SHUTDOWN. Adds a GoodbyeReason enum mirroring aiosendspin's wire values.