### PR TITLE
feat(ios): bridge Kermit logs to os.Logger for un-redacted dev logs

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/music_assistant/client/logging/PlatformLogWriters.android.kt
+++ b/composeApp/src/androidMain/kotlin/io/music_assistant/client/logging/PlatformLogWriters.android.kt
@@ -1,0 +1,7 @@
+package io.music_assistant.client.logging
+
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.platformLogWriter
+
+/** Android keeps Kermit's stock Logcat writer. */
+actual fun platformLogWriters(): List<LogWriter> = listOf(platformLogWriter())

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/di/initKoin.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/di/initKoin.kt
@@ -7,6 +7,7 @@ import io.music_assistant.client.api.ServiceClient
 import io.music_assistant.client.imageloader.WebRTCImageFetcher
 import io.music_assistant.client.imageloader.buildAppImageLoader
 import io.music_assistant.client.logging.InMemoryLogWriter
+import io.music_assistant.client.logging.platformLogWriters
 import org.koin.core.context.startKoin
 import org.koin.core.module.Module
 import org.koin.dsl.KoinAppDeclaration
@@ -21,7 +22,11 @@ fun initKoin(
     // lines/sec for the idle clock-sync heartbeat, which otherwise floods (and
     // evicts useful entries from) InMemoryLogWriter for the entire session.
     Logger.setMinSeverity(if (verboseLogging) Severity.Verbose else Severity.Info)
-    Logger.addLogWriter(InMemoryLogWriter)
+    // setLogWriters (not addLogWriter) so each platform's console sink replaces
+    // Kermit's default rather than doubling it: on iOS the default NSLog writer
+    // renders every line as <private>, which would otherwise duplicate the
+    // public os.Logger bridge.
+    Logger.setLogWriters(listOf(InMemoryLogWriter) + platformLogWriters())
     startKoin {
         config?.invoke(this)
         modules(sharedModule(), webrtcModule, *platformModules)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/logging/PlatformLogWriters.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/logging/PlatformLogWriters.kt
@@ -1,0 +1,11 @@
+package io.music_assistant.client.logging
+
+import co.touchlab.kermit.LogWriter
+
+/**
+ * Platform console [LogWriter]s, registered alongside [InMemoryLogWriter] in `initKoin`.
+ *
+ * Each platform owns its console sink so common code can register writers without
+ * inheriting Kermit's default (which on iOS redacts every interpolated value).
+ */
+expect fun platformLogWriters(): List<LogWriter>

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/logging/OsLogBridge.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/logging/OsLogBridge.kt
@@ -1,0 +1,31 @@
+package io.music_assistant.client.logging
+
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.Severity
+
+/**
+ * Swift-side `os.Logger` sink. Implemented in `iosApp` and registered via
+ * [OsLogSinkProvider] at startup, mirroring `PlatformPlayerProvider`.
+ *
+ * Kotlin can't express `os.Logger`'s `privacy:` interpolation, so the Swift side
+ * owns the actual logging and privacy decision; Kotlin only forwards the line.
+ *
+ * @param severity Kermit [Severity.name] (e.g. "Info"); Swift maps it to an `OSLogType`.
+ */
+interface OsLogSink {
+    fun log(severity: String, tag: String, message: String)
+}
+
+/** Bridge point: Swift assigns its [OsLogSink] here (DEBUG builds only). */
+object OsLogSinkProvider {
+    var sink: OsLogSink? = null
+}
+
+/** Kermit [LogWriter] forwarding to the Swift [OsLogSink]; no-ops until a sink is set. */
+object OsLogBridgeWriter : LogWriter() {
+    override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
+        val sink = OsLogSinkProvider.sink ?: return
+        val line = if (throwable != null) "$message\n${throwable.stackTraceToString()}" else message
+        sink.log(severity.name, tag, line)
+    }
+}

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/logging/PlatformLogWriters.ios.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/logging/PlatformLogWriters.ios.kt
@@ -1,0 +1,17 @@
+@file:OptIn(kotlin.experimental.ExperimentalNativeApi::class)
+
+package io.music_assistant.client.logging
+
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.platformLogWriter
+import kotlin.native.Platform
+
+/**
+ * DEBUG: the public `os.Logger` bridge ([OsLogBridgeWriter]) replaces Kermit's
+ * stock writer, whose `NSLog("%s", …)` renders every line as `<private>`.
+ *
+ * Release/TestFlight: keep the stock writer unchanged
+ **/
+
+actual fun platformLogWriters(): List<LogWriter> =
+    if (Platform.isDebugBinary) listOf(OsLogBridgeWriter) else listOf(platformLogWriter())

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -3,6 +3,7 @@ import ComposeApp
 import UIKit
 import CarPlay
 import Intents
+import os
 import os.log
 import os.lock
 
@@ -87,6 +88,28 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     }
 }
 
+#if DEBUG
+/// Forwards Kermit logs (via the KMP `OsLogSink` bridge) to the unified log with
+/// `privacy: .public`, for local development
+final class OsLogSinkImpl: NSObject, OsLogSink {
+    private let subsystem = Bundle.main.bundleIdentifier ?? "io.music-assistant.client"
+
+    func log(severity: String, tag: String, message: String) {
+        let logger = os.Logger(subsystem: subsystem, category: tag)
+        let level: OSLogType
+        switch severity {
+        case "Verbose", "Debug": level = .debug
+        case "Info":             level = .info
+        case "Warn":             level = .default
+        case "Error":            level = .error
+        case "Assert":           level = .fault
+        default:                 level = .default
+        }
+        logger.log(level: level, "\(message, privacy: .public)")
+    }
+}
+#endif
+
 @main
 struct iOSApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
@@ -98,6 +121,12 @@ struct iOSApp: App {
     init() {
         // Register the Swift implementation with Kotlin
         PlatformPlayerProvider.shared.player = player
+
+        #if DEBUG
+        // Route Kermit logs to the unified log un-redacted during development
+        // Must run before bootstrapKmp() so init-time logs reach the sink.
+        OsLogSinkProvider.shared.sink = OsLogSinkImpl()
+        #endif
 
         // Initialize NowPlayingManager early to configure AudioSession
         _ = NowPlayingManager.shared


### PR DESCRIPTION
This adds debug-only unredacted logging to better help anyone doing local iOS development (for times when the phone isn't attached to the Xcode debugger, i.e., doing actual "field" tests), because I keep running into issues where the iOS private-by-default log redaction makes it harder to debug. Doesn't affect Android logging which is "public" by default.

Commit:

DEBUG iOS builds now route Kermit through a Swift os.Logger sink that marks the line privacy: .public, so console output shows full text instead of <private>. The sink is injected only under #if DEBUG and Kotlin only swaps in the bridge writer when Platform.isDebugBinary, so release/TestFlight keeps Kermit's stock NSLog writer unchanged and never emits public.

Introduces an expect/actual platformLogWriters() and switches initKoin from addLogWriter to setLogWriters so each platform's console sink replaces Kermit's default rather than doubling it (avoiding redacted + public duplicate lines on iOS). Android keeps its Logcat writer; InMemoryLogWriter is unchanged on both, so the crash/share diagnostic path is unaffected.