### PR TITLE
Don't use server dynamic colors

### DIFF
--- a/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTest.kt
@@ -48,7 +48,6 @@ class ItemDetailsTest {
                     DataState.NoData(),
                 ),
                 geEditablePlaylists = suspend { emptyList() },
-                fetchColors = { null },
             )
         }
 
@@ -73,7 +72,6 @@ class ItemDetailsTest {
                     playableItemsState = DataState.Data(tracks),
                 ),
                 geEditablePlaylists = suspend { emptyList() },
-                fetchColors = { null },
             )
         }
 
@@ -98,7 +96,6 @@ class ItemDetailsTest {
                     playableItemsState = DataState.Data(emptyList()),
                 ),
                 geEditablePlaylists = suspend { emptyList() },
-                fetchColors = { null },
             )
         }
 
@@ -117,7 +114,6 @@ class ItemDetailsTest {
                     albumsState = DataState.NoData(),
                     playableItemsState = DataState.Data(emptyList()),
                 ),
-                fetchColors = { null },
             )
         }
 
@@ -138,7 +134,6 @@ class ItemDetailsTest {
                     playableItemsState = DataState.Data(tracks),
                 ),
                 geEditablePlaylists = suspend { emptyList() },
-                fetchColors = { null },
             )
         }
 
@@ -165,7 +160,6 @@ class ItemDetailsTest {
                     playableItemsState = DataState.Data(episodes),
                 ),
                 geEditablePlaylists = suspend { emptyList() },
-                fetchColors = { null },
             )
         }
 
@@ -188,7 +182,6 @@ class ItemDetailsTest {
                     playableItemsState = DataState.NoData(),
                 ),
                 geEditablePlaylists = suspend { emptyList() },
-                fetchColors = { null },
             )
         }
 
@@ -216,7 +209,6 @@ class ItemDetailsTest {
             ItemDetails(
                 state = state.value,
                 geEditablePlaylists = suspend { emptyList() },
-                fetchColors = { null },
                 onPlayClick = onPlayClick,
             )
         }
@@ -258,7 +250,6 @@ class ItemDetailsTest {
                 state = state.value,
                 onBack = onBack,
                 geEditablePlaylists = suspend { emptyList() },
-                fetchColors = { null },
             )
         }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/DominantColor.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/DominantColor.kt
@@ -21,8 +21,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import coil3.compose.LocalPlatformContext
 import com.kmpalette.palette.graphics.Palette
-import io.music_assistant.client.data.model.server.MediaItemPalette
-import io.music_assistant.client.data.model.server.RgbColor
 import org.koin.compose.koinInject
 
 /**
@@ -35,24 +33,6 @@ data class ExtractedColors(
     val tintOnDark: Color,
     val tintOnLight: Color,
 )
-
-private fun RgbColor.toColor() = Color(r, g, b) // Compose Color(Int, Int, Int) expects 0..255
-
-/**
- * Build extraction colors from a server-provided palette. Uses the vivid `primary` (falling
- * back to `accent`) as the single background for both themes and derives the readable control
- * tint via [ensureReadable] — mirroring local artwork extraction so the server path looks
- * equally punchy. The muted `background_*`/`on_*` slots are intentionally unused. Returns null
- * when neither vivid slot is present, so the caller falls back to local extraction.
- */
-fun MediaItemPalette.toExtractedColors(): ExtractedColors? {
-    val base = (primary ?: accent)?.toColor() ?: return null
-    return ExtractedColors(
-        background = base,
-        tintOnDark = base.ensureReadable(onDarkSurface = true),
-        tintOnLight = base.ensureReadable(onDarkSurface = false),
-    )
-}
 
 /**
  * Suspending fetcher used by [rememberAnimatedPlayerColors] — supplied by the screen

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/DominantColor.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/DominantColor.kt
@@ -82,24 +82,17 @@ data class PlayerColors(
 @Composable
 fun rememberAnimatedPlayerColors(
     imageUrl: String?,
-    palette: MediaItemPalette?,
     fallback: Color,
     fetchColors: ExtractedColorsFetcher,
 ): State<PlayerColors> {
     val onDark = MaterialTheme.colorScheme.surface.luminance() < 0.5f
 
-    val serverColors = remember(palette) { palette?.toExtractedColors() }
-    val localColors by produceState<ExtractedColors?>(
-        initialValue = null,
-        key1 = imageUrl,
-        key2 = serverColors,
-    ) {
-        value = if (serverColors != null) null else imageUrl?.let { fetchColors(it) }
+    val extractedColors by produceState<ExtractedColors?>(initialValue = null, key1 = imageUrl) {
+        value = imageUrl?.let { fetchColors(it) }
     }
-    val extracted = serverColors ?: localColors
 
-    val targetDominant = extracted?.background ?: fallback
-    val targetTint = extracted
+    val targetDominant = extractedColors?.background ?: fallback
+    val targetTint = extractedColors
         ?.let { if (onDark) it.tintOnDark else it.tintOnLight }
         ?: fallback.ensureReadable(onDarkSurface = onDark)
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/DominantColor.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/DominantColor.kt
@@ -6,6 +6,7 @@
 package io.music_assistant.client.ui.compose.common
 
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.tween
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -14,6 +15,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import coil3.compose.LocalPlatformContext
@@ -96,11 +99,11 @@ fun rememberAnimatedPlayerColors(
         ?.let { if (onDark) it.tintOnDark else it.tintOnLight }
         ?: fallback.ensureReadable(onDarkSurface = onDark)
 
-    val animatedDominant by animateColorAsState(
+    val animatedDominant by rememberAnimatedColorAsState(
         targetValue = targetDominant,
         animationSpec = tween(durationMillis = 500),
     )
-    val animatedTint by animateColorAsState(
+    val animatedTint by rememberAnimatedColorAsState(
         targetValue = targetTint,
         animationSpec = tween(durationMillis = 500),
     )
@@ -179,5 +182,19 @@ private fun hueToRgb(p: Float, q: Float, t: Float): Float {
         tt < 1f / 2f -> q
         tt < 2f / 3f -> p + (q - p) * (2f / 3f - tt) * 6f
         else -> p
+    }
+}
+
+@Composable
+private fun rememberAnimatedColorAsState(
+    targetValue: Color,
+    animationSpec: AnimationSpec<Color>,
+): State<Color> {
+    var animated by rememberSaveable(targetValue) { mutableStateOf(false) }
+
+    return if (!animated) {
+        animateColorAsState(targetValue, animationSpec) { animated = true }
+    } else {
+        mutableStateOf(targetValue)
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/DominantColor.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/DominantColor.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
@@ -88,9 +89,9 @@ fun rememberAnimatedPlayerColors(
         animationSpec = tween(durationMillis = 500),
     )
 
-    val state = remember { mutableStateOf(PlayerColors(targetDominant, targetTint)) }
-    state.value = PlayerColors(animatedDominant, animatedTint)
-    return state
+    return derivedStateOf {
+        PlayerColors(animatedDominant, animatedTint)
+    }
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -194,7 +194,6 @@ fun PlayersPager(
             val media = it.player.currentMedia
             rememberAnimatedPlayerColors(
                 imageUrl = media?.imageUrl,
-                palette = media?.palette,
                 fallback = MaterialTheme.colorScheme.primaryContainer,
                 fetchColors = fetchColors,
             )

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -148,6 +147,7 @@ fun ItemDetailsScreen(
         onAlbumsSortChanged = itemDetailsViewModel::onAlbumsSortChanged,
         onPlayableItemsSortChanged = itemDetailsViewModel::onPlayableItemsSortChanged,
         onTabSelected = itemDetailsViewModel::onTabSelected,
+        fetchColors = rememberExtractedColorsFetcher(),
     )
 }
 
@@ -161,7 +161,7 @@ fun ItemDetails(
     toastState: ToastState = rememberToastState(),
     onNavigateToItem: (String, MediaType, String) -> Unit = { _, _, _ -> },
     geEditablePlaylists: suspend () -> List<Playlist> = suspend { emptyList() },
-    fetchColors: ExtractedColorsFetcher? = null,
+    fetchColors: ExtractedColorsFetcher = { null },
     addToPlaylist: (String?, Playlist) -> Unit = { _, _ -> },
     onLibraryClick: (AppMediaItem) -> Unit = {},
     onFavoriteClick: (AppMediaItem) -> Unit = {},
@@ -269,7 +269,7 @@ private fun ItemChildren(
     onRemoveFromPlaylist: (String, Int) -> Unit,
     libraryActions: LibraryActions,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
-    fetchColors: ExtractedColorsFetcher?,
+    fetchColors: ExtractedColorsFetcher,
     onBack: () -> Unit,
     onToggleViewMode: (MediaType) -> Unit,
     onAlbumsSortChanged: (SubItemContext, SortOption) -> Unit,
@@ -343,7 +343,7 @@ private fun ItemContent(
     onRemoveFromPlaylist: (String, Int) -> Unit,
     libraryActions: LibraryActions,
     providerIconFetcher: @Composable (Modifier, String) -> Unit,
-    fetchColors: ExtractedColorsFetcher?,
+    fetchColors: ExtractedColorsFetcher,
     onBack: () -> Unit,
     viewModeProvider: @Composable (MediaType) -> ViewMode,
     onToggleViewMode: (MediaType) -> Unit,
@@ -355,21 +355,10 @@ private fun ItemContent(
     // Tabs, the loading gate, and the selected tab are all derived in ItemDetailsViewModel.State.
     val tabs = state.tabs
 
-    // Artwork-driven header colors. Library items carry no server palette, so colors are
-    // extracted locally from the thumbnail (cached by DominantColorViewModel) — same path
-    // as the player. The fetcher is Koin-backed, so fall back to a no-op when one isn't
-    // supplied and there's no Koin graph (under @Preview or in tests).
-    val resolvedFetchColors: ExtractedColorsFetcher = fetchColors
-        ?: if (LocalInspectionMode.current) {
-            { null }
-        } else {
-            rememberExtractedColorsFetcher()
-        }
-
     val colors by rememberAnimatedPlayerColors(
         imageUrl = item.image(ImageType.THUMB)?.url,
         fallback = MaterialTheme.colorScheme.primaryContainer,
-        fetchColors = resolvedFetchColors,
+        fetchColors = fetchColors,
     )
 
     val heroSlot: @Composable () -> Unit = {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -47,6 +48,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.music_assistant.client.data.model.client.AppMediaItemFixtures
 import io.music_assistant.client.data.model.client.Chapter
 import io.music_assistant.client.data.model.client.ClickContext
+import io.music_assistant.client.data.model.client.ImageType
 import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.QueueOption
 import io.music_assistant.client.data.model.client.SortConfig
@@ -66,6 +68,7 @@ import io.music_assistant.client.data.model.client.stringResource
 import io.music_assistant.client.data.model.client.toClickContext
 import io.music_assistant.client.settings.ViewMode
 import io.music_assistant.client.ui.compose.common.DataState
+import io.music_assistant.client.ui.compose.common.ExtractedColorsFetcher
 import io.music_assistant.client.ui.compose.common.SortChip
 import io.music_assistant.client.ui.compose.common.ToastHost
 import io.music_assistant.client.ui.compose.common.ToastState
@@ -80,6 +83,8 @@ import io.music_assistant.client.ui.compose.common.items.ProvideClickActions
 import io.music_assistant.client.ui.compose.common.items.TrackWithMenu
 import io.music_assistant.client.ui.compose.common.items.supportsAddToPlaylist
 import io.music_assistant.client.ui.compose.common.providers.ProviderIcon
+import io.music_assistant.client.ui.compose.common.rememberAnimatedPlayerColors
+import io.music_assistant.client.ui.compose.common.rememberExtractedColorsFetcher
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.nav.Screen
@@ -156,6 +161,7 @@ fun ItemDetails(
     toastState: ToastState = rememberToastState(),
     onNavigateToItem: (String, MediaType, String) -> Unit = { _, _, _ -> },
     geEditablePlaylists: suspend () -> List<Playlist> = suspend { emptyList() },
+    fetchColors: ExtractedColorsFetcher? = null,
     addToPlaylist: (String?, Playlist) -> Unit = { _, _ -> },
     onLibraryClick: (AppMediaItem) -> Unit = {},
     onFavoriteClick: (AppMediaItem) -> Unit = {},
@@ -236,6 +242,7 @@ fun ItemDetails(
         onPlayableItemsSortChanged = onPlayableItemsSortChanged,
         onTabSelected = onTabSelected,
         contentPadding = contentPadding,
+        fetchColors = fetchColors,
     )
 }
 
@@ -262,6 +269,7 @@ private fun ItemChildren(
     onRemoveFromPlaylist: (String, Int) -> Unit,
     libraryActions: LibraryActions,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
+    fetchColors: ExtractedColorsFetcher?,
     onBack: () -> Unit,
     onToggleViewMode: (MediaType) -> Unit,
     onAlbumsSortChanged: (SubItemContext, SortOption) -> Unit,
@@ -306,6 +314,7 @@ private fun ItemChildren(
                     onPlayableItemsSortChanged = onPlayableItemsSortChanged,
                     contentPadding = contentPadding,
                     onTabSelected = onTabSelected,
+                    fetchColors = fetchColors,
                 )
             }
 
@@ -334,6 +343,7 @@ private fun ItemContent(
     onRemoveFromPlaylist: (String, Int) -> Unit,
     libraryActions: LibraryActions,
     providerIconFetcher: @Composable (Modifier, String) -> Unit,
+    fetchColors: ExtractedColorsFetcher?,
     onBack: () -> Unit,
     viewModeProvider: @Composable (MediaType) -> ViewMode,
     onToggleViewMode: (MediaType) -> Unit,
@@ -345,12 +355,30 @@ private fun ItemContent(
     // Tabs, the loading gate, and the selected tab are all derived in ItemDetailsViewModel.State.
     val tabs = state.tabs
 
+    // Artwork-driven header colors. Library items carry no server palette, so colors are
+    // extracted locally from the thumbnail (cached by DominantColorViewModel) — same path
+    // as the player. The fetcher is Koin-backed, so fall back to a no-op when one isn't
+    // supplied and there's no Koin graph (under @Preview or in tests).
+    val resolvedFetchColors: ExtractedColorsFetcher = fetchColors
+        ?: if (LocalInspectionMode.current) {
+            { null }
+        } else {
+            rememberExtractedColorsFetcher()
+        }
+
+    val colors by rememberAnimatedPlayerColors(
+        imageUrl = item.image(ImageType.THUMB)?.url,
+        fallback = MaterialTheme.colorScheme.primaryContainer,
+        fetchColors = resolvedFetchColors,
+    )
+
     val heroSlot: @Composable () -> Unit = {
         ProvideClickActions(ClickContext.DETAIL) {
             ItemHeader(
                 item = item,
                 providerIconFetcher = providerIconFetcher,
                 onPlayClick = onPlayItemClick,
+                colors = colors,
             )
         }
     }
@@ -363,6 +391,7 @@ private fun ItemContent(
                 libraryActions = libraryActions,
                 playlistActions = playlistActions.takeIf { item.supportsAddToPlaylist },
                 navigateToItem = onNavigateClick,
+                colors = colors,
             )
         },
     ) {
@@ -391,6 +420,7 @@ private fun ItemContent(
                         TabsBar(
                             tabs = tabs,
                             selectedIndex = safeIndex,
+                            controlTint = colors.controlTint,
                             onTabSelected = { onTabSelected(tabs[it]) },
                             albumsSortOption = state.albumsSortOption,
                             playableItemsSortOption = state.playableItemsSortOption,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -48,7 +47,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.music_assistant.client.data.model.client.AppMediaItemFixtures
 import io.music_assistant.client.data.model.client.Chapter
 import io.music_assistant.client.data.model.client.ClickContext
-import io.music_assistant.client.data.model.client.ImageType
 import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.QueueOption
 import io.music_assistant.client.data.model.client.SortConfig
@@ -68,7 +66,6 @@ import io.music_assistant.client.data.model.client.stringResource
 import io.music_assistant.client.data.model.client.toClickContext
 import io.music_assistant.client.settings.ViewMode
 import io.music_assistant.client.ui.compose.common.DataState
-import io.music_assistant.client.ui.compose.common.ExtractedColorsFetcher
 import io.music_assistant.client.ui.compose.common.SortChip
 import io.music_assistant.client.ui.compose.common.ToastHost
 import io.music_assistant.client.ui.compose.common.ToastState
@@ -83,8 +80,6 @@ import io.music_assistant.client.ui.compose.common.items.ProvideClickActions
 import io.music_assistant.client.ui.compose.common.items.TrackWithMenu
 import io.music_assistant.client.ui.compose.common.items.supportsAddToPlaylist
 import io.music_assistant.client.ui.compose.common.providers.ProviderIcon
-import io.music_assistant.client.ui.compose.common.rememberAnimatedPlayerColors
-import io.music_assistant.client.ui.compose.common.rememberExtractedColorsFetcher
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.nav.Screen
@@ -161,7 +156,6 @@ fun ItemDetails(
     toastState: ToastState = rememberToastState(),
     onNavigateToItem: (String, MediaType, String) -> Unit = { _, _, _ -> },
     geEditablePlaylists: suspend () -> List<Playlist> = suspend { emptyList() },
-    fetchColors: ExtractedColorsFetcher? = null,
     addToPlaylist: (String?, Playlist) -> Unit = { _, _ -> },
     onLibraryClick: (AppMediaItem) -> Unit = {},
     onFavoriteClick: (AppMediaItem) -> Unit = {},
@@ -236,7 +230,6 @@ fun ItemDetails(
         onRemoveFromPlaylist = onRemoveFromPlaylist,
         libraryActions = libraryActions,
         providerIconFetcher = providerIconFetcher,
-        fetchColors = fetchColors,
         onBack = onBack,
         onToggleViewMode = onToggleViewMode,
         onAlbumsSortChanged = onAlbumsSortChanged,
@@ -269,7 +262,6 @@ private fun ItemChildren(
     onRemoveFromPlaylist: (String, Int) -> Unit,
     libraryActions: LibraryActions,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
-    fetchColors: ExtractedColorsFetcher?,
     onBack: () -> Unit,
     onToggleViewMode: (MediaType) -> Unit,
     onAlbumsSortChanged: (SubItemContext, SortOption) -> Unit,
@@ -308,7 +300,6 @@ private fun ItemChildren(
                     onRemoveFromPlaylist = onRemoveFromPlaylist,
                     libraryActions = libraryActions,
                     providerIconFetcher = providerIconFetcher,
-                    fetchColors = fetchColors,
                     onBack = onBack,
                     onToggleViewMode = onToggleViewMode,
                     onAlbumsSortChanged = onAlbumsSortChanged,
@@ -343,7 +334,6 @@ private fun ItemContent(
     onRemoveFromPlaylist: (String, Int) -> Unit,
     libraryActions: LibraryActions,
     providerIconFetcher: @Composable (Modifier, String) -> Unit,
-    fetchColors: ExtractedColorsFetcher?,
     onBack: () -> Unit,
     viewModeProvider: @Composable (MediaType) -> ViewMode,
     onToggleViewMode: (MediaType) -> Unit,
@@ -355,28 +345,10 @@ private fun ItemContent(
     // Tabs, the loading gate, and the selected tab are all derived in ItemDetailsViewModel.State.
     val tabs = state.tabs
 
-    // Artwork-driven header colors. Library items carry no server palette, so colors are
-    // extracted locally from the thumbnail (cached by DominantColorViewModel) — same path
-    // as the player. The fetcher is Koin-backed, so fall back to a no-op when one isn't
-    // supplied and there's no Koin graph (under @Preview or in tests).
-    val resolvedFetchColors: ExtractedColorsFetcher = fetchColors
-        ?: if (LocalInspectionMode.current) {
-            { null }
-        } else {
-            rememberExtractedColorsFetcher()
-        }
-    val colors by rememberAnimatedPlayerColors(
-        imageUrl = item.image(ImageType.THUMB)?.url,
-        palette = null,
-        fallback = MaterialTheme.colorScheme.primaryContainer,
-        fetchColors = resolvedFetchColors,
-    )
-
     val heroSlot: @Composable () -> Unit = {
         ProvideClickActions(ClickContext.DETAIL) {
             ItemHeader(
                 item = item,
-                colors = colors,
                 providerIconFetcher = providerIconFetcher,
                 onPlayClick = onPlayItemClick,
             )
@@ -387,7 +359,6 @@ private fun ItemContent(
         topBar = {
             ItemTopBar(
                 item = item,
-                colors = colors,
                 onBack = onBack,
                 libraryActions = libraryActions,
                 playlistActions = playlistActions.takeIf { item.supportsAddToPlaylist },
@@ -420,7 +391,6 @@ private fun ItemContent(
                         TabsBar(
                             tabs = tabs,
                             selectedIndex = safeIndex,
-                            controlTint = colors.controlTint,
                             onTabSelected = { onTabSelected(tabs[it]) },
                             albumsSortOption = state.albumsSortOption,
                             playableItemsSortOption = state.playableItemsSortOption,
@@ -463,7 +433,7 @@ private fun ItemContent(
 private fun TabsBar(
     tabs: List<ItemDetailsTab>,
     selectedIndex: Int,
-    controlTint: Color,
+    controlTint: Color = MaterialTheme.colorScheme.primary,
     onTabSelected: (Int) -> Unit,
     albumsSortOption: SortOption?,
     playableItemsSortOption: SortOption?,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
@@ -170,11 +170,9 @@ internal fun ItemTopBar(
     // tween on top of our color animation and visibly lag the header. Transparent container =
     // single-pass color change, in lockstep with the header gradient.
     Box(
-        modifier = Modifier.apply {
-            colors?.dominant?.inactive()?.let {
-                background(Brush.verticalGradient(listOf(it, MaterialTheme.colorScheme.surface)))
-            }
-        },
+        modifier = Modifier.background(
+            colors?.dominant?.inactive() ?: MaterialTheme.colorScheme.primaryContainer.inactive(),
+        ),
     ) {
         TopAppBar(
             title = {},
@@ -217,10 +215,12 @@ private fun ItemOverflow(
             when (it) {
                 ItemAction.AddToLibrary,
                 ItemAction.RemoveFromLibrary,
-                -> libraryActions?.onLibraryClick(item)
+                    -> libraryActions?.onLibraryClick(item)
+
                 ItemAction.Favorite,
                 ItemAction.Unfavorite,
-                -> libraryActions?.onFavoriteClick(item)
+                    -> libraryActions?.onFavoriteClick(item)
+
                 ItemAction.AddToPlaylist -> showPlaylistDialog = true
                 else -> Unit
             }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
@@ -78,10 +78,7 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun ItemHeader(
     item: AppMediaItem,
-    colors: PlayerColors = PlayerColors(
-        MaterialTheme.colorScheme.primaryContainer,
-        MaterialTheme.colorScheme.primary,
-    ),
+    colors: PlayerColors? = null,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)? = null,
     onPlayClick: (QueueOption, Boolean) -> Unit = { _, _ -> },
 ) {
@@ -90,11 +87,17 @@ fun ItemHeader(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .background(
-                Brush.verticalGradient(
-                    listOf(colors.dominant.inactive(), MaterialTheme.colorScheme.surface),
-                ),
-            ),
+            .let {
+                if (colors != null) {
+                    it.background(
+                        Brush.verticalGradient(
+                            listOf(colors.dominant.inactive(), MaterialTheme.colorScheme.surface),
+                        ),
+                    )
+                } else {
+                    it
+                }
+            },
     ) {
         val image = @Composable {
             Image(
@@ -108,7 +111,7 @@ fun ItemHeader(
             ItemPlayButton(
                 item,
                 onPlayClick = onPlayClick,
-                tint = colors.controlTint,
+                tint = colors?.controlTint,
                 modifier = Modifier.padding(top = 8.dp),
             )
         }
@@ -138,10 +141,7 @@ fun ItemHeader(
 @Composable
 internal fun ItemTopBar(
     item: AppMediaItem,
-    colors: PlayerColors = PlayerColors(
-        MaterialTheme.colorScheme.primaryContainer,
-        MaterialTheme.colorScheme.primary,
-    ),
+    colors: PlayerColors? = null,
     onBack: () -> Unit,
     libraryActions: LibraryActions?,
     playlistActions: PlaylistActions?,
@@ -150,23 +150,37 @@ internal fun ItemTopBar(
     // Flat fill equal to the header gradient's top color, so the bar reads as one
     // continuous wash with the header below it. Back/overflow icons are NOT control-tinted
     // — just black or white per the composited bar luminance, keeping them legible.
-    val barBg = colors.dominant.inactive()
-    val onBar = lerp(MaterialTheme.colorScheme.surface, colors.dominant, INACTIVE_ALPHA)
-        .contentColorByLuminance()
+    val topAppBarColors = if (colors != null) {
+        val onBar = lerp(MaterialTheme.colorScheme.surface, colors.dominant, INACTIVE_ALPHA)
+            .contentColorByLuminance()
+
+        TopAppBarDefaults.topAppBarColors(
+            containerColor = Color.Transparent,
+            scrolledContainerColor = Color.Transparent,
+            navigationIconContentColor = onBar,
+            actionIconContentColor = onBar,
+            titleContentColor = onBar,
+        )
+    } else {
+        TopAppBarDefaults.topAppBarColors()
+    }
+
     // Paint barBg directly on the wrapping Box rather than via TopAppBar's containerColor:
     // TopAppBar runs its own animateColorAsState on the container, which would stack a second
     // tween on top of our color animation and visibly lag the header. Transparent container =
     // single-pass color change, in lockstep with the header gradient.
-    Box(modifier = Modifier.background(barBg)) {
+    Box(
+        modifier = Modifier.let {
+            if (colors != null) {
+                it.background(colors.dominant.inactive())
+            } else {
+                it
+            }
+        },
+    ) {
         TopAppBar(
             title = {},
-            colors = TopAppBarDefaults.topAppBarColors(
-                containerColor = Color.Transparent,
-                scrolledContainerColor = Color.Transparent,
-                navigationIconContentColor = onBar,
-                actionIconContentColor = onBar,
-                titleContentColor = onBar,
-            ),
+            colors = topAppBarColors,
             navigationIcon = {
                 IconButton(onClick = onBack) {
                     Icon(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
@@ -170,11 +170,9 @@ internal fun ItemTopBar(
     // tween on top of our color animation and visibly lag the header. Transparent container =
     // single-pass color change, in lockstep with the header gradient.
     Box(
-        modifier = Modifier.let {
-            if (colors != null) {
-                it.background(colors.dominant.inactive())
-            } else {
-                it
+        modifier = Modifier.apply {
+            colors?.dominant?.inactive()?.let {
+                background(Brush.verticalGradient(listOf(it, MaterialTheme.colorScheme.surface)))
             }
         },
     ) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemPlayButton.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemPlayButton.kt
@@ -7,7 +7,6 @@ import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SplitButtonDefaults.LeadingButton
 import androidx.compose.material3.SplitButtonDefaults.TrailingButton
 import androidx.compose.material3.SplitButtonLayout
@@ -44,17 +43,21 @@ import org.jetbrains.compose.resources.stringResource
 fun ItemPlayButton(
     item: AppMediaItem,
     onPlayClick: (QueueOption, Boolean) -> Unit,
-    tint: Color = MaterialTheme.colorScheme.primary,
+    tint: Color? = null,
     modifier: Modifier = Modifier,
 ) {
     if (!item.isPlayable) return
 
-    // Art-derived control tint as the button fill; black/white content per its luminance.
-    val onTint = tint.contentColorByLuminance()
-    val buttonColors = ButtonDefaults.buttonColors(
-        containerColor = tint,
-        contentColor = onTint,
-    )
+    val buttonColors = if (tint != null)  {
+        // Art-derived control tint as the button fill; black/white content per its luminance.
+        val onTint = tint.contentColorByLuminance()
+        ButtonDefaults.buttonColors(
+            containerColor = tint,
+            contentColor = onTint,
+        )
+    } else {
+        ButtonDefaults.buttonColors()
+    }
 
     // The detail header is wrapped in ProvideClickActions(DETAIL), so the config resolves
     // this item's DETAIL default. effectiveActionFor is non-null here (item is playable).


### PR DESCRIPTION
As discussed, this removes the server colors (which creates inconsitencies) and just uses the locally calculated colors everywhere. I've also made sure that animations only run once for a navigation entry so you don't see colors pop back in when going back.