### PR TITLE
fix(auth): make reconnect re-auth resilient instead of dropping to login

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/AuthRoundTrip.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/AuthRoundTrip.kt
@@ -1,0 +1,73 @@
+package io.music_assistant.client.api
+
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Outcome of an auth round-trip (`client/auth` or `auth/login`).
+ *
+ * The server authenticates per WebSocket connection, so every reconnect re-runs
+ * `client/auth`. A round-trip that never completes (`Result.failure`) is a
+ * connectivity failure, not a rejection: the token is still valid, so treating it
+ * as one would bounce the user to login for no reason.
+ */
+internal sealed interface AuthRoundTrip {
+    /**
+     * No server response (send failed / socket died) — connectivity, not rejection.
+     * [surfaceAsFailure] is true when the caller should drop to the login screen.
+     */
+    data class NoResponse(val surfaceAsFailure: Boolean) : AuthRoundTrip
+
+    /** Server returned an `error_code` — the token/credentials were rejected. */
+    data class Rejected(val message: String) : AuthRoundTrip
+
+    /** Server returned a payload for the caller to parse. */
+    data class Responded(val answer: Answer) : AuthRoundTrip
+}
+
+/** The auth round-trip was sent but no response arrived within the timeout. */
+internal class AuthRoundTripTimeout(timeoutMs: Long) :
+    Exception("Auth round-trip timed out after ${timeoutMs}ms")
+
+/**
+ * Run an auth round-trip under a timeout. The reply travels the same WebSocket as
+ * the request, so a socket that dies after the send (but before the reply) would
+ * otherwise leave [send] suspended forever — wedging the auth flow. The timeout
+ * converts that into a completed [Result.failure], which the budget then counts.
+ */
+internal suspend fun authRoundTrip(
+    timeoutMs: Long,
+    send: suspend () -> Result<Answer>,
+): Result<Answer> =
+    withTimeoutOrNull(timeoutMs) { send() } ?: Result.failure(AuthRoundTripTimeout(timeoutMs))
+
+/**
+ * Classify an auth round-trip. A non-response surfaces to the login screen only for
+ * a user-initiated login ([isAutoLogin] false) or once the silent-failure budget is
+ * reached — a silent reconnect re-auth below budget is tolerated so the reconnect
+ * cycle can retry.
+ *
+ * @param priorSilentFailures consecutive silent re-auth failures before this one;
+ *   resets to 0 on any successful auth.
+ */
+internal fun classifyAuthRoundTrip(
+    response: Result<Answer>,
+    isAutoLogin: Boolean,
+    priorSilentFailures: Int,
+    maxSilentFailures: Int,
+): AuthRoundTrip = response.fold(
+    onSuccess = { answer ->
+        if (answer.json.containsKey("error_code")) {
+            AuthRoundTrip.Rejected(
+                answer.json["error"]?.jsonPrimitive?.contentOrNull ?: "Authentication failed",
+            )
+        } else {
+            AuthRoundTrip.Responded(answer)
+        }
+    },
+    onFailure = {
+        val budgetReached = priorSilentFailures + 1 >= maxSilentFailures
+        AuthRoundTrip.NoResponse(surfaceAsFailure = !isAutoLogin || budgetReached)
+    },
+)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -27,9 +27,9 @@ import io.music_assistant.client.utils.connectionInfo
 import io.music_assistant.client.utils.createPlatformHttpClient
 import io.music_assistant.client.utils.currentTimeMillis
 import io.music_assistant.client.utils.myJson
-import io.music_assistant.client.utils.resultAs
 import io.music_assistant.client.utils.update
 import io.music_assistant.client.webrtc.model.RemoteId
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -55,9 +55,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.decodeFromJsonElement
-import kotlinx.serialization.json.jsonPrimitive
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.koin.core.qualifier.named
@@ -101,6 +99,14 @@ class KtorServiceClient(
     private var hasActiveExternalConsumer = false
     private var hasActivePlayback = false
     private var backgroundedAt = 0L
+
+    private val silentReauth = SilentReauth(
+        ReauthPolicy(
+            maxSilentFailures = MAX_SILENT_REAUTH_FAILURES,
+            roundTripTimeoutMs = AUTH_ROUNDTRIP_TIMEOUT_MS,
+            retryDelayMs = SILENT_REAUTH_RETRY_DELAY_MS,
+        ),
+    )
 
     private sealed class BackgroundedConnectionInfo {
         data class Direct(val connectionInfo: ConnectionInfo) : BackgroundedConnectionInfo()
@@ -579,6 +585,9 @@ class KtorServiceClient(
      * should keep using [connect] so accidental double-connects are still cheap.
      */
     private fun forceConnect(connection: ConnectionInfo) {
+        // New connection episode: the silent-failure budget is per-server-session, so
+        // a prior server's failures must not pre-charge this one's escape hatch.
+        silentReauth.reset()
         // Cancel observer before disconnecting transport to prevent race where the old
         // observer processes TransportState.Disconnected and briefly sets ByUser
         transportObserverJob?.cancel()
@@ -635,6 +644,7 @@ class KtorServiceClient(
 
     /** WebRTC twin of [forceConnect]. */
     private fun forceConnectWebRTC(remoteId: RemoteId) {
+        silentReauth.reset()
         transportObserverJob?.cancel()
         transport?.disconnect()
         transport?.close()
@@ -732,49 +742,48 @@ class KtorServiceClient(
         username: String,
         password: String,
     ) {
-        if (_sessionState.value !is SessionState.Connected) return
-        setAuthState(AuthProcessState.InProgress)
-
         try {
-            val response =
-                sendRequestRaw(Request.Auth.login(username, password, settings.deviceName.value))
-            if (_sessionState.value !is SessionState.Connected) return
-
-            if (response.isFailure) {
-                setAuthFailed("No response from server")
-                return
-            }
-
-            if (response.getOrNull()?.json?.containsKey("error_code") == true) {
-                val errorMessage =
-                    response.getOrNull()?.json["error"]?.jsonPrimitive?.contentOrNull
-                        ?: "Authentication failed"
-                clearCurrentServerToken()
-                setAuthFailed(errorMessage)
-                return
-            }
-
-            response.resultAs<LoginResponse>()?.let { auth ->
-                if (!auth.success) {
-                    setAuthFailed(auth.error ?: "Authentication failed")
-                    return
+            when (
+                // Manual login is single-shot (isAutoLogin = false surfaces on the first
+                // failure). Unlike re-auth it must proceed from a LoggedOut session, so its
+                // guard checks only liveness — not LoggedOut, which would abort the retry.
+                val resolution = silentReauth.resolve(
+                    isAutoLogin = false,
+                    shouldAttempt = { _sessionState.value is SessionState.Connected },
+                    onAttempt = { setAuthState(AuthProcessState.InProgress) },
+                    send = {
+                        sendRequestRaw(Request.Auth.login(username, password, settings.deviceName.value))
+                    },
+                )
+            ) {
+                AuthResolution.Aborted -> return
+                is AuthResolution.Surface -> setAuthFailed(resolution.message)
+                is AuthResolution.Reject -> {
+                    clearCurrentServerToken()
+                    setAuthFailed(resolution.message)
                 }
-                if (auth.token.isNullOrBlank()) {
-                    setAuthFailed("No token received")
-                    return
-                }
-                if (auth.user == null) {
-                    setAuthFailed("No user data received")
-                    return
-                }
-                authorize(auth.token, isAutoLogin = false)
-            } ?: run {
-                setAuthFailed("Failed to parse auth data")
+
+                is AuthResolution.Authenticated -> handleLoginResponse(resolution.answer)
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             if (_sessionState.value !is SessionState.Connected) return
             setAuthFailed(e.message ?: "Exception happened: $e")
             clearCurrentServerToken()
+        }
+    }
+
+    private suspend fun handleLoginResponse(answer: Answer) {
+        val auth = answer.resultAs<LoginResponse>() ?: run {
+            setAuthFailed("Failed to parse auth data")
+            return
+        }
+        when {
+            !auth.success -> setAuthFailed(auth.error ?: "Authentication failed")
+            auth.token.isNullOrBlank() -> setAuthFailed("No token received")
+            auth.user == null -> setAuthFailed("No user data received")
+            else -> authorize(auth.token, isAutoLogin = false)
         }
     }
 
@@ -815,58 +824,67 @@ class KtorServiceClient(
 
     override suspend fun authorize(token: String, isAutoLogin: Boolean) {
         try {
-            if (_sessionState.value !is SessionState.Connected) return
-            setAuthState(AuthProcessState.InProgress)
-            val response = sendRequestRaw(Request.Auth.authorize(token, settings.deviceName.value))
-            if (_sessionState.value !is SessionState.Connected) return
-            if (response.isFailure) {
-                Logger.e(response.exceptionOrNull().toString())
-                setAuthFailed("No response from server")
-                return
-            }
-            if (response.getOrNull()?.json?.containsKey("error_code") == true) {
-                val errorMessage =
-                    response.getOrNull()?.json["error"]?.jsonPrimitive?.contentOrNull
-                        ?: "Authentication failed"
-                clearCurrentServerToken()
-                setAuthFailed(errorMessage)
-                return
-            }
-            response.resultAs<AuthorizationResponse>()?.user?.let { user ->
-                val currentState = _sessionState.value
-                if (currentState is SessionState.Connected) {
-                    val serverIdentifier = when (currentState) {
-                        is SessionState.Connected.Direct -> {
-                            settings.getDirectServerIdentifier(
-                                currentState.connectionInfo.host,
-                                currentState.connectionInfo.port,
-                                currentState.connectionInfo.isTls,
-                            )
-                        }
-
-                        is SessionState.Connected.WebRTC -> {
-                            settings.getWebRTCServerIdentifier(currentState.remoteId.rawId)
-                        }
-                    }
-                    settings.setTokenForServer(serverIdentifier, token)
-                    logger.d { "Saved token for server" }
+            when (
+                val resolution = silentReauth.resolve(
+                    isAutoLogin = isAutoLogin,
+                    // Keep retrying only while the session is live and hasn't been logged
+                    // out from under us — otherwise a late retry could undo a logout.
+                    shouldAttempt = {
+                        val state = _sessionState.value
+                        state is SessionState.Connected &&
+                            state.authProcessState != AuthProcessState.LoggedOut
+                    },
+                    onAttempt = { setAuthState(AuthProcessState.InProgress) },
+                    send = { sendRequestRaw(Request.Auth.authorize(token, settings.deviceName.value)) },
+                )
+            ) {
+                AuthResolution.Aborted -> return
+                is AuthResolution.Surface -> setAuthFailed(resolution.message)
+                is AuthResolution.Reject -> {
+                    clearCurrentServerToken()
+                    setAuthFailed(resolution.message)
                 }
-
-                _sessionState.update {
-                    (it as? SessionState.Connected)?.update(
-                        authProcessState = AuthProcessState.NotStarted,
-                        user = user,
-                        wasAutoLogin = isAutoLogin,
-                        needsServerReauth = false,
-                    ) ?: it
-                }
-            } ?: run {
-                setAuthFailed("Failed to parse user data")
+                is AuthResolution.Authenticated ->
+                    onAuthorized(token, isAutoLogin, resolution.answer)
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             if (_sessionState.value !is SessionState.Connected) return
             setAuthFailed(e.message ?: "Exception happened: $e")
             clearCurrentServerToken()
+        }
+    }
+
+    private fun onAuthorized(token: String, isAutoLogin: Boolean, answer: Answer) {
+        val user = answer.resultAs<AuthorizationResponse>()?.user ?: run {
+            setAuthFailed("Failed to parse user data")
+            return
+        }
+        val currentState = _sessionState.value
+        if (currentState is SessionState.Connected) {
+            val serverIdentifier = when (currentState) {
+                is SessionState.Connected.Direct -> settings.getDirectServerIdentifier(
+                    currentState.connectionInfo.host,
+                    currentState.connectionInfo.port,
+                    currentState.connectionInfo.isTls,
+                )
+
+                is SessionState.Connected.WebRTC ->
+                    settings.getWebRTCServerIdentifier(currentState.remoteId.rawId)
+            }
+            settings.setTokenForServer(serverIdentifier, token)
+            logger.d { "Saved token for server" }
+        }
+
+        silentReauth.reset()
+        _sessionState.update {
+            (it as? SessionState.Connected)?.update(
+                authProcessState = AuthProcessState.NotStarted,
+                user = user,
+                wasAutoLogin = isAutoLogin,
+                needsServerReauth = false,
+            ) ?: it
         }
     }
 
@@ -1090,6 +1108,18 @@ class KtorServiceClient(
     companion object {
         private const val STALE_CONNECTION_THRESHOLD_MS = 30_000L
         private const val ENSURE_READY_TIMEOUT_MS = 10_000L
+
+        // Silent reconnect re-auth failures tolerated before surfacing login — rides
+        // through a flaky handoff without trapping the user if re-auth never recovers.
+        private const val MAX_SILENT_REAUTH_FAILURES = 3
+
+        // Cap on one auth round-trip. Above the 10s ping interval so a merely slow
+        // server isn't cut off, but bounded so a dead-after-send socket can't suspend
+        // the auth flow forever (the reply rides the same WebSocket as the request).
+        private const val AUTH_ROUNDTRIP_TIMEOUT_MS = 15_000L
+
+        // Backoff between silent re-auth retries, so a fast-failing attempt can't spin.
+        private const val SILENT_REAUTH_RETRY_DELAY_MS = 1_000L
         private const val WEBRTC_PROXY_BASE = "mawebrtc://proxy"
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/SilentReauth.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/SilentReauth.kt
@@ -1,0 +1,89 @@
+package io.music_assistant.client.api
+
+import co.touchlab.kermit.Logger
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.delay
+
+private val log = Logger.withTag("SilentReauth")
+
+/** Tuning for [SilentReauth]. */
+internal data class ReauthPolicy(
+    val maxSilentFailures: Int,
+    val roundTripTimeoutMs: Long,
+    val retryDelayMs: Long,
+)
+
+/** What the caller should do once an auth attempt (or retry run) settles. */
+internal sealed interface AuthResolution {
+    /** Drop to the login screen with this message. */
+    data class Surface(val message: String) : AuthResolution
+
+    /** Server rejected the token/credentials. */
+    data class Reject(val message: String) : AuthResolution
+
+    /** Server returned a payload for the caller to parse into a user. */
+    data class Authenticated(val answer: Answer) : AuthResolution
+
+    /** The connection went away mid-attempt; nothing to report. */
+    data object Aborted : AuthResolution
+}
+
+/**
+ * Bounded retry engine for per-connection re-auth.
+ *
+ * A reconnect re-auth that fails to complete (no server response) is retried in
+ * place, spaced by [ReauthPolicy.retryDelayMs] and capped by
+ * [ReauthPolicy.maxSilentFailures], after which we surface the login screen. The
+ * failure count persists across [resolve] calls so a flapping transport (each bounce
+ * aborting a run early) still escalates; [reset] clears it at a new connection
+ * episode or a successful auth.
+ *
+ * A user-initiated login ([isAutoLogin] false) never retries — it surfaces on the
+ * first failure for immediate feedback.
+ */
+internal class SilentReauth(private val policy: ReauthPolicy) {
+    // Atomic: reset() is called from the connection path (the client's IO context)
+    // while resolve() runs on the auth dispatcher.
+    private val consecutiveSilentFailures = atomic(0)
+
+    fun reset() {
+        consecutiveSilentFailures.value = 0
+    }
+
+    suspend fun resolve(
+        isAutoLogin: Boolean,
+        shouldAttempt: () -> Boolean,
+        onAttempt: () -> Unit,
+        send: suspend () -> Result<Answer>,
+    ): AuthResolution {
+        while (shouldAttempt()) {
+            onAttempt()
+            val response = authRoundTrip(policy.roundTripTimeoutMs, send)
+            if (!shouldAttempt()) return AuthResolution.Aborted
+
+            when (
+                val outcome = classifyAuthRoundTrip(
+                    response,
+                    isAutoLogin,
+                    priorSilentFailures = consecutiveSilentFailures.value,
+                    maxSilentFailures = policy.maxSilentFailures,
+                )
+            ) {
+                is AuthRoundTrip.NoResponse -> {
+                    log.e { "re-auth round-trip failed: ${response.exceptionOrNull()}" }
+                    if (outcome.surfaceAsFailure) return AuthResolution.Surface("No response from server")
+                    consecutiveSilentFailures.incrementAndGet()
+                    delay(policy.retryDelayMs)
+                }
+
+                is AuthRoundTrip.Rejected -> {
+                    consecutiveSilentFailures.value = 0
+                    return AuthResolution.Reject(outcome.message)
+                }
+
+                is AuthRoundTrip.Responded -> return AuthResolution.Authenticated(outcome.answer)
+            }
+        }
+        return AuthResolution.Aborted
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/api/AuthRoundTripTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/api/AuthRoundTripTest.kt
@@ -1,0 +1,145 @@
+package io.music_assistant.client.api
+
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Guards the transport-failure vs server-rejection distinction and the retry budget
+ * that decides when a persistent transport failure escalates to the login screen.
+ */
+class AuthRoundTripTest {
+    private fun answer(rawJson: String): Answer =
+        Answer(Json.parseToJsonElement(rawJson) as JsonObject)
+
+    private fun failed() = Result.failure<Answer>(IllegalStateException("Not connected"))
+
+    @Test
+    fun silentReauthBelowBudgetIsNotSurfaced() {
+        val result = classifyAuthRoundTrip(
+            response = failed(),
+            isAutoLogin = true,
+            priorSilentFailures = 1,
+            maxSilentFailures = 3,
+        )
+
+        assertTrue(result is AuthRoundTrip.NoResponse)
+        assertEquals(
+            false,
+            result.surfaceAsFailure,
+            "A transient silent re-auth failure must not bounce the user to the login screen",
+        )
+    }
+
+    @Test
+    fun silentReauthAtBudgetIsSurfaced() {
+        // priorSilentFailures = 2 means this is the 3rd consecutive failure → budget of 3 reached.
+        val result = classifyAuthRoundTrip(
+            response = failed(),
+            isAutoLogin = true,
+            priorSilentFailures = 2,
+            maxSilentFailures = 3,
+        )
+
+        assertTrue(result is AuthRoundTrip.NoResponse)
+        assertEquals(
+            true,
+            result.surfaceAsFailure,
+            "A persistent silent re-auth failure must escalate so the user can reach login/Settings",
+        )
+    }
+
+    @Test
+    fun userLoginIsSurfacedRegardlessOfBudget() {
+        val result = classifyAuthRoundTrip(
+            response = failed(),
+            isAutoLogin = false,
+            priorSilentFailures = 0,
+            maxSilentFailures = 3,
+        )
+
+        assertTrue(result is AuthRoundTrip.NoResponse)
+        assertEquals(
+            true,
+            result.surfaceAsFailure,
+            "A failed user-initiated login must always surface so the user gets feedback",
+        )
+    }
+
+    @Test
+    fun serverErrorCodeIsRejectionWithMessage() {
+        val result = classifyAuthRoundTrip(
+            response = Result.success(answer("""{"message_id":"m1","error_code":20,"error":"Token expired"}""")),
+            isAutoLogin = true,
+            priorSilentFailures = 0,
+            maxSilentFailures = 3,
+        )
+
+        assertTrue(result is AuthRoundTrip.Rejected)
+        assertEquals("Token expired", result.message)
+    }
+
+    @Test
+    fun serverErrorCodeWithoutMessageFallsBack() {
+        val result = classifyAuthRoundTrip(
+            response = Result.success(answer("""{"message_id":"m1","error_code":20}""")),
+            isAutoLogin = true,
+            priorSilentFailures = 0,
+            maxSilentFailures = 3,
+        )
+
+        assertTrue(result is AuthRoundTrip.Rejected)
+        assertEquals("Authentication failed", result.message)
+    }
+
+    @Test
+    fun cleanResponseIsResponded() {
+        val payload = answer("""{"message_id":"m1","result":{"user":{"username":"daveb"}}}""")
+
+        val result = classifyAuthRoundTrip(
+            response = Result.success(payload),
+            isAutoLogin = true,
+            priorSilentFailures = 0,
+            maxSilentFailures = 3,
+        )
+
+        assertTrue(result is AuthRoundTrip.Responded)
+        assertEquals(payload, result.answer)
+    }
+
+    // --- authRoundTrip (timeout helper) ---
+
+    @Test
+    fun roundTripTimesOutToFailure() = runTest {
+        val result = authRoundTrip(timeoutMs = 5_000) { awaitCancellation() }
+
+        assertTrue(result.isFailure)
+        assertTrue(
+            result.exceptionOrNull() is AuthRoundTripTimeout,
+            "A round-trip that never completes must surface as an AuthRoundTripTimeout failure",
+        )
+    }
+
+    @Test
+    fun roundTripReturnsCompletedResultBeforeTimeout() = runTest {
+        val payload = answer("""{"message_id":"m1","result":{"user":{"username":"daveb"}}}""")
+
+        val result = authRoundTrip(timeoutMs = 5_000) { Result.success(payload) }
+
+        assertEquals(payload, result.getOrNull())
+    }
+
+    @Test
+    fun roundTripPropagatesSendFailure() = runTest {
+        val boom = IllegalStateException("Not connected")
+
+        val result = authRoundTrip(timeoutMs = 5_000) { Result.failure(boom) }
+
+        assertSame(boom, result.exceptionOrNull())
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/api/SilentReauthTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/api/SilentReauthTest.kt
@@ -1,0 +1,157 @@
+package io.music_assistant.client.api
+
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The silent-reauth retry engine: a reconnect re-auth that fails to complete is
+ * retried in place, and only surfaced to login once the consecutive-failure budget
+ * is spent.
+ */
+class SilentReauthTest {
+    private fun answer(rawJson: String): Answer =
+        Answer(Json.parseToJsonElement(rawJson) as JsonObject)
+
+    private fun engine(maxSilentFailures: Int = 3) =
+        SilentReauth(
+            ReauthPolicy(
+                maxSilentFailures = maxSilentFailures,
+                roundTripTimeoutMs = 5_000,
+                retryDelayMs = 1_000,
+            ),
+        )
+
+    private val userPayload = """{"message_id":"m","result":{"user":{"username":"daveb"}}}"""
+
+    @Test
+    fun toleratedTimeoutRetriesUntilSuccess() = runTest {
+        var calls = 0
+
+        val resolution = engine().resolve(
+            isAutoLogin = true,
+            shouldAttempt = { true },
+            onAttempt = {},
+            send = {
+                calls++
+                if (calls == 1) awaitCancellation() else answer(userPayload).let { Result.success(it) }
+            },
+        )
+
+        assertTrue(resolution is AuthResolution.Authenticated)
+        assertEquals(2, calls, "A tolerated timeout must trigger a retry, not dead-end on InProgress")
+    }
+
+    @Test
+    fun persistentSilentTimeoutsSurfaceAfterBudget() = runTest {
+        var calls = 0
+
+        val resolution = engine(maxSilentFailures = 3).resolve(
+            isAutoLogin = true,
+            shouldAttempt = { true },
+            onAttempt = {},
+            send = {
+                calls++
+                awaitCancellation()
+            },
+        )
+
+        assertTrue(resolution is AuthResolution.Surface)
+        assertEquals(3, calls, "Budget of 3 means three attempts before surfacing login")
+    }
+
+    @Test
+    fun manualLoginTimeoutSurfacesWithoutRetry() = runTest {
+        var calls = 0
+
+        val resolution = engine().resolve(
+            isAutoLogin = false,
+            shouldAttempt = { true },
+            onAttempt = {},
+            send = {
+                calls++
+                awaitCancellation()
+            },
+        )
+
+        assertTrue(resolution is AuthResolution.Surface)
+        assertEquals(1, calls, "A user-initiated login must surface on the first failure, no silent retry")
+    }
+
+    @Test
+    fun serverRejectionRejectsWithoutRetry() = runTest {
+        var calls = 0
+
+        val resolution = engine().resolve(
+            isAutoLogin = true,
+            shouldAttempt = { true },
+            onAttempt = {},
+            send = {
+                calls++
+                Result.success(answer("""{"message_id":"m","error_code":20,"error":"Token expired"}"""))
+            },
+        )
+
+        assertTrue(resolution is AuthResolution.Reject)
+        assertEquals("Token expired", resolution.message)
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun abortsWhenConnectionDropsDuringAttempt() = runTest {
+        var connected = true
+
+        val resolution = engine().resolve(
+            isAutoLogin = true,
+            shouldAttempt = { connected },
+            onAttempt = {},
+            send = {
+                connected = false
+                awaitCancellation()
+            },
+        )
+
+        assertTrue(resolution is AuthResolution.Aborted)
+    }
+
+    @Test
+    fun silentFailuresPersistAcrossResolveCalls() = runTest {
+        val engine = engine(maxSilentFailures = 2)
+        var calls = 0
+        val send: suspend () -> Result<Answer> = {
+            calls++
+            awaitCancellation()
+        }
+
+        assertTrue(engine.resolve(true, { true }, {}, send) is AuthResolution.Surface)
+        val afterFirst = calls
+        assertTrue(engine.resolve(true, { true }, {}, send) is AuthResolution.Surface)
+
+        assertEquals(
+            1,
+            calls - afterFirst,
+            "A prior episode's failures must carry over so a flapping transport still escalates",
+        )
+    }
+
+    @Test
+    fun resetClearsAccumulatedFailures() = runTest {
+        val engine = engine(maxSilentFailures = 2)
+        var calls = 0
+        val send: suspend () -> Result<Answer> = {
+            calls++
+            awaitCancellation()
+        }
+
+        engine.resolve(true, { true }, {}, send)
+        engine.reset()
+        val afterReset = calls
+        engine.resolve(true, { true }, {}, send)
+
+        assertEquals(2, calls - afterReset, "reset() must restore the full budget for a new episode")
+    }
+}


### PR DESCRIPTION
I have been "blessed" with crappy cell signal and wifi over the past couple of days. That helped me discover a bug where we could end up in a state where the app thinks it's logged out, when it was actually just timing out on a reconnection to the MA server after the web socket was torn down. Specifically, we were treating a timeout as an auth failure vs. network instability that should be retried a set number of times. That led me down a *little* bit of a rabbit hole, in terms of hardening the auth/re-auth paths. I've tested this against the same crappy connection and haven't been able to reproduce the bug, and it seems to be working / resilient in all the normal ways.


Commit message:

The server authenticates per WebSocket connection, so every reconnect re-runs client/auth. On a flaky network that round-trip can fail; the old code treated any failure as an auth rejection and bounced the user to the login screen despite a still-valid token.

Replace that with a small, unit-tested retry engine (SilentReauth) that the auth flow delegates to:

- A silent (reconnect) re-auth that doesn't complete is retried in place with backoff, and only surfaces the login screen once a bounded budget of consecutive failures is spent. A user-initiated login still surfaces on the first failure. This fixes both the false-logout and the dead-end where a tolerated failure left the session stuck on InProgress forever (AuthenticationManager does nothing for InProgress, and nothing re-drove the attempt without an unrelated transport bounce).

- A socket that dies after the send but before the reply (the reply rides the same WebSocket) is bounded by authRoundTrip()'s timeout, turning a would-be infinite suspend into a completed failure the budget counts.

- The failure budget persists across attempts so a flapping transport still escalates, but resets at each new connection episode (forceConnect / forceConnectWebRTC) so one server's failures don't leak into the next.

- The retry loop stops if the session drops or is logged out from under it, so a late retry can't undo a logout. CancellationException is now rethrown rather than mis-surfaced as an auth failure.