### PR TITLE
Add "Play from here" as default click option

### DIFF
--- a/androidApp/src/main/kotlin/io/music_assistant/client/auto/AutoLibrary.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/auto/AutoLibrary.kt
@@ -373,7 +373,7 @@ class AutoLibrary(
         DefaultClickOption.INSERT_NEXT -> "Add all next"
         DefaultClickOption.ADD_TO_QUEUE -> "Add all to queue"
         DefaultClickOption.START_RADIO -> "Start radio"
-        else -> throw IllegalStateException()
+        else -> throw IllegalArgumentException("$name not supported by Android Auto!")
     }
 
     @DrawableRes
@@ -383,7 +383,7 @@ class AutoLibrary(
         DefaultClickOption.INSERT_NEXT, DefaultClickOption.ADD_TO_QUEUE ->
             android.R.drawable.ic_menu_add
         DefaultClickOption.START_RADIO -> android.R.drawable.ic_menu_compass
-        else -> throw IllegalStateException()
+        else -> throw IllegalArgumentException("$name not supported by Android Auto!")
     }
 
     fun search(

--- a/androidApp/src/main/kotlin/io/music_assistant/client/auto/AutoLibrary.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/auto/AutoLibrary.kt
@@ -32,7 +32,7 @@ import io.music_assistant.client.data.model.server.SearchResult
 import io.music_assistant.client.data.model.server.ServerMediaItem
 import io.music_assistant.client.data.planLocalPlayerDispatch
 import io.music_assistant.client.settings.CarPlatform
-import io.music_assistant.client.settings.DefaultClickAction
+import io.music_assistant.client.settings.DefaultClickOption
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.settings.carBulkActions
 import io.music_assistant.client.settings.carTapAction
@@ -367,21 +367,21 @@ class AutoLibrary(
 
     // Bulk-button labels/icons. AA titles are hard-coded English to match the rest of this
     // library (tab names, sub-lists). "All" framing because the action applies to the container.
-    private fun DefaultClickAction.bulkTitle(): String = when (this) {
-        DefaultClickAction.PLAY_NOW -> "Play all"
-        DefaultClickAction.INSERT_NEXT_AND_PLAY -> "Play all next"
-        DefaultClickAction.INSERT_NEXT -> "Add all next"
-        DefaultClickAction.ADD_TO_QUEUE -> "Add all to queue"
-        DefaultClickAction.START_RADIO -> "Start radio"
+    private fun DefaultClickOption.bulkTitle(): String = when (this) {
+        DefaultClickOption.PLAY_NOW -> "Play all"
+        DefaultClickOption.INSERT_NEXT_AND_PLAY -> "Play all next"
+        DefaultClickOption.INSERT_NEXT -> "Add all next"
+        DefaultClickOption.ADD_TO_QUEUE -> "Add all to queue"
+        DefaultClickOption.START_RADIO -> "Start radio"
     }
 
     @DrawableRes
-    private fun DefaultClickAction.bulkIcon(): Int = when (this) {
-        DefaultClickAction.PLAY_NOW, DefaultClickAction.INSERT_NEXT_AND_PLAY ->
+    private fun DefaultClickOption.bulkIcon(): Int = when (this) {
+        DefaultClickOption.PLAY_NOW, DefaultClickOption.INSERT_NEXT_AND_PLAY ->
             android.R.drawable.ic_media_play
-        DefaultClickAction.INSERT_NEXT, DefaultClickAction.ADD_TO_QUEUE ->
+        DefaultClickOption.INSERT_NEXT, DefaultClickOption.ADD_TO_QUEUE ->
             android.R.drawable.ic_menu_add
-        DefaultClickAction.START_RADIO -> android.R.drawable.ic_menu_compass
+        DefaultClickOption.START_RADIO -> android.R.drawable.ic_menu_compass
     }
 
     fun search(
@@ -760,12 +760,12 @@ class AutoLibrary(
         // car default (encoded MediaType -> ItemKind). valueOf throws on unknown names — a stale
         // item or malformed bundle would crash the service — so every decode falls back silently.
         val explicit = extras?.getString(MediaIds.ACTION_KEY)
-            ?.let { runCatching { DefaultClickAction.valueOf(it) }.getOrNull() }
+            ?.let { runCatching { DefaultClickOption.valueOf(it) }.getOrNull() }
         val action = explicit ?: parts.getOrNull(2)
             ?.let { runCatching { MediaType.valueOf(it) }.getOrNull() }
             ?.toItemKind()
             ?.let { settingsRepository.carPlayableClickActions.value.carTapAction(it) }
-            ?: DefaultClickAction.PLAY_NOW
+            ?: DefaultClickOption.PLAY_NOW
         val dispatch = action.toCarDispatch()
         scope.launch { dispatchToLocalPlayer(listOf(uri), dispatch.option, dispatch.radioMode) }
     }

--- a/androidApp/src/main/kotlin/io/music_assistant/client/auto/AutoLibrary.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/auto/AutoLibrary.kt
@@ -373,6 +373,7 @@ class AutoLibrary(
         DefaultClickOption.INSERT_NEXT -> "Add all next"
         DefaultClickOption.ADD_TO_QUEUE -> "Add all to queue"
         DefaultClickOption.START_RADIO -> "Start radio"
+        else -> throw IllegalStateException()
     }
 
     @DrawableRes
@@ -382,6 +383,7 @@ class AutoLibrary(
         DefaultClickOption.INSERT_NEXT, DefaultClickOption.ADD_TO_QUEUE ->
             android.R.drawable.ic_menu_add
         DefaultClickOption.START_RADIO -> android.R.drawable.ic_menu_compass
+        else -> throw IllegalStateException()
     }
 
     fun search(

--- a/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTest.kt
@@ -13,12 +13,11 @@ import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.music_assistant.client.data.model.client.AppMediaItemFixtures
 import io.music_assistant.client.data.model.client.QueueOption
-import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.support.get
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.support.inScrollable
 import io.music_assistant.client.utils.support.MockFunction0
-import io.music_assistant.client.utils.support.MockFunction3
+import io.music_assistant.client.utils.support.MockFunction2
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.action_go_to_artist
 import musicassistantclient.composeapp.generated.resources.cd_more
@@ -210,7 +209,7 @@ class ItemDetailsTest {
             ),
         )
 
-        val onPlayClick = MockFunction3<QueueOption, Boolean, AppMediaItem?>()
+        val onPlayClick = MockFunction2<QueueOption, Boolean>()
 
         composeTestRule.setContent {
             ItemDetails(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/CarActionPrefs.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/CarActionPrefs.kt
@@ -27,19 +27,19 @@ val carBrowsableKinds: List<ItemKind> = listOf(
 )
 
 /** Today's hard-coded pair — the default bulk actions for a browsable kind with no stored config. */
-val defaultCarBulkActions: List<DefaultClickAction> = listOf(
-    DefaultClickAction.PLAY_NOW,
-    DefaultClickAction.ADD_TO_QUEUE,
+val defaultCarBulkActions: List<DefaultClickOption> = listOf(
+    DefaultClickOption.PLAY_NOW,
+    DefaultClickOption.ADD_TO_QUEUE,
 )
 
 /**
  * Whether this action can be offered/honored on [platform] for [kind]. Intersects the kind
- * applicability ([DefaultClickAction.appliesTo]) with per-platform capability. Both the Settings
+ * applicability ([DefaultClickOption.appliesTo]) with per-platform capability. Both the Settings
  * UI (offered options) and the car-side dispatch consult this, so an unsupported stored action is
  * silently skipped rather than mis-dispatched. The platform arms are identical today; the seam
  * exists so a future CarPlay/AA limitation lands in one place.
  */
-fun DefaultClickAction.isCarSupported(platform: CarPlatform, kind: ItemKind): Boolean {
+fun DefaultClickOption.isCarSupported(platform: CarPlatform, kind: ItemKind): Boolean {
     if (!appliesTo(kind)) return false
     return when (platform) {
         CarPlatform.ANDROID_AUTO -> true
@@ -48,29 +48,29 @@ fun DefaultClickAction.isCarSupported(platform: CarPlatform, kind: ItemKind): Bo
 }
 
 /** The action a plain tap performs for [kind] in the car, falling back to today's PLAY_NOW. */
-fun Map<ItemKind, DefaultClickAction>.carTapAction(kind: ItemKind): DefaultClickAction =
-    this[kind] ?: DefaultClickAction.PLAY_NOW
+fun Map<ItemKind, DefaultClickOption>.carTapAction(kind: ItemKind): DefaultClickOption =
+    this[kind] ?: DefaultClickOption.PLAY_NOW
 
 /**
  * The ordered, platform-supported bulk buttons shown for browsable [kind] in [platform], defaulting
  * to [defaultCarBulkActions] when unconfigured. Always filtered through [isCarSupported].
  */
-fun Map<ItemKind, List<DefaultClickAction>>.carBulkActions(
+fun Map<ItemKind, List<DefaultClickOption>>.carBulkActions(
     kind: ItemKind,
     platform: CarPlatform,
-): List<DefaultClickAction> =
+): List<DefaultClickOption> =
     (this[kind] ?: defaultCarBulkActions).filter { it.isCarSupported(platform, kind) }
 
-/** How a [DefaultClickAction] is dispatched to a player: queue option + radio-mode flag. */
+/** How a [DefaultClickOption] is dispatched to a player: queue option + radio-mode flag. */
 data class CarDispatch(val option: QueueOption, val radioMode: Boolean)
 
 /** The single source for turning a chosen action into a play_media dispatch (AA and CarPlay share it). */
-fun DefaultClickAction.toCarDispatch(): CarDispatch = when (this) {
-    DefaultClickAction.PLAY_NOW -> CarDispatch(QueueOption.REPLACE, radioMode = false)
-    DefaultClickAction.INSERT_NEXT_AND_PLAY -> CarDispatch(QueueOption.PLAY, radioMode = false)
-    DefaultClickAction.INSERT_NEXT -> CarDispatch(QueueOption.NEXT, radioMode = false)
-    DefaultClickAction.ADD_TO_QUEUE -> CarDispatch(QueueOption.ADD, radioMode = false)
-    DefaultClickAction.START_RADIO -> CarDispatch(QueueOption.REPLACE, radioMode = true)
+fun DefaultClickOption.toCarDispatch(): CarDispatch = when (this) {
+    DefaultClickOption.PLAY_NOW -> CarDispatch(QueueOption.REPLACE, radioMode = false)
+    DefaultClickOption.INSERT_NEXT_AND_PLAY -> CarDispatch(QueueOption.PLAY, radioMode = false)
+    DefaultClickOption.INSERT_NEXT -> CarDispatch(QueueOption.NEXT, radioMode = false)
+    DefaultClickOption.ADD_TO_QUEUE -> CarDispatch(QueueOption.ADD, radioMode = false)
+    DefaultClickOption.START_RADIO -> CarDispatch(QueueOption.REPLACE, radioMode = true)
 }
 
 /** The car surface the current platform exposes. */

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/CarActionPrefs.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/CarActionPrefs.kt
@@ -41,9 +41,14 @@ val defaultCarBulkActions: List<DefaultClickOption> = listOf(
  */
 fun DefaultClickOption.isCarSupported(platform: CarPlatform, kind: ItemKind): Boolean {
     if (!appliesTo(kind)) return false
-    return when (platform) {
-        CarPlatform.ANDROID_AUTO -> true
-        CarPlatform.CARPLAY -> true
+
+    return if (this == DefaultClickOption.PLAY_FROM_HERE) {
+        false
+    } else {
+        when (platform) {
+            CarPlatform.ANDROID_AUTO -> true
+            CarPlatform.CARPLAY -> true
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/CarActionPrefs.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/CarActionPrefs.kt
@@ -71,6 +71,7 @@ fun DefaultClickOption.toCarDispatch(): CarDispatch = when (this) {
     DefaultClickOption.INSERT_NEXT -> CarDispatch(QueueOption.NEXT, radioMode = false)
     DefaultClickOption.ADD_TO_QUEUE -> CarDispatch(QueueOption.ADD, radioMode = false)
     DefaultClickOption.START_RADIO -> CarDispatch(QueueOption.REPLACE, radioMode = true)
+    else -> throw IllegalStateException()
 }
 
 /** The car surface the current platform exposes. */

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/CarActionPrefs.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/CarActionPrefs.kt
@@ -76,7 +76,7 @@ fun DefaultClickOption.toCarDispatch(): CarDispatch = when (this) {
     DefaultClickOption.INSERT_NEXT -> CarDispatch(QueueOption.NEXT, radioMode = false)
     DefaultClickOption.ADD_TO_QUEUE -> CarDispatch(QueueOption.ADD, radioMode = false)
     DefaultClickOption.START_RADIO -> CarDispatch(QueueOption.REPLACE, radioMode = true)
-    else -> throw IllegalStateException()
+    else -> throw IllegalArgumentException("$name not supported by Android Auto!")
 }
 
 /** The car surface the current platform exposes. */

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/DefaultClickOption.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/DefaultClickOption.kt
@@ -8,7 +8,7 @@ import io.music_assistant.client.data.model.client.ItemKind
  * (ItemKind, ClickContext). Pure preference value (no UI deps) — UI mapping lives in
  * DefaultClickActionUi.kt.
  */
-enum class DefaultClickAction {
+enum class DefaultClickOption {
     PLAY_NOW,
     INSERT_NEXT_AND_PLAY,
     INSERT_NEXT,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/DefaultClickOption.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/DefaultClickOption.kt
@@ -14,6 +14,7 @@ enum class DefaultClickOption {
     INSERT_NEXT,
     ADD_TO_QUEUE,
     START_RADIO,
+    PLAY_FROM_HERE,
     ;
 
     /** Whether this action is ever meaningful for [kind] — gates the matrix ROW. */
@@ -33,10 +34,13 @@ enum class DefaultClickOption {
      * Extension hook for context-restricted actions (e.g. a future Track action valid
      * only in Album/Playlist); currently everything applicable is available everywhere.
      */
-    fun isAvailableIn(context: ClickContext, kind: ItemKind): Boolean = when (context) {
-        ClickContext.ARTIST,
-        ClickContext.PLAYLIST,
-        -> appliesTo(kind) // TODO wire up logic for start from here
-        else -> appliesTo(kind)
+    fun isAvailableIn(context: ClickContext, kind: ItemKind): Boolean = when (this) {
+        PLAY_FROM_HERE -> context == ClickContext.ALBUM
+        else -> when (context) {
+            ClickContext.ARTIST,
+            ClickContext.PLAYLIST,
+            -> appliesTo(kind)
+            else -> appliesTo(kind)
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/DefaultClickOption.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/DefaultClickOption.kt
@@ -35,7 +35,7 @@ enum class DefaultClickOption {
      * only in Album/Playlist); currently everything applicable is available everywhere.
      */
     fun isAvailableIn(context: ClickContext, kind: ItemKind): Boolean = when (this) {
-        PLAY_FROM_HERE -> context == ClickContext.ALBUM
+        PLAY_FROM_HERE -> context == ClickContext.ALBUM || context == ClickContext.PLAYLIST
         else -> when (context) {
             ClickContext.ARTIST,
             ClickContext.PLAYLIST,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/SettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/SettingsRepository.kt
@@ -197,14 +197,14 @@ class SettingsRepository(
     private val _defaultClickActions = MutableStateFlow(loadDefaultClickActions())
     val defaultClickActions = _defaultClickActions.asStateFlow()
 
-    private fun loadDefaultClickActions(): Map<ItemKind, Map<ClickContext, DefaultClickAction>> {
+    private fun loadDefaultClickActions(): Map<ItemKind, Map<ClickContext, DefaultClickOption>> {
         val raw = settings.getStringOrNull("default_click_actions") ?: return emptyMap()
         return runCatching {
             myJson.decodeFromString<Map<String, Map<String, String>>>(raw).mapNotNull { (k, perContext) ->
                 val kind = runCatching { ItemKind.valueOf(k) }.getOrNull() ?: return@mapNotNull null
                 kind to perContext.mapNotNull { (c, v) ->
                     val ctx = runCatching { ClickContext.valueOf(c) }.getOrNull() ?: return@mapNotNull null
-                    val action = runCatching { DefaultClickAction.valueOf(v) }.getOrNull() ?: return@mapNotNull null
+                    val action = runCatching { DefaultClickOption.valueOf(v) }.getOrNull() ?: return@mapNotNull null
                     ctx to action
                 }.toMap()
             }.toMap()
@@ -212,7 +212,7 @@ class SettingsRepository(
     }
 
     /** Replaces the per-context table for a single [kind]; other kinds are preserved. */
-    fun setDefaultClickActions(kind: ItemKind, perContext: Map<ClickContext, DefaultClickAction>) {
+    fun setDefaultClickActions(kind: ItemKind, perContext: Map<ClickContext, DefaultClickOption>) {
         val updated = _defaultClickActions.value.toMutableMap().apply { put(kind, perContext) }
         val encoded = myJson.encodeToString(
             updated.entries.associate { (k, m) -> k.name to m.entries.associate { it.key.name to it.value.name } },
@@ -227,18 +227,18 @@ class SettingsRepository(
     private val _carPlayableClickActions = MutableStateFlow(loadCarPlayableClickActions())
     val carPlayableClickActions = _carPlayableClickActions.asStateFlow()
 
-    private fun loadCarPlayableClickActions(): Map<ItemKind, DefaultClickAction> {
+    private fun loadCarPlayableClickActions(): Map<ItemKind, DefaultClickOption> {
         val raw = settings.getStringOrNull("car_playable_click_actions") ?: return emptyMap()
         return runCatching {
             myJson.decodeFromString<Map<String, String>>(raw).mapNotNull { (k, v) ->
                 val kind = runCatching { ItemKind.valueOf(k) }.getOrNull() ?: return@mapNotNull null
-                val action = runCatching { DefaultClickAction.valueOf(v) }.getOrNull() ?: return@mapNotNull null
+                val action = runCatching { DefaultClickOption.valueOf(v) }.getOrNull() ?: return@mapNotNull null
                 kind to action
             }.toMap()
         }.getOrDefault(emptyMap())
     }
 
-    fun setCarPlayableClickAction(kind: ItemKind, action: DefaultClickAction) {
+    fun setCarPlayableClickAction(kind: ItemKind, action: DefaultClickOption) {
         val updated = _carPlayableClickActions.value.toMutableMap().apply { put(kind, action) }
         settings.putString(
             "car_playable_click_actions",
@@ -253,18 +253,18 @@ class SettingsRepository(
     private val _carBrowsableBulkActions = MutableStateFlow(loadCarBrowsableBulkActions())
     val carBrowsableBulkActions = _carBrowsableBulkActions.asStateFlow()
 
-    private fun loadCarBrowsableBulkActions(): Map<ItemKind, List<DefaultClickAction>> {
+    private fun loadCarBrowsableBulkActions(): Map<ItemKind, List<DefaultClickOption>> {
         val raw = settings.getStringOrNull("car_browsable_bulk_actions") ?: return emptyMap()
         return runCatching {
             myJson.decodeFromString<Map<String, List<String>>>(raw).mapNotNull { (k, list) ->
                 val kind = runCatching { ItemKind.valueOf(k) }.getOrNull() ?: return@mapNotNull null
-                kind to list.mapNotNull { v -> runCatching { DefaultClickAction.valueOf(v) }.getOrNull() }
+                kind to list.mapNotNull { v -> runCatching { DefaultClickOption.valueOf(v) }.getOrNull() }
             }.toMap()
         }.getOrDefault(emptyMap())
     }
 
     /** Replaces the bulk-action list for a single [kind]; other kinds are preserved. */
-    fun setCarBrowsableBulkActions(kind: ItemKind, actions: List<DefaultClickAction>) {
+    fun setCarBrowsableBulkActions(kind: ItemKind, actions: List<DefaultClickOption>) {
         val updated = _carBrowsableBulkActions.value.toMutableMap().apply { put(kind, actions) }
         settings.putString(
             "car_browsable_bulk_actions",

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/ActionDropdown.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/ActionDropdown.kt
@@ -25,19 +25,19 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import io.music_assistant.client.settings.DefaultClickAction
+import io.music_assistant.client.settings.DefaultClickOption
 import org.jetbrains.compose.resources.stringResource
 
 /**
- * Single-line, ellipsizing dropdown over [DefaultClickAction]s. Shared by the per-context
+ * Single-line, ellipsizing dropdown over [DefaultClickOption]s. Shared by the per-context
  * customize dialog and the car tap-behaviour dialog so the look stays identical.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ActionDropdown(
-    options: List<DefaultClickAction>,
-    selected: DefaultClickAction,
-    onSelect: (DefaultClickAction) -> Unit,
+    options: List<DefaultClickOption>,
+    selected: DefaultClickOption,
+    onSelect: (DefaultClickOption) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/ActionDropdown.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/ActionDropdown.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import io.music_assistant.client.data.model.client.ClickContext
 import io.music_assistant.client.settings.DefaultClickOption
 import org.jetbrains.compose.resources.stringResource
 
@@ -35,6 +36,7 @@ import org.jetbrains.compose.resources.stringResource
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ActionDropdown(
+    context: ClickContext?,
     options: List<DefaultClickOption>,
     selected: DefaultClickOption,
     onSelect: (DefaultClickOption) -> Unit,
@@ -60,9 +62,9 @@ fun ActionDropdown(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            Icon(selectedAction.icon(), contentDescription = null, modifier = Modifier.size(20.dp))
+            Icon(selectedAction.icon(context), contentDescription = null, modifier = Modifier.size(20.dp))
             Text(
-                text = stringResource(selectedAction.title()),
+                text = stringResource(selectedAction.title(context)),
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 style = MaterialTheme.typography.bodyLarge,
@@ -76,14 +78,14 @@ fun ActionDropdown(
                 DropdownMenuItem(
                     text = {
                         Text(
-                            stringResource(itemAction.title()),
+                            stringResource(itemAction.title(context)),
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
                         )
                     },
                     leadingIcon = {
                         Icon(
-                            itemAction.icon(),
+                            itemAction.icon(context),
                             contentDescription = null,
                             modifier = Modifier.size(20.dp),
                         )

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/BrowsableItemWithMenu.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/BrowsableItemWithMenu.kt
@@ -301,8 +301,8 @@ private fun <T : AppMediaItem> BrowsableItemWithMenu(
             ItemActionMenuItems(clickContext, actions) { action ->
                 expandedItemId = null
                 when (action) {
-                    is ItemAction.Play -> onPlayOption(item, action.queueOption, false, null)
-                    ItemAction.StartRadio -> onPlayOption(item, QueueOption.REPLACE, true, null)
+                    is ItemAction.Play -> onPlayOption(item, action.queueOption, false, false)
+                    ItemAction.StartRadio -> onPlayOption(item, QueueOption.REPLACE, true, false)
                     ItemAction.AddToLibrary,
                     ItemAction.RemoveFromLibrary,
                     -> libraryActions.onLibraryClick(item)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/BrowsableItemWithMenu.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/BrowsableItemWithMenu.kt
@@ -271,11 +271,13 @@ private fun <T : AppMediaItem> BrowsableItemWithMenu(
         onLongClick: (T) -> Unit,
     ) -> Unit,
 ) {
+    val clickContext = LocalClickActionConfig.current.context
     var expandedItemId by remember { mutableStateOf<String?>(null) }
     var showPlaylistDialog by rememberSaveable { mutableStateOf(false) }
 
     val actions = resolveLongClickActions(
         item = item,
+        clickContext = clickContext,
         librarySupported = item !is Genre,
         canAddToPlaylist = playlistActions != null && item.supportsAddToPlaylist,
         canRemoveFromPlaylist = false,
@@ -296,7 +298,7 @@ private fun <T : AppMediaItem> BrowsableItemWithMenu(
             expanded = expandedItemId == item.itemId,
             onDismissRequest = { expandedItemId = null },
         ) {
-            ItemActionMenuItems(actions) { action ->
+            ItemActionMenuItems(clickContext, actions) { action ->
                 expandedItemId = null
                 when (action) {
                     is ItemAction.Play -> onPlayOption(item, action.queueOption, false, null)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/DefaultClickActionUi.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/DefaultClickActionUi.kt
@@ -70,7 +70,7 @@ fun DefaultClickOption.toItemAction(): ItemAction = when (this) {
     DefaultClickOption.INSERT_NEXT -> ItemAction.Play(QueueOption.NEXT)
     DefaultClickOption.ADD_TO_QUEUE -> ItemAction.Play(QueueOption.ADD)
     DefaultClickOption.START_RADIO -> ItemAction.StartRadio
-    DefaultClickOption.PLAY_FROM_HERE -> ItemAction.PlayFromHere(isPlaylist = false)
+    DefaultClickOption.PLAY_FROM_HERE -> ItemAction.PlayFromHere
 }
 
 /**
@@ -84,7 +84,7 @@ fun DefaultClickOption.effectiveFor(item: AppMediaItem): ItemAction? {
         DefaultClickOption.START_RADIO ->
             if (item.canStartRadio) ItemAction.StartRadio else ItemAction.Play(QueueOption.REPLACE)
         DefaultClickOption.PLAY_FROM_HERE ->
-            if (item is Track) ItemAction.PlayFromHere(isPlaylist = false) else ItemAction.Play(QueueOption.REPLACE)
+            if (item is Track) ItemAction.PlayFromHere else ItemAction.Play(QueueOption.REPLACE)
         else -> toItemAction()
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/DefaultClickActionUi.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/DefaultClickActionUi.kt
@@ -10,7 +10,7 @@ import io.music_assistant.client.data.model.client.ItemKind
 import io.music_assistant.client.data.model.client.QueueOption
 import io.music_assistant.client.data.model.client.itemKind
 import io.music_assistant.client.data.model.client.items.AppMediaItem
-import io.music_assistant.client.settings.DefaultClickAction
+import io.music_assistant.client.settings.DefaultClickOption
 import io.music_assistant.client.ui.compose.settings.DefaultClickActionsViewModel
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -21,12 +21,12 @@ import org.koin.compose.viewmodel.koinViewModel
  */
 data class ClickActionConfig(
     val context: ClickContext?,
-    val prefs: Map<ItemKind, Map<ClickContext, DefaultClickAction>>,
+    val prefs: Map<ItemKind, Map<ClickContext, DefaultClickOption>>,
 ) {
-    fun actionFor(item: AppMediaItem): DefaultClickAction {
-        val ctx = context ?: return DefaultClickAction.PLAY_NOW
-        val kind = item.itemKind() ?: return DefaultClickAction.PLAY_NOW
-        return prefs[kind]?.get(ctx) ?: DefaultClickAction.PLAY_NOW
+    fun actionFor(item: AppMediaItem): DefaultClickOption {
+        val ctx = context ?: return DefaultClickOption.PLAY_NOW
+        val kind = item.itemKind() ?: return DefaultClickOption.PLAY_NOW
+        return prefs[kind]?.get(ctx) ?: DefaultClickOption.PLAY_NOW
     }
 
     /** The concrete action a tap performs for [item], or null when it isn't playable. */
@@ -37,7 +37,7 @@ val LocalClickActionConfig = compositionLocalOf { ClickActionConfig(null, emptyM
 
 /** The saved preference table, loaded once from Koin near the app root (empty in tests/previews). */
 val LocalClickActionPrefs =
-    compositionLocalOf<Map<ItemKind, Map<ClickContext, DefaultClickAction>>> { emptyMap() }
+    compositionLocalOf<Map<ItemKind, Map<ClickContext, DefaultClickOption>>> { emptyMap() }
 
 /**
  * Reads the saved tables once from Koin and exposes them via [LocalClickActionPrefs].
@@ -63,12 +63,12 @@ fun ProvideClickActions(context: ClickContext?, content: @Composable () -> Unit)
 }
 
 /** Matrix-row display mapping (no concrete item — reuses ItemAction.title()/icon()). */
-fun DefaultClickAction.toItemAction(): ItemAction = when (this) {
-    DefaultClickAction.PLAY_NOW -> ItemAction.Play(QueueOption.REPLACE)
-    DefaultClickAction.INSERT_NEXT_AND_PLAY -> ItemAction.Play(QueueOption.PLAY)
-    DefaultClickAction.INSERT_NEXT -> ItemAction.Play(QueueOption.NEXT)
-    DefaultClickAction.ADD_TO_QUEUE -> ItemAction.Play(QueueOption.ADD)
-    DefaultClickAction.START_RADIO -> ItemAction.StartRadio
+fun DefaultClickOption.toItemAction(): ItemAction = when (this) {
+    DefaultClickOption.PLAY_NOW -> ItemAction.Play(QueueOption.REPLACE)
+    DefaultClickOption.INSERT_NEXT_AND_PLAY -> ItemAction.Play(QueueOption.PLAY)
+    DefaultClickOption.INSERT_NEXT -> ItemAction.Play(QueueOption.NEXT)
+    DefaultClickOption.ADD_TO_QUEUE -> ItemAction.Play(QueueOption.ADD)
+    DefaultClickOption.START_RADIO -> ItemAction.StartRadio
 }
 
 /**
@@ -76,10 +76,10 @@ fun DefaultClickAction.toItemAction(): ItemAction = when (this) {
  * isn't playable (click should open the menu instead). START_RADIO falls back to
  * Play Now when the item can't start a radio.
  */
-fun DefaultClickAction.effectiveFor(item: AppMediaItem): ItemAction? {
+fun DefaultClickOption.effectiveFor(item: AppMediaItem): ItemAction? {
     if (!item.isPlayable) return null
     return when (this) {
-        DefaultClickAction.START_RADIO ->
+        DefaultClickOption.START_RADIO ->
             if (item.canStartRadio) ItemAction.StartRadio else ItemAction.Play(QueueOption.REPLACE)
         else -> toItemAction()
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/DefaultClickActionUi.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/DefaultClickActionUi.kt
@@ -10,6 +10,7 @@ import io.music_assistant.client.data.model.client.ItemKind
 import io.music_assistant.client.data.model.client.QueueOption
 import io.music_assistant.client.data.model.client.itemKind
 import io.music_assistant.client.data.model.client.items.AppMediaItem
+import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.settings.DefaultClickOption
 import io.music_assistant.client.ui.compose.settings.DefaultClickActionsViewModel
 import org.koin.compose.viewmodel.koinViewModel
@@ -69,6 +70,7 @@ fun DefaultClickOption.toItemAction(): ItemAction = when (this) {
     DefaultClickOption.INSERT_NEXT -> ItemAction.Play(QueueOption.NEXT)
     DefaultClickOption.ADD_TO_QUEUE -> ItemAction.Play(QueueOption.ADD)
     DefaultClickOption.START_RADIO -> ItemAction.StartRadio
+    DefaultClickOption.PLAY_FROM_HERE -> ItemAction.PlayFromHere(isPlaylist = false)
 }
 
 /**
@@ -81,6 +83,8 @@ fun DefaultClickOption.effectiveFor(item: AppMediaItem): ItemAction? {
     return when (this) {
         DefaultClickOption.START_RADIO ->
             if (item.canStartRadio) ItemAction.StartRadio else ItemAction.Play(QueueOption.REPLACE)
+        DefaultClickOption.PLAY_FROM_HERE ->
+            if (item is Track) ItemAction.PlayFromHere(isPlaylist = false) else ItemAction.Play(QueueOption.REPLACE)
         else -> toItemAction()
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/DefaultClickActionsDialog.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/DefaultClickActionsDialog.kt
@@ -56,7 +56,7 @@ private fun ClickContext.label(): StringResource = when (this) {
  * Save (other kinds untouched).
  */
 @Composable
-fun DefaultClickActionsDialog(itemKind: ItemKind, onDismiss: () -> Unit) {
+fun DefaultClickActionsDialog(clickContext: ClickContext?, itemKind: ItemKind, onDismiss: () -> Unit) {
     val viewModel = koinViewModel<DefaultClickActionsViewModel>()
     val stored by viewModel.actions.collectAsStateWithLifecycle()
 
@@ -95,6 +95,7 @@ fun DefaultClickActionsDialog(itemKind: ItemKind, onDismiss: () -> Unit) {
                             overflow = TextOverflow.Ellipsis,
                         )
                         ActionDropdown(
+                            context = clickContext,
                             options = options,
                             selected = selection[ctx] ?: DefaultClickOption.PLAY_NOW,
                             onSelect = { selection[ctx] = it },

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/DefaultClickActionsDialog.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/DefaultClickActionsDialog.kt
@@ -21,7 +21,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.music_assistant.client.data.model.client.ClickContext
 import io.music_assistant.client.data.model.client.ItemKind
 import io.music_assistant.client.data.model.client.appearsIn
-import io.music_assistant.client.settings.DefaultClickAction
+import io.music_assistant.client.settings.DefaultClickOption
 import io.music_assistant.client.ui.compose.settings.DefaultClickActionsViewModel
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.clickctx_album
@@ -64,9 +64,9 @@ fun DefaultClickActionsDialog(itemKind: ItemKind, onDismiss: () -> Unit) {
 
     // Local working copy; missing keys default to PLAY_NOW (the historic behavior).
     val selection = remember(itemKind) {
-        mutableStateMapOf<ClickContext, DefaultClickAction>().apply {
+        mutableStateMapOf<ClickContext, DefaultClickOption>().apply {
             val saved = stored[itemKind].orEmpty()
-            contexts.forEach { put(it, saved[it] ?: DefaultClickAction.PLAY_NOW) }
+            contexts.forEach { put(it, saved[it] ?: DefaultClickOption.PLAY_NOW) }
         }
     }
 
@@ -85,7 +85,7 @@ fun DefaultClickActionsDialog(itemKind: ItemKind, onDismiss: () -> Unit) {
             ) {
                 contexts.forEach { ctx ->
                     val options = remember(itemKind, ctx) {
-                        DefaultClickAction.entries.filter { it.isAvailableIn(ctx, itemKind) }
+                        DefaultClickOption.entries.filter { it.isAvailableIn(ctx, itemKind) }
                     }
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
@@ -96,7 +96,7 @@ fun DefaultClickActionsDialog(itemKind: ItemKind, onDismiss: () -> Unit) {
                         )
                         ActionDropdown(
                             options = options,
-                            selected = selection[ctx] ?: DefaultClickAction.PLAY_NOW,
+                            selected = selection[ctx] ?: DefaultClickOption.PLAY_NOW,
                             onSelect = { selection[ctx] = it },
                             modifier = Modifier.weight(1f),
                         )

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/DefaultClickActionsDialog.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/DefaultClickActionsDialog.kt
@@ -56,7 +56,7 @@ private fun ClickContext.label(): StringResource = when (this) {
  * Save (other kinds untouched).
  */
 @Composable
-fun DefaultClickActionsDialog(clickContext: ClickContext?, itemKind: ItemKind, onDismiss: () -> Unit) {
+fun DefaultClickActionsDialog(itemKind: ItemKind, onDismiss: () -> Unit) {
     val viewModel = koinViewModel<DefaultClickActionsViewModel>()
     val stored by viewModel.actions.collectAsStateWithLifecycle()
 
@@ -95,7 +95,7 @@ fun DefaultClickActionsDialog(clickContext: ClickContext?, itemKind: ItemKind, o
                             overflow = TextOverflow.Ellipsis,
                         )
                         ActionDropdown(
-                            context = clickContext,
+                            context = ctx,
                             options = options,
                             selected = selection[ctx] ?: DefaultClickOption.PLAY_NOW,
                             onSelect = { selection[ctx] = it },

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/ItemAction.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/ItemAction.kt
@@ -16,6 +16,7 @@ import compose.icons.tablericons.FolderMinus
 import compose.icons.tablericons.FolderPlus
 import compose.icons.tablericons.Heart
 import compose.icons.tablericons.HeartBroken
+import io.music_assistant.client.data.model.client.ClickContext
 import io.music_assistant.client.data.model.client.QueueOption
 import io.music_assistant.client.ui.compose.common.icons.AlbumIcon
 import io.music_assistant.client.ui.compose.common.icons.PlayIcon
@@ -43,7 +44,7 @@ sealed class ItemAction(val kind: Kind) {
     enum class Kind { PLAYBACK, OTHER }
 
     data class Play(val queueOption: QueueOption) : ItemAction(Kind.PLAYBACK)
-    data class PlayFromHere(val isPlaylist: Boolean) : ItemAction(Kind.PLAYBACK)
+    data object PlayFromHere : ItemAction(Kind.PLAYBACK)
     data object StartRadio : ItemAction(Kind.PLAYBACK)
 
     data object AddToLibrary : ItemAction(Kind.OTHER)
@@ -60,7 +61,7 @@ sealed class ItemAction(val kind: Kind) {
     data object Customize : ItemAction(Kind.PLAYBACK)
 }
 
-fun ItemAction.title(): StringResource = when (this) {
+fun ItemAction.title(context: ClickContext? = null): StringResource = when (this) {
     is ItemAction.Play -> when (queueOption) {
         QueueOption.REPLACE -> Res.string.action_play_now
         QueueOption.PLAY -> Res.string.action_insert_next_and_play
@@ -68,11 +69,12 @@ fun ItemAction.title(): StringResource = when (this) {
         QueueOption.ADD -> Res.string.action_add_to_queue
     }
 
-    is ItemAction.PlayFromHere -> if (isPlaylist) {
-        Res.string.action_play_playlist_from_here
-    } else {
-        Res.string.action_play_album_from_here
+    is ItemAction.PlayFromHere -> when (context) {
+        ClickContext.ALBUM -> Res.string.action_play_album_from_here
+        ClickContext.PLAYLIST -> Res.string.action_play_playlist_from_here
+        else -> throw IllegalArgumentException()
     }
+
     ItemAction.StartRadio -> Res.string.action_start_radio
     ItemAction.AddToLibrary -> Res.string.action_add_to_library
     ItemAction.RemoveFromLibrary -> Res.string.action_remove_from_library
@@ -85,7 +87,7 @@ fun ItemAction.title(): StringResource = when (this) {
     ItemAction.Customize -> Res.string.action_customize
 }
 
-fun ItemAction.icon(): ImageVector = when (this) {
+fun ItemAction.icon(context: ClickContext?): ImageVector = when (this) {
     is ItemAction.Play -> when (queueOption) {
         QueueOption.REPLACE -> PlayIcon
         QueueOption.PLAY -> Icons.Default.PlaylistAddCircle
@@ -93,11 +95,12 @@ fun ItemAction.icon(): ImageVector = when (this) {
         QueueOption.ADD -> Icons.Default.AddToQueue
     }
 
-    is ItemAction.PlayFromHere -> if (isPlaylist) {
-        PlaylistIcon
-    } else {
-        AlbumIcon
+    is ItemAction.PlayFromHere -> when (context) {
+        ClickContext.ALBUM -> AlbumIcon
+        ClickContext.PLAYLIST -> PlaylistIcon
+        else -> throw IllegalArgumentException()
     }
+
     ItemAction.StartRadio -> Icons.Default.CellTower
     ItemAction.AddToLibrary -> TablerIcons.FolderPlus
     ItemAction.RemoveFromLibrary -> TablerIcons.FolderMinus

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/ItemAction.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/ItemAction.kt
@@ -72,7 +72,7 @@ fun ItemAction.title(context: ClickContext? = null): StringResource = when (this
     is ItemAction.PlayFromHere -> when (context) {
         ClickContext.ALBUM -> Res.string.action_play_album_from_here
         ClickContext.PLAYLIST -> Res.string.action_play_playlist_from_here
-        else -> throw IllegalArgumentException()
+        else -> throw IllegalArgumentException("No string for this action!")
     }
 
     ItemAction.StartRadio -> Res.string.action_start_radio
@@ -98,7 +98,7 @@ fun ItemAction.icon(context: ClickContext?): ImageVector = when (this) {
     is ItemAction.PlayFromHere -> when (context) {
         ClickContext.ALBUM -> AlbumIcon
         ClickContext.PLAYLIST -> PlaylistIcon
-        else -> throw IllegalArgumentException()
+        else -> throw IllegalArgumentException("No icon for this action!")
     }
 
     ItemAction.StartRadio -> Icons.Default.CellTower

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/ItemActionMenu.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/ItemActionMenu.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import io.music_assistant.client.data.model.client.ClickContext
 import io.music_assistant.client.ui.compose.common.OverflowMenuOption
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.menu_default_label
@@ -21,6 +22,7 @@ import org.jetbrains.compose.resources.stringResource
  */
 @Composable
 fun ItemActionMenuItems(
+    clickContext: ClickContext?,
     actions: List<ItemAction>,
     defaultAction: ItemAction? = null,
     onAction: (ItemAction) -> Unit,
@@ -30,7 +32,7 @@ fun ItemActionMenuItems(
     val dividerAfter = if (lastPlayback in 0 until firstOther) lastPlayback else -1
 
     actions.forEachIndexed { index, action ->
-        val title = stringResource(action.title())
+        val title = stringResource(action.title(clickContext))
         DropdownMenuItem(
             text = {
                 when (action) {
@@ -52,7 +54,7 @@ fun ItemActionMenuItems(
             },
             onClick = { onAction(action) },
             leadingIcon = {
-                Icon(imageVector = action.icon(), contentDescription = title)
+                Icon(imageVector = action.icon(clickContext), contentDescription = title)
             },
         )
         if (index == dividerAfter) HorizontalDivider()
@@ -60,11 +62,11 @@ fun ItemActionMenuItems(
 }
 
 @Composable
-fun ItemAction.toOverflowOption(onAction: (ItemAction) -> Unit): OverflowMenuOption {
+fun ItemAction.toOverflowOption(clickContext: ClickContext?, onAction: (ItemAction) -> Unit): OverflowMenuOption {
     val action = this
     return OverflowMenuOption(
-        title = stringResource(title()),
-        icon = icon(),
+        title = stringResource(title(clickContext)),
+        icon = icon(clickContext),
         onClick = { onAction(action) },
     )
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/ItemActionResolver.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/ItemActionResolver.kt
@@ -20,7 +20,7 @@ val AppMediaItem.supportsAddToPlaylist: Boolean
  */
 fun resolveLongClickActions(
     item: AppMediaItem,
-    clickContext: ClickContext?,
+    clickContext: ClickContext? = null,
     librarySupported: Boolean,
     canAddToPlaylist: Boolean,
     canRemoveFromPlaylist: Boolean,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/ItemActionResolver.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/ItemActionResolver.kt
@@ -1,10 +1,10 @@
 package io.music_assistant.client.ui.compose.common.items
 
+import io.music_assistant.client.data.model.client.ClickContext
 import io.music_assistant.client.data.model.client.QueueOption
 import io.music_assistant.client.data.model.client.items.Album
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Audiobook
-import io.music_assistant.client.data.model.client.items.Playlist
 import io.music_assistant.client.data.model.client.items.PodcastEpisode
 import io.music_assistant.client.data.model.client.items.RadioStation
 import io.music_assistant.client.data.model.client.items.Track
@@ -20,15 +20,15 @@ val AppMediaItem.supportsAddToPlaylist: Boolean
  */
 fun resolveLongClickActions(
     item: AppMediaItem,
+    clickContext: ClickContext?,
     librarySupported: Boolean,
     canAddToPlaylist: Boolean,
     canRemoveFromPlaylist: Boolean,
     progressSupported: Boolean,
     defaultAction: ItemAction? = null,
-    parent: AppMediaItem? = null,
     customizationAllowed: Boolean = false,
 ): List<ItemAction> = buildList {
-    if (item.isPlayable) addPlaybackActions(item, parent)
+    if (item.isPlayable) addPlaybackActions(item, clickContext)
     if (customizationAllowed) add(ItemAction.Customize)
     if (librarySupported) {
         add(if (item.isInLibrary) ItemAction.RemoveFromLibrary else ItemAction.AddToLibrary)
@@ -67,14 +67,17 @@ fun resolvePlayButtonActions(
     }.filterNot { it == default }
 
 /** The playback block: Play Now / Insert Next & Play / Insert Next / Add to Bottom / Start Radio. */
-private fun MutableList<ItemAction>.addPlaybackActions(item: AppMediaItem, parent: AppMediaItem? = null) {
+private fun MutableList<ItemAction>.addPlaybackActions(
+    item: AppMediaItem,
+    context: ClickContext? = null,
+) {
     add(ItemAction.Play(QueueOption.REPLACE))
     add(ItemAction.Play(QueueOption.PLAY))
     add(ItemAction.Play(QueueOption.NEXT))
     add(ItemAction.Play(QueueOption.ADD))
 
-    if (parent is Album || parent is Playlist) {
-        add(ItemAction.PlayFromHere(isPlaylist = parent is Playlist))
+    if (context == ClickContext.ALBUM || context == ClickContext.PLAYLIST) {
+        add(ItemAction.PlayFromHere)
     }
 
     if (item.canStartRadio) add(ItemAction.StartRadio)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/MediaItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/MediaItems.kt
@@ -916,7 +916,7 @@ fun BoxScope.ProgressBadge(
 internal fun TrackRowItem(
     modifier: Modifier = Modifier,
     item: Track,
-    isAlbumRow: Boolean,
+    showTrackNumber: Boolean,
     onClick: (Track) -> Unit,
     onLongClick: (Track) -> Unit,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)?,
@@ -925,7 +925,7 @@ internal fun TrackRowItem(
         modifier = modifier,
         name = item.displayName,
         subtitle = item.localizedSubtitle(),
-        prefixContent = if (isAlbumRow) {
+        prefixContent = if (showTrackNumber) {
             item.trackNumber?.toString()?.let { trackNumber ->
                 {
                     Text(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/PlayableItemWithMenu.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/PlayableItemWithMenu.kt
@@ -183,16 +183,17 @@ private fun <T> PlayableItemWithMenu(
 
     // The tap action for this item's (kind, context) pair (PLAY_NOW outside customizable
     // screens). Null when the item isn't playable — then a tap opens the menu instead.
-    val effectiveDefault = LocalClickActionConfig.current.effectiveActionFor(item)
+    val clickActionConfig = LocalClickActionConfig.current
+    val effectiveDefault = clickActionConfig.effectiveActionFor(item)
 
     val actions = resolveLongClickActions(
         item = item,
+        clickContext = clickActionConfig.context,
         librarySupported = true,
         canAddToPlaylist = playlistActions != null && item.supportsAddToPlaylist,
         canRemoveFromPlaylist = onRemoveFromPlaylist != null,
         progressSupported = progressActions != null && item is PodcastEpisode,
         defaultAction = effectiveDefault,
-        parent = parent,
         customizationAllowed = true,
     )
 
@@ -222,7 +223,7 @@ private fun <T> PlayableItemWithMenu(
             expanded = expandedItemId == item.itemId,
             onDismissRequest = { expandedItemId = null },
         ) {
-            ItemActionMenuItems(actions, defaultAction = effectiveDefault) { action ->
+            ItemActionMenuItems(clickActionConfig.context, actions, defaultAction = effectiveDefault) { action ->
                 expandedItemId = null
                 when (action) {
                     is ItemAction.Play,
@@ -256,7 +257,11 @@ private fun <T> PlayableItemWithMenu(
 
         if (showCustomizeDialog) {
             item.itemKind()?.let { kind ->
-                DefaultClickActionsDialog(itemKind = kind, onDismiss = { showCustomizeDialog = false })
+                DefaultClickActionsDialog(
+                    clickActionConfig.context,
+                    itemKind = kind,
+                    onDismiss = { showCustomizeDialog = false },
+                )
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/PlayableItemWithMenu.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/PlayableItemWithMenu.kt
@@ -255,7 +255,6 @@ private fun <T> PlayableItemWithMenu(
         if (showCustomizeDialog) {
             item.itemKind()?.let { kind ->
                 DefaultClickActionsDialog(
-                    clickActionConfig.context,
                     itemKind = kind,
                     onDismiss = { showCustomizeDialog = false },
                 )

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/PlayableItemWithMenu.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/PlayableItemWithMenu.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import io.music_assistant.client.data.model.client.QueueOption
 import io.music_assistant.client.data.model.client.itemKind
-import io.music_assistant.client.data.model.client.items.Album
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.PlayableItem
 import io.music_assistant.client.data.model.client.items.PodcastEpisode
@@ -25,13 +24,13 @@ import io.music_assistant.client.data.model.client.items.RadioStation
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.settings.ViewMode
 
-typealias PlayHandler<T> = (item: T, queueOption: QueueOption, radio: Boolean, parent: AppMediaItem?) -> Unit
+typealias PlayHandler<T> = (item: T, queueOption: QueueOption, radio: Boolean, formHereInParent: Boolean) -> Unit
 
 @Composable
 fun TrackWithMenu(
     item: Track,
     viewMode: ViewMode = ViewMode.GRID,
-    parent: AppMediaItem? = null,
+    showTrackNumber: Boolean = false,
     onPlayOption: PlayHandler<Track>,
     playlistActions: PlaylistActions? = null,
     onRemoveFromPlaylist: (() -> Unit)? = null,
@@ -44,7 +43,6 @@ fun TrackWithMenu(
             ViewMode.LIST -> Modifier.fillMaxWidth()
         },
         item = item,
-        parent = parent,
         onPlayOption = onPlayOption,
         playlistActions = playlistActions,
         onRemoveFromPlaylist = onRemoveFromPlaylist,
@@ -54,7 +52,7 @@ fun TrackWithMenu(
                 ViewMode.LIST -> TrackRowItem(
                     modifier = mod,
                     item = item,
-                    isAlbumRow = parent is Album,
+                    showTrackNumber = showTrackNumber,
                     onClick = onClick,
                     onLongClick = onLongClick,
                     providerIconFetcher = providerIconFetcher,
@@ -165,7 +163,6 @@ fun RadioWithMenu(
 private fun <T> PlayableItemWithMenu(
     modifier: Modifier = Modifier,
     item: T,
-    parent: AppMediaItem? = null,
     onPlayOption: PlayHandler<T>,
     playlistActions: PlaylistActions? = null,
     onRemoveFromPlaylist: (() -> Unit)? = null,
@@ -199,9 +196,9 @@ private fun <T> PlayableItemWithMenu(
 
     val runPlayAction: (ItemAction) -> Unit = { action ->
         when (action) {
-            is ItemAction.Play -> onPlayOption(item, action.queueOption, false, null)
-            ItemAction.StartRadio -> onPlayOption(item, QueueOption.REPLACE, true, null)
-            is ItemAction.PlayFromHere -> onPlayOption(item, QueueOption.REPLACE, false, parent)
+            is ItemAction.Play -> onPlayOption(item, action.queueOption, false, false)
+            ItemAction.StartRadio -> onPlayOption(item, QueueOption.REPLACE, true, false)
+            is ItemAction.PlayFromHere -> onPlayOption(item, QueueOption.REPLACE, false, true)
             else -> Unit
         }
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/PlayableItemWithMenu.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/PlayableItemWithMenu.kt
@@ -24,7 +24,7 @@ import io.music_assistant.client.data.model.client.items.RadioStation
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.settings.ViewMode
 
-typealias PlayHandler<T> = (item: T, queueOption: QueueOption, radio: Boolean, formHereInParent: Boolean) -> Unit
+typealias PlayHandler<T> = (item: T, queueOption: QueueOption, radio: Boolean, fromHereInParent: Boolean) -> Unit
 
 @Composable
 fun TrackWithMenu(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -172,7 +172,7 @@ fun ItemDetails(
     onMarkUnplayed: (AppMediaItem) -> Unit = {},
     onRemoveFromPlaylist: (String, Int) -> Unit = { _, _ -> },
     providerIconFetcher: @Composable (Modifier, String) -> Unit = { _, _ -> },
-    onPlayClick: (QueueOption, Boolean, AppMediaItem?) -> Unit = { _, _, _ -> },
+    onPlayClick: (QueueOption, Boolean) -> Unit = { _, _ -> },
     onChapterClick: (Int) -> Unit = {},
     onChildPlayClick: PlayHandler<AppMediaItem> = { _, _, _, _ -> },
     onAlbumsSortChanged: (SubItemContext, SortOption) -> Unit = { _, _ -> },
@@ -265,7 +265,7 @@ private fun ItemChildren(
     toastState: ToastState,
     viewModeProvider: @Composable (MediaType) -> ViewMode,
     onNavigateClick: (AppMediaItem) -> Unit,
-    onPlayItemClick: (QueueOption, Boolean, AppMediaItem?) -> Unit,
+    onPlayItemClick: (QueueOption, Boolean) -> Unit,
     onPlayChildClick: PlayHandler<AppMediaItem>,
     onChapterClick: (Int) -> Unit,
     playlistActions: PlaylistActions,
@@ -302,9 +302,7 @@ private fun ItemChildren(
                     state = state,
                     viewModeProvider = viewModeProvider,
                     onNavigateClick = onNavigateClick,
-                    onPlayItemClick = { queueOption, radio ->
-                        onPlayItemClick(queueOption, radio, null)
-                    },
+                    onPlayItemClick = onPlayItemClick,
                     onPlayChildClick = onPlayChildClick,
                     onChapterClick = onChapterClick,
                     playlistActions = playlistActions,
@@ -830,11 +828,7 @@ private fun PlayablesTabContent(
                         is Track -> TrackWithMenu(
                             item = track,
                             viewMode = viewMode,
-                            parent = if (parentItem is Album || parentItem is Playlist) {
-                                parentItem
-                            } else {
-                                null
-                            },
+                            showTrackNumber = parentItem is Album,
                             onPlayOption = onPlayChildClick,
                             playlistActions = playlistActions,
                             onRemoveFromPlaylist = if (parentItem is Playlist && parentItem.isEditable) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -400,9 +400,9 @@ class ItemDetailsViewModel(
         }
     }
 
-    fun onPlayClick(option: QueueOption, radio: Boolean, startItem: AppMediaItem? = null) {
+    fun onPlayClick(option: QueueOption, radio: Boolean) {
         (_state.value.itemState as? DataState.Data)?.data?.let {
-            onPlayClick(it, option, radio, startItem)
+            onPlayClick(it, option, radio, false)
         }
     }
 
@@ -410,9 +410,10 @@ class ItemDetailsViewModel(
         item: AppMediaItem,
         option: QueueOption,
         radio: Boolean,
-        parent: AppMediaItem? = null,
+        formHereInParent: Boolean,
     ) {
-        val (itemToPlay, startItem) = if (parent != null) {
+        val parent = (_state.value.itemState as? DataState.Data)?.data
+        val (itemToPlay, startItem) = if (formHereInParent && parent != null) {
             Pair(parent, item)
         } else {
             Pair(item, null)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -410,10 +410,10 @@ class ItemDetailsViewModel(
         item: AppMediaItem,
         option: QueueOption,
         radio: Boolean,
-        formHereInParent: Boolean,
+        fromHereInParent: Boolean,
     ) {
         val parent = (_state.value.itemState as? DataState.Data)?.data
-        val (itemToPlay, startItem) = if (formHereInParent && parent != null) {
+        val (itemToPlay, startItem) = if (fromHereInParent && parent != null) {
             Pair(parent, item)
         } else {
             Pair(item, null)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
@@ -61,6 +61,7 @@ import io.music_assistant.client.ui.compose.common.items.AddToPlaylistDialog
 import io.music_assistant.client.ui.compose.common.items.Badges
 import io.music_assistant.client.ui.compose.common.items.ItemAction
 import io.music_assistant.client.ui.compose.common.items.LibraryActions
+import io.music_assistant.client.ui.compose.common.items.LocalClickActionConfig
 import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import io.music_assistant.client.ui.compose.common.items.localizedSubtitle
 import io.music_assistant.client.ui.compose.common.items.navigationOptions
@@ -202,7 +203,7 @@ private fun ItemOverflow(
         librarySupported = libraryActions != null && item !is Genre,
         canAddToPlaylist = playlistActions != null,
     ).map { action ->
-        action.toOverflowOption {
+        action.toOverflowOption(LocalClickActionConfig.current.context) {
             when (it) {
                 ItemAction.AddToLibrary,
                 ItemAction.RemoveFromLibrary,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemPlayButton.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemPlayButton.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import io.music_assistant.client.data.model.client.ClickContext
 import io.music_assistant.client.data.model.client.QueueOption
 import io.music_assistant.client.data.model.client.itemKind
 import io.music_assistant.client.data.model.client.items.AppMediaItem
@@ -58,7 +59,8 @@ fun ItemPlayButton(
 
     // The detail header is wrapped in ProvideClickActions(DETAIL), so the config resolves
     // this item's DETAIL default. effectiveActionFor is non-null here (item is playable).
-    val effective = LocalClickActionConfig.current.effectiveActionFor(item)
+    val clickActionConfig = LocalClickActionConfig.current
+    val effective = clickActionConfig.effectiveActionFor(item)
         ?: ItemAction.Play(QueueOption.REPLACE)
     val kind = item.itemKind()
 
@@ -82,7 +84,7 @@ fun ItemPlayButton(
                 colors = buttonColors,
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(imageVector = effective.icon(), contentDescription = null)
+                    Icon(imageVector = effective.icon(clickActionConfig.context), contentDescription = null)
                     Text(modifier = Modifier.padding(start = 8.dp), text = label)
                 }
             }
@@ -94,6 +96,7 @@ fun ItemPlayButton(
                 // Customize opens the per-kind table — meaningless for kindless items (e.g. Genre).
                 onCustomize = if (kind != null) ({ showCustomizeDialog = true }) else null,
                 onPlayAction = runPlayAction,
+                context = clickActionConfig.context,
             ) { onClick ->
                 TrailingButton(onClick = onClick, colors = buttonColors) {
                     Icon(
@@ -106,7 +109,11 @@ fun ItemPlayButton(
     )
 
     if (showCustomizeDialog && kind != null) {
-        DefaultClickActionsDialog(itemKind = kind, onDismiss = { showCustomizeDialog = false })
+        DefaultClickActionsDialog(
+            clickActionConfig.context,
+            itemKind = kind,
+            onDismiss = { showCustomizeDialog = false },
+        )
     }
 }
 
@@ -116,11 +123,12 @@ private fun PlayOverflow(
     default: ItemAction,
     onCustomize: (() -> Unit)?,
     onPlayAction: (ItemAction) -> Unit,
+    context: ClickContext?,
     button: @Composable (() -> Unit) -> Unit,
 ) {
     val actions = resolvePlayButtonActions(item, default, onCustomize != null)
     val options = actions.map { action ->
-        action.toOverflowOption {
+        action.toOverflowOption(context) {
             if (it == ItemAction.Customize) onCustomize?.invoke() else onPlayAction(it)
         }
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemPlayButton.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemPlayButton.kt
@@ -110,7 +110,6 @@ fun ItemPlayButton(
 
     if (showCustomizeDialog && kind != null) {
         DefaultClickActionsDialog(
-            clickActionConfig.context,
             itemKind = kind,
             onDismiss = { showCustomizeDialog = false },
         )

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/CarActionsSettings.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/CarActionsSettings.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.music_assistant.client.data.model.client.ItemKind
-import io.music_assistant.client.settings.DefaultClickAction
+import io.music_assistant.client.settings.DefaultClickOption
 import io.music_assistant.client.settings.carBrowsableKinds
 import io.music_assistant.client.settings.carPlayableKinds
 import io.music_assistant.client.settings.carTapAction
@@ -154,7 +154,7 @@ private fun CarEnqueueActionDialog(viewModel: CarActionsViewModel, onDismiss: ()
     val stored by viewModel.playableClickActions.collectAsStateWithLifecycle()
     val platform = remember { currentCarPlatform() }
     val selection = remember {
-        mutableStateMapOf<ItemKind, DefaultClickAction>().apply {
+        mutableStateMapOf<ItemKind, DefaultClickOption>().apply {
             carPlayableKinds.forEach { put(it, stored.carTapAction(it)) }
         }
     }
@@ -168,7 +168,7 @@ private fun CarEnqueueActionDialog(viewModel: CarActionsViewModel, onDismiss: ()
             ) {
                 carPlayableKinds.forEach { kind ->
                     val options = remember(kind) {
-                        DefaultClickAction.entries.filter { it.isCarSupported(platform, kind) }
+                        DefaultClickOption.entries.filter { it.isCarSupported(platform, kind) }
                     }
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
@@ -179,7 +179,7 @@ private fun CarEnqueueActionDialog(viewModel: CarActionsViewModel, onDismiss: ()
                         )
                         ActionDropdown(
                             options = options,
-                            selected = selection[kind] ?: DefaultClickAction.PLAY_NOW,
+                            selected = selection[kind] ?: DefaultClickOption.PLAY_NOW,
                             onSelect = { selection[kind] = it },
                             modifier = Modifier.weight(1f),
                         )
@@ -212,7 +212,7 @@ private fun CarBulkActionsDialog(
     val platform = remember { currentCarPlatform() }
     // Enabled+ordered actions first, then the remaining applicable ones (disabled) so they can be added.
     val initial = remember(kind, stored) {
-        val universe = DefaultClickAction.entries.filter { it.isCarSupported(platform, kind) }
+        val universe = DefaultClickOption.entries.filter { it.isCarSupported(platform, kind) }
         val enabled = (stored[kind] ?: defaultCarBulkActions).filter { it in universe }
         val disabled = universe.filter { it !in enabled }
         enabled.map { it to true } + disabled.map { it to false }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/CarActionsSettings.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/CarActionsSettings.kt
@@ -43,6 +43,7 @@ import io.music_assistant.client.settings.defaultCarBulkActions
 import io.music_assistant.client.settings.isCarSupported
 import io.music_assistant.client.ui.compose.common.ReorderableEnabledList
 import io.music_assistant.client.ui.compose.common.items.ActionDropdown
+import io.music_assistant.client.ui.compose.common.items.LocalClickActionConfig
 import io.music_assistant.client.ui.compose.common.items.labelRes
 import io.music_assistant.client.ui.compose.common.items.title
 import io.music_assistant.client.ui.compose.common.items.toItemAction
@@ -178,6 +179,7 @@ private fun CarEnqueueActionDialog(viewModel: CarActionsViewModel, onDismiss: ()
                             overflow = TextOverflow.Ellipsis,
                         )
                         ActionDropdown(
+                            context = LocalClickActionConfig.current.context,
                             options = options,
                             selected = selection[kind] ?: DefaultClickOption.PLAY_NOW,
                             onSelect = { selection[kind] = it },

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/CarActionsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/CarActionsViewModel.kt
@@ -3,7 +3,7 @@ package io.music_assistant.client.ui.compose.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.music_assistant.client.data.model.client.ItemKind
-import io.music_assistant.client.settings.DefaultClickAction
+import io.music_assistant.client.settings.DefaultClickOption
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.compose.library.LibraryCategory
 import io.music_assistant.client.ui.compose.library.carTabCategories
@@ -19,10 +19,10 @@ class CarActionsViewModel(
     val playableClickActions = settingsRepository.carPlayableClickActions
     val browsableBulkActions = settingsRepository.carBrowsableBulkActions
 
-    fun savePlayableClickAction(kind: ItemKind, action: DefaultClickAction) =
+    fun savePlayableClickAction(kind: ItemKind, action: DefaultClickOption) =
         settingsRepository.setCarPlayableClickAction(kind, action)
 
-    fun saveBrowsableBulkActions(kind: ItemKind, actions: List<DefaultClickAction>) =
+    fun saveBrowsableBulkActions(kind: ItemKind, actions: List<DefaultClickOption>) =
         settingsRepository.setCarBrowsableBulkActions(kind, actions)
 
     // Auto tabs reconciled against the AA-supported universe (mirrors LibraryCategoriesViewModel).

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/DefaultClickActionsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/DefaultClickActionsViewModel.kt
@@ -3,13 +3,13 @@ package io.music_assistant.client.ui.compose.settings
 import androidx.lifecycle.ViewModel
 import io.music_assistant.client.data.model.client.ClickContext
 import io.music_assistant.client.data.model.client.ItemKind
-import io.music_assistant.client.settings.DefaultClickAction
+import io.music_assistant.client.settings.DefaultClickOption
 import io.music_assistant.client.settings.SettingsRepository
 
 class DefaultClickActionsViewModel(
     private val settingsRepository: SettingsRepository,
 ) : ViewModel() {
     val actions = settingsRepository.defaultClickActions
-    fun save(kind: ItemKind, perContext: Map<ClickContext, DefaultClickAction>) =
+    fun save(kind: ItemKind, perContext: Map<ClickContext, DefaultClickOption>) =
         settingsRepository.setDefaultClickActions(kind, perContext)
 }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/settings/DefaultClickActionsRepoTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/settings/DefaultClickActionsRepoTest.kt
@@ -18,10 +18,10 @@ class DefaultClickActionsRepoTest {
         val repo = SettingsRepository(MapSettings())
         repo.setDefaultClickActions(
             ItemKind.TRACK,
-            mapOf(ClickContext.SEARCH to DefaultClickAction.ADD_TO_QUEUE),
+            mapOf(ClickContext.SEARCH to DefaultClickOption.ADD_TO_QUEUE),
         )
         assertEquals(
-            DefaultClickAction.ADD_TO_QUEUE,
+            DefaultClickOption.ADD_TO_QUEUE,
             repo.defaultClickActions.value[ItemKind.TRACK]?.get(ClickContext.SEARCH),
         )
     }
@@ -29,15 +29,15 @@ class DefaultClickActionsRepoTest {
     @Test
     fun `saving one kind preserves the others`() {
         val repo = SettingsRepository(MapSettings())
-        repo.setDefaultClickActions(ItemKind.TRACK, mapOf(ClickContext.SEARCH to DefaultClickAction.INSERT_NEXT))
-        repo.setDefaultClickActions(ItemKind.ALBUM, mapOf(ClickContext.DETAIL to DefaultClickAction.ADD_TO_QUEUE))
+        repo.setDefaultClickActions(ItemKind.TRACK, mapOf(ClickContext.SEARCH to DefaultClickOption.INSERT_NEXT))
+        repo.setDefaultClickActions(ItemKind.ALBUM, mapOf(ClickContext.DETAIL to DefaultClickOption.ADD_TO_QUEUE))
 
         assertEquals(
-            DefaultClickAction.INSERT_NEXT,
+            DefaultClickOption.INSERT_NEXT,
             repo.defaultClickActions.value[ItemKind.TRACK]?.get(ClickContext.SEARCH),
         )
         assertEquals(
-            DefaultClickAction.ADD_TO_QUEUE,
+            DefaultClickOption.ADD_TO_QUEUE,
             repo.defaultClickActions.value[ItemKind.ALBUM]?.get(ClickContext.DETAIL),
         )
     }
@@ -47,11 +47,11 @@ class DefaultClickActionsRepoTest {
         val settings = MapSettings()
         SettingsRepository(settings).setDefaultClickActions(
             ItemKind.RADIO,
-            mapOf(ClickContext.HOME to DefaultClickAction.INSERT_NEXT_AND_PLAY),
+            mapOf(ClickContext.HOME to DefaultClickOption.INSERT_NEXT_AND_PLAY),
         )
         val reopened = SettingsRepository(settings)
         assertEquals(
-            DefaultClickAction.INSERT_NEXT_AND_PLAY,
+            DefaultClickOption.INSERT_NEXT_AND_PLAY,
             reopened.defaultClickActions.value[ItemKind.RADIO]?.get(ClickContext.HOME),
         )
     }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/settings/DefaultClickOptionTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/settings/DefaultClickOptionTest.kt
@@ -13,14 +13,14 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
-class DefaultClickActionTest {
+class DefaultClickOptionTest {
     @Test
     fun `start radio applies only to radio-capable kinds`() {
         val radioCapable = setOf(ItemKind.TRACK, ItemKind.ALBUM, ItemKind.ARTIST, ItemKind.PLAYLIST)
         ItemKind.entries.forEach { kind ->
             assertEquals(
                 kind in radioCapable,
-                DefaultClickAction.START_RADIO.appliesTo(kind),
+                DefaultClickOption.START_RADIO.appliesTo(kind),
                 "START_RADIO.appliesTo($kind)",
             )
         }
@@ -28,7 +28,7 @@ class DefaultClickActionTest {
 
     @Test
     fun `queue actions apply to every kind`() {
-        val queueActions = DefaultClickAction.entries - DefaultClickAction.START_RADIO
+        val queueActions = DefaultClickOption.entries - DefaultClickOption.START_RADIO
         queueActions.forEach { action ->
             ItemKind.entries.forEach { kind ->
                 assertEquals(true, action.appliesTo(kind), "$action.appliesTo($kind)")
@@ -38,7 +38,7 @@ class DefaultClickActionTest {
 
     @Test
     fun `isAvailableIn currently mirrors appliesTo for every context`() {
-        DefaultClickAction.entries.forEach { action ->
+        DefaultClickOption.entries.forEach { action ->
             ItemKind.entries.forEach { kind ->
                 ClickContext.entries.forEach { ctx ->
                     assertEquals(
@@ -53,27 +53,27 @@ class DefaultClickActionTest {
 
     @Test
     fun `toItemAction maps to the matching ItemAction`() {
-        assertEquals(ItemAction.Play(QueueOption.REPLACE), DefaultClickAction.PLAY_NOW.toItemAction())
-        assertEquals(ItemAction.Play(QueueOption.PLAY), DefaultClickAction.INSERT_NEXT_AND_PLAY.toItemAction())
-        assertEquals(ItemAction.Play(QueueOption.NEXT), DefaultClickAction.INSERT_NEXT.toItemAction())
-        assertEquals(ItemAction.Play(QueueOption.ADD), DefaultClickAction.ADD_TO_QUEUE.toItemAction())
-        assertEquals(ItemAction.StartRadio, DefaultClickAction.START_RADIO.toItemAction())
+        assertEquals(ItemAction.Play(QueueOption.REPLACE), DefaultClickOption.PLAY_NOW.toItemAction())
+        assertEquals(ItemAction.Play(QueueOption.PLAY), DefaultClickOption.INSERT_NEXT_AND_PLAY.toItemAction())
+        assertEquals(ItemAction.Play(QueueOption.NEXT), DefaultClickOption.INSERT_NEXT.toItemAction())
+        assertEquals(ItemAction.Play(QueueOption.ADD), DefaultClickOption.ADD_TO_QUEUE.toItemAction())
+        assertEquals(ItemAction.StartRadio, DefaultClickOption.START_RADIO.toItemAction())
     }
 
     @Test
     fun `effectiveFor returns null for a non-playable item`() {
-        assertNull(DefaultClickAction.PLAY_NOW.effectiveFor(testTrack(isPlayable = false)))
+        assertNull(DefaultClickOption.PLAY_NOW.effectiveFor(testTrack(isPlayable = false)))
     }
 
     @Test
     fun `effectiveFor keeps start radio when the item can start one`() {
-        assertEquals(ItemAction.StartRadio, DefaultClickAction.START_RADIO.effectiveFor(testTrack()))
+        assertEquals(ItemAction.StartRadio, DefaultClickOption.START_RADIO.effectiveFor(testTrack()))
     }
 
     @Test
     fun `effectiveFor falls back to play now when radio is unavailable`() {
         val playNow = ItemAction.Play(QueueOption.REPLACE)
-        assertEquals(playNow, DefaultClickAction.START_RADIO.effectiveFor(testPlaylist(isDynamic = true)))
-        assertEquals(playNow, DefaultClickAction.START_RADIO.effectiveFor(testPodcastEpisode()))
+        assertEquals(playNow, DefaultClickOption.START_RADIO.effectiveFor(testPlaylist(isDynamic = true)))
+        assertEquals(playNow, DefaultClickOption.START_RADIO.effectiveFor(testPodcastEpisode()))
     }
 }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/settings/DefaultClickOptionTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/settings/DefaultClickOptionTest.kt
@@ -13,6 +13,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class DefaultClickOptionTest {
     @Test
@@ -54,9 +55,22 @@ class DefaultClickOptionTest {
     }
 
     @Test
+    fun `isAvailableIn is true for PLAY_FROM_HERE with ALBUM and PLAYLIST`() {
+        assertTrue(
+            DefaultClickOption.PLAY_FROM_HERE.isAvailableIn(ClickContext.ALBUM, ItemKind.TRACK),
+            "PLAY_FROM_HERE.isAvailableIn(ALBUM, TRACK) should be false",
+        )
+
+        assertTrue(
+            DefaultClickOption.PLAY_FROM_HERE.isAvailableIn(ClickContext.PLAYLIST, ItemKind.TRACK),
+            "PLAY_FROM_HERE.isAvailableIn(ALBUM, TRACK) should be false",
+        )
+    }
+
+    @Test
     fun `isAvailableIn is false for PLAY_FROM_HERE outside ALBUM`() {
         val otherContexts =
-            ClickContext.entries.filter { it != ClickContext.ALBUM }
+            ClickContext.entries.filter { it != ClickContext.ALBUM && it != ClickContext.PLAYLIST }
 
         otherContexts.forEach {
             assertFalse(

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/settings/DefaultClickOptionTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/settings/DefaultClickOptionTest.kt
@@ -61,7 +61,7 @@ class DefaultClickOptionTest {
         otherContexts.forEach {
             assertFalse(
                 DefaultClickOption.PLAY_FROM_HERE.isAvailableIn(it, ItemKind.TRACK),
-                "PLAY_FROM_HERE.isAvailableIn($it, TRACK) should be false"
+                "PLAY_FROM_HERE.isAvailableIn($it, TRACK) should be false",
             )
         }
     }
@@ -70,19 +70,19 @@ class DefaultClickOptionTest {
     fun `toItemAction maps to the matching ItemAction`() {
         assertEquals(
             ItemAction.Play(QueueOption.REPLACE),
-            DefaultClickOption.PLAY_NOW.toItemAction()
+            DefaultClickOption.PLAY_NOW.toItemAction(),
         )
         assertEquals(
             ItemAction.Play(QueueOption.PLAY),
-            DefaultClickOption.INSERT_NEXT_AND_PLAY.toItemAction()
+            DefaultClickOption.INSERT_NEXT_AND_PLAY.toItemAction(),
         )
         assertEquals(
             ItemAction.Play(QueueOption.NEXT),
-            DefaultClickOption.INSERT_NEXT.toItemAction()
+            DefaultClickOption.INSERT_NEXT.toItemAction(),
         )
         assertEquals(
             ItemAction.Play(QueueOption.ADD),
-            DefaultClickOption.ADD_TO_QUEUE.toItemAction()
+            DefaultClickOption.ADD_TO_QUEUE.toItemAction(),
         )
         assertEquals(ItemAction.StartRadio, DefaultClickOption.START_RADIO.toItemAction())
     }
@@ -96,7 +96,7 @@ class DefaultClickOptionTest {
     fun `effectiveFor keeps start radio when the item can start one`() {
         assertEquals(
             ItemAction.StartRadio,
-            DefaultClickOption.START_RADIO.effectiveFor(testTrack())
+            DefaultClickOption.START_RADIO.effectiveFor(testTrack()),
         )
     }
 
@@ -105,7 +105,7 @@ class DefaultClickOptionTest {
         val playNow = ItemAction.Play(QueueOption.REPLACE)
         assertEquals(
             playNow,
-            DefaultClickOption.START_RADIO.effectiveFor(testPlaylist(isDynamic = true))
+            DefaultClickOption.START_RADIO.effectiveFor(testPlaylist(isDynamic = true)),
         )
         assertEquals(playNow, DefaultClickOption.START_RADIO.effectiveFor(testPodcastEpisode()))
     }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/settings/DefaultClickOptionTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/settings/DefaultClickOptionTest.kt
@@ -11,6 +11,7 @@ import io.music_assistant.client.ui.compose.common.items.effectiveFor
 import io.music_assistant.client.ui.compose.common.items.toItemAction
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 
 class DefaultClickOptionTest {
@@ -37,26 +38,52 @@ class DefaultClickOptionTest {
     }
 
     @Test
-    fun `isAvailableIn currently mirrors appliesTo for every context`() {
-        DefaultClickOption.entries.forEach { action ->
-            ItemKind.entries.forEach { kind ->
-                ClickContext.entries.forEach { ctx ->
-                    assertEquals(
-                        action.appliesTo(kind),
-                        action.isAvailableIn(ctx, kind),
-                        "$action.isAvailableIn($ctx, $kind)",
-                    )
+    fun `isAvailableIn currently mirrors appliesTo for every context for actions other than PLAY_FROM_HERE`() {
+        DefaultClickOption.entries.filter { it != DefaultClickOption.PLAY_FROM_HERE }
+            .forEach { action ->
+                ItemKind.entries.forEach { kind ->
+                    ClickContext.entries.forEach { ctx ->
+                        assertEquals(
+                            action.appliesTo(kind),
+                            action.isAvailableIn(ctx, kind),
+                            "$action.isAvailableIn($ctx, $kind)",
+                        )
+                    }
                 }
             }
+    }
+
+    @Test
+    fun `isAvailableIn is false for PLAY_FROM_HERE outside ALBUM`() {
+        val otherContexts =
+            ClickContext.entries.filter { it != ClickContext.ALBUM }
+
+        otherContexts.forEach {
+            assertFalse(
+                DefaultClickOption.PLAY_FROM_HERE.isAvailableIn(it, ItemKind.TRACK),
+                "PLAY_FROM_HERE.isAvailableIn($it, TRACK) should be false"
+            )
         }
     }
 
     @Test
     fun `toItemAction maps to the matching ItemAction`() {
-        assertEquals(ItemAction.Play(QueueOption.REPLACE), DefaultClickOption.PLAY_NOW.toItemAction())
-        assertEquals(ItemAction.Play(QueueOption.PLAY), DefaultClickOption.INSERT_NEXT_AND_PLAY.toItemAction())
-        assertEquals(ItemAction.Play(QueueOption.NEXT), DefaultClickOption.INSERT_NEXT.toItemAction())
-        assertEquals(ItemAction.Play(QueueOption.ADD), DefaultClickOption.ADD_TO_QUEUE.toItemAction())
+        assertEquals(
+            ItemAction.Play(QueueOption.REPLACE),
+            DefaultClickOption.PLAY_NOW.toItemAction()
+        )
+        assertEquals(
+            ItemAction.Play(QueueOption.PLAY),
+            DefaultClickOption.INSERT_NEXT_AND_PLAY.toItemAction()
+        )
+        assertEquals(
+            ItemAction.Play(QueueOption.NEXT),
+            DefaultClickOption.INSERT_NEXT.toItemAction()
+        )
+        assertEquals(
+            ItemAction.Play(QueueOption.ADD),
+            DefaultClickOption.ADD_TO_QUEUE.toItemAction()
+        )
         assertEquals(ItemAction.StartRadio, DefaultClickOption.START_RADIO.toItemAction())
     }
 
@@ -67,13 +94,19 @@ class DefaultClickOptionTest {
 
     @Test
     fun `effectiveFor keeps start radio when the item can start one`() {
-        assertEquals(ItemAction.StartRadio, DefaultClickOption.START_RADIO.effectiveFor(testTrack()))
+        assertEquals(
+            ItemAction.StartRadio,
+            DefaultClickOption.START_RADIO.effectiveFor(testTrack())
+        )
     }
 
     @Test
     fun `effectiveFor falls back to play now when radio is unavailable`() {
         val playNow = ItemAction.Play(QueueOption.REPLACE)
-        assertEquals(playNow, DefaultClickOption.START_RADIO.effectiveFor(testPlaylist(isDynamic = true)))
+        assertEquals(
+            playNow,
+            DefaultClickOption.START_RADIO.effectiveFor(testPlaylist(isDynamic = true))
+        )
         assertEquals(playNow, DefaultClickOption.START_RADIO.effectiveFor(testPodcastEpisode()))
     }
 }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/common/items/ClickActionConfigTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/common/items/ClickActionConfigTest.kt
@@ -5,33 +5,33 @@ import io.music_assistant.client.data.model.client.ItemKind
 import io.music_assistant.client.data.model.client.QueueOption
 import io.music_assistant.client.data.model.client.testPlaylist
 import io.music_assistant.client.data.model.client.testTrack
-import io.music_assistant.client.settings.DefaultClickAction
+import io.music_assistant.client.settings.DefaultClickOption
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class ClickActionConfigTest {
     private val trackSearchAddToQueue = mapOf(
-        ItemKind.TRACK to mapOf(ClickContext.SEARCH to DefaultClickAction.ADD_TO_QUEUE),
+        ItemKind.TRACK to mapOf(ClickContext.SEARCH to DefaultClickOption.ADD_TO_QUEUE),
     )
 
     @Test
     fun `null context resolves to play now`() {
         val config = ClickActionConfig(context = null, prefs = trackSearchAddToQueue)
-        assertEquals(DefaultClickAction.PLAY_NOW, config.actionFor(testTrack()))
+        assertEquals(DefaultClickOption.PLAY_NOW, config.actionFor(testTrack()))
     }
 
     @Test
     fun `unknown kind or context resolves to play now`() {
         val config = ClickActionConfig(context = ClickContext.LIBRARY, prefs = trackSearchAddToQueue)
         // TRACK has a SEARCH entry but no LIBRARY entry.
-        assertEquals(DefaultClickAction.PLAY_NOW, config.actionFor(testTrack()))
+        assertEquals(DefaultClickOption.PLAY_NOW, config.actionFor(testTrack()))
     }
 
     @Test
     fun `populated lookup hit is returned`() {
         val config = ClickActionConfig(context = ClickContext.SEARCH, prefs = trackSearchAddToQueue)
-        assertEquals(DefaultClickAction.ADD_TO_QUEUE, config.actionFor(testTrack()))
+        assertEquals(DefaultClickOption.ADD_TO_QUEUE, config.actionFor(testTrack()))
         assertEquals(ItemAction.Play(QueueOption.ADD), config.effectiveActionFor(testTrack()))
     }
 
@@ -39,7 +39,7 @@ class ClickActionConfigTest {
     fun `effectiveActionFor applies the radio fallback`() {
         val config = ClickActionConfig(
             context = ClickContext.DETAIL,
-            prefs = mapOf(ItemKind.PLAYLIST to mapOf(ClickContext.DETAIL to DefaultClickAction.START_RADIO)),
+            prefs = mapOf(ItemKind.PLAYLIST to mapOf(ClickContext.DETAIL to DefaultClickOption.START_RADIO)),
         )
         assertEquals(ItemAction.Play(QueueOption.REPLACE), config.effectiveActionFor(testPlaylist(isDynamic = true)))
     }

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/carplay/CarPlayStrings.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/carplay/CarPlayStrings.kt
@@ -1,6 +1,6 @@
 package io.music_assistant.client.carplay
 
-import io.music_assistant.client.settings.DefaultClickAction
+import io.music_assistant.client.settings.DefaultClickOption
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.action_add_all_to_queue
 import musicassistantclient.composeapp.generated.resources.action_browse
@@ -82,11 +82,11 @@ class CarPlayStrings internal constructor(
             radio = getString(Res.string.media_type_radio),
             albumsByArtistTemplate = getString(Res.string.albums_by_artist),
             bulkActionTitlesByName = mapOf(
-                DefaultClickAction.PLAY_NOW.name to getString(Res.string.action_play_all),
-                DefaultClickAction.INSERT_NEXT_AND_PLAY.name to getString(Res.string.action_insert_next_and_play),
-                DefaultClickAction.INSERT_NEXT.name to getString(Res.string.action_insert_next),
-                DefaultClickAction.ADD_TO_QUEUE.name to getString(Res.string.action_add_all_to_queue),
-                DefaultClickAction.START_RADIO.name to getString(Res.string.action_start_radio),
+                DefaultClickOption.PLAY_NOW.name to getString(Res.string.action_play_all),
+                DefaultClickOption.INSERT_NEXT_AND_PLAY.name to getString(Res.string.action_insert_next_and_play),
+                DefaultClickOption.INSERT_NEXT.name to getString(Res.string.action_insert_next),
+                DefaultClickOption.ADD_TO_QUEUE.name to getString(Res.string.action_add_all_to_queue),
+                DefaultClickOption.START_RADIO.name to getString(Res.string.action_start_radio),
             ),
         )
     }

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
@@ -26,7 +26,7 @@ import io.music_assistant.client.data.model.client.toItemKind
 import io.music_assistant.client.data.planLocalPlayerDispatch
 import io.music_assistant.client.data.repository.MediaItemRepository
 import io.music_assistant.client.settings.CarPlatform
-import io.music_assistant.client.settings.DefaultClickAction
+import io.music_assistant.client.settings.DefaultClickOption
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.settings.carBulkActions
 import io.music_assistant.client.settings.carTapAction
@@ -415,9 +415,9 @@ object KmpHelper : KoinComponent {
             .map { it.name }
     }
 
-    /** Dispatch a named [DefaultClickAction] (a bulk button) onto [item]. False if invalid/no-op. */
+    /** Dispatch a named [DefaultClickOption] (a bulk button) onto [item]. False if invalid/no-op. */
     fun playCarAction(item: AppMediaItem, actionName: String): Boolean {
-        val action = runCatching { DefaultClickAction.valueOf(actionName) }.getOrNull() ?: return false
+        val action = runCatching { DefaultClickOption.valueOf(actionName) }.getOrNull() ?: return false
         val dispatch = action.toCarDispatch()
         return dispatchLocal(item, dispatch.option, dispatch.radioMode)
     }
@@ -430,7 +430,7 @@ object KmpHelper : KoinComponent {
     fun playCarDefaultTap(item: AppMediaItem): String? {
         val action = item.mediaType.toItemKind()
             ?.let { settingsRepository.carPlayableClickActions.value.carTapAction(it) }
-            ?: DefaultClickAction.PLAY_NOW
+            ?: DefaultClickOption.PLAY_NOW
         val dispatch = action.toCarDispatch()
         return if (dispatchLocal(item, dispatch.option, dispatch.radioMode)) action.name else null
     }


### PR DESCRIPTION
Closes https://github.com/music-assistant/mobile-app/issues/535

This adds the album/playlist default option and also reworks how the action icon/title is determined so that it uses `ClickContext` instead of needing to pass the parent `Album`/`Playlist` around.