### PR TITLE
feat(logging): make in-app shared logs useful for field debugging

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/DirectTransport.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/DirectTransport.kt
@@ -106,7 +106,7 @@ class DirectTransport(
                 }
             } catch (@Suppress("SwallowedException") e: ClosedReceiveChannelException) {
                 // Expected on graceful close — the channel-closed exception type IS the signal.
-                logger.d { "WebSocket connection closed" }
+                logger.i { "WebSocket connection closed" }
             } finally {
                 session = null
             }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Event.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Event.kt
@@ -68,9 +68,12 @@ data class Event(
             EventType.CONNECTED,
             EventType.DISCONNECTED,
             EventType.ALL,
-            null,
             -> {
-                logger.w { "Unparsed event: $json" }
+                logger.d { "Ignoring unmodeled event: $type" }
+                null
+            }
+            null -> {
+                logger.w { "Unparsed event of unknown type: ${json.toString().take(200)}" }
                 null
             }
         }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -57,6 +57,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.decodeFromJsonElement
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -941,7 +942,7 @@ class KtorServiceClient(
                 }
             }
             settings.setTokenForServer(serverIdentifier, null)
-            logger.d { "Cleared token for server due to auth failure" }
+            logger.i { "Cleared token for server due to auth failure" }
         }
     }
 
@@ -1072,14 +1073,25 @@ class KtorServiceClient(
     }
 
     override suspend fun sendRequest(request: Request): Result<Answer> {
+        val controlLog = request.playerControlLogLabel()
         // Auth-handshake commands bypass the gate — they're the mechanism by which
         // `ensureReadyForCommands` is *resolved*, so gating them would deadlock.
         if (request.command in authHandshakeCommands) return sendRequestRaw(request)
         if (!ensureReadyForCommands()) {
             logger.i { "sendRequest gated — not ready (state=${stateLabel(_sessionState.value)})" }
+            controlLog?.let { logger.i { "$it command failed: transport not ready" } }
             return Result.failure(IllegalStateException("Not ready for commands"))
         }
-        return sendRequestRaw(request)
+        controlLog?.let { logger.i { "$it command sent" } }
+        val result = sendRequestRaw(request)
+        controlLog?.let {
+            if (result.isSuccess) {
+                logger.i { "$it command acked" }
+            } else {
+                logger.i(result.exceptionOrNull()) { "$it command failed" }
+            }
+        }
+        return result
     }
 
     /**
@@ -1140,6 +1152,19 @@ class KtorServiceClient(
         supervisorJob.cancel()
         client.close()
     }
+
+    private fun Request.playerControlLogLabel(): String? {
+        if (!command.startsWith("players/cmd/") && !command.startsWith("player_queues/")) return null
+        val targetId = args?.stringArg("player_id")
+            ?: args?.stringArg("queue_id")
+            ?: args?.stringArg("queue_item_id")
+        return buildString {
+            append(command)
+            targetId?.let { append(" target=").append(it) }
+        }
+    }
+
+    private fun JsonObject.stringArg(name: String): String? = (this[name] as? JsonPrimitive)?.content
 
     companion object {
         private const val STALE_CONNECTION_THRESHOLD_MS = 30_000L

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerRepository.kt
@@ -304,7 +304,7 @@ class LocalPlayerRepository(
                 }
 
                 is PlayerAction.SeekTo -> {
-                    Logger.e("SeekTo: ${action.position}")
+                    log.i { "SeekTo: ${action.position}" }
                     commandQueue.removeAll { it.action is PlayerAction.SeekTo }
                     commandQueue.add(entry)
                 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -503,7 +503,7 @@ class MainDataSource(
 
                             is DataState.Loading, is DataState.NoData, is DataState.Error -> {
                                 // No data to preserve - stay in current state
-                                log.d { "Reconnecting with no data to preserve (state: ${currentState::class.simpleName})" }
+                                log.i { "Reconnecting with no data to preserve (state: ${currentState::class.simpleName})" }
                             }
                         }
 
@@ -609,7 +609,7 @@ class MainDataSource(
                                     }
 
                                     else -> {
-                                        log.d { "Backgrounded with no data to preserve" }
+                                        log.i { "Backgrounded with no data to preserve" }
                                     }
                                 }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/logging/InMemoryLogWriter.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/logging/InMemoryLogWriter.kt
@@ -6,10 +6,14 @@ import io.music_assistant.client.utils.currentTimeMillis
 
 /** Kermit [LogWriter] that retains recent log lines in memory for crash/share reports. */
 object InMemoryLogWriter : LogWriter() {
-    private const val MAX_ENTRIES = 3000
+    private const val MAX_ENTRIES = 8000
+
+    // Own severity floor, independent of the global (console) min severity.
+    private val minSeverity = Severity.Info
     private val buffer = LogRingBuffer(MAX_ENTRIES)
 
     override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
+        if (severity < minSeverity) return
         buffer.add(
             buildString {
                 append(currentTimeMillis())

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/SendspinClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/SendspinClient.kt
@@ -301,6 +301,7 @@ class SendspinClient(
                 // Update playback state based on sync quality
                 if (clockSynchronizer.currentQuality == SyncQuality.GOOD) {
                     if (_state.value is SendspinState.Buffering) {
+                        logger.i { "Playback synchronized (sync quality good)" }
                         _state.update { SendspinState.Synchronized }
                         stateReporter?.reportNow(PlayerStateValue.SYNCHRONIZED)
                     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/StateReporter.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/StateReporter.kt
@@ -82,7 +82,7 @@ class StateReporter(
      * Used for volume/mute changes or initial sync.
      */
     suspend fun reportNow(state: PlayerStateValue) {
-        logger.i { "Reporting state: state=$state" }
+        logger.d { "Reporting state: state=$state" }
         messageDispatcher.sendState(PlayerStateObject(state = state))
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/protocol/MessageDispatcher.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/protocol/MessageDispatcher.kt
@@ -257,7 +257,7 @@ class MessageDispatcher(
     }
 
     suspend fun sendCommand(command: String, value: CommandValue?) {
-        logger.d { "Sending client/command: $command" }
+        logger.i { "Sending client/command: $command" }
         val message = ClientCommandMessage(
             payload = CommandPayload(command = command, value = value),
         )
@@ -361,7 +361,7 @@ class MessageDispatcher(
     }
 
     private suspend fun handleServerCommand(message: ServerCommandMessage) {
-        logger.d { "Received server/command: ${message.payload.player.command}" }
+        logger.i { "Received server/command: ${message.payload.player.command}" }
         _serverCommandEvent.emit(message)
     }
 
@@ -393,7 +393,7 @@ class MessageDispatcher(
                             album = album,
                             artworkUrl = artworkUrl,
                         )
-                        logger.d { "Updated stream metadata from server/state: $title by $artist" }
+                        logger.i { "Updated stream metadata from server/state: $title by $artist" }
                     }
                 }
             } catch (e: Exception) {

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/logging/InMemoryLogWriterTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/logging/InMemoryLogWriterTest.kt
@@ -1,0 +1,31 @@
+package io.music_assistant.client.logging
+
+import co.touchlab.kermit.Severity
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class InMemoryLogWriterTest {
+    // InMemoryLogWriter is a shared object, so each case uses a unique marker and asserts
+    // only on its own lines — safe against entries left by other tests.
+
+    @Test
+    fun `retains Info and above`() {
+        InMemoryLogWriter.log(Severity.Info, "marker-info-A1B2", "Test", null)
+        InMemoryLogWriter.log(Severity.Warn, "marker-warn-A1B2", "Test", null)
+        InMemoryLogWriter.log(Severity.Error, "marker-error-A1B2", "Test", null)
+        val text = InMemoryLogWriter.getLogText()
+        assertTrue("marker-info-A1B2" in text)
+        assertTrue("marker-warn-A1B2" in text)
+        assertTrue("marker-error-A1B2" in text)
+    }
+
+    @Test
+    fun `drops Debug and Verbose`() {
+        InMemoryLogWriter.log(Severity.Debug, "marker-debug-C3D4", "Test", null)
+        InMemoryLogWriter.log(Severity.Verbose, "marker-verbose-C3D4", "Test", null)
+        val text = InMemoryLogWriter.getLogText()
+        assertFalse("marker-debug-C3D4" in text)
+        assertFalse("marker-verbose-C3D4" in text)
+    }
+}

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/logging/NativeLog.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/logging/NativeLog.kt
@@ -1,0 +1,17 @@
+package io.music_assistant.client.logging
+
+import co.touchlab.kermit.Logger
+
+/**
+ * Entry point for Swift to emit logs through Kermit, so iOS-native events reach
+ * the same writers as Kotlin logs.
+ *
+ * Severity is explicit per call so the Swift side keeps per-packet detail at
+ * `debug` (below the share buffer's Info floor) and state/error events at `info`+.
+ */
+object NativeLog {
+    fun debug(tag: String, message: String) = Logger.withTag(tag).d(message)
+    fun info(tag: String, message: String) = Logger.withTag(tag).i(message)
+    fun warn(tag: String, message: String) = Logger.withTag(tag).w(message)
+    fun error(tag: String, message: String) = Logger.withTag(tag).e(message)
+}

--- a/iosApp/AudioDecoders.swift
+++ b/iosApp/AudioDecoders.swift
@@ -1,6 +1,7 @@
 import Foundation
 import AVFoundation
 import AudioToolbox
+import ComposeApp
 
 // Import external decoder libraries
 // NOTE: These must be added via Xcode SPM:
@@ -124,7 +125,7 @@ class OpusLibDecoder: NativeAudioDecoder {
 
         do {
             self.decoder = try Opus.Decoder(format: format)
-            print("🎵 OpusLibDecoder: ✅ Created decoder for \(sampleRate)Hz, \(channels)ch")
+            NativeLog.shared.info(tag: "OpusLibDecoder", message: "Created decoder for \(sampleRate)Hz, \(channels)ch")
         } catch {
             throw AudioDecoderError.decodingFailed("Opus decoder: \(error.localizedDescription)")
         }
@@ -170,7 +171,13 @@ class FLACLibDecoder: NativeAudioDecoder {
     // Buffer for decoded samples (Int32 to preserve native bit depth)
     private var decodedSamples: [Int32] = []
     private var lastError: FLAC__StreamDecoderErrorStatus?
-    
+
+    // MARK: - Logging
+    private static let logTag = "FLACLibDecoder"
+    private func logInfo(_ message: String) { NativeLog.shared.info(tag: Self.logTag, message: message) }
+    private func logWarn(_ message: String) { NativeLog.shared.warn(tag: Self.logTag, message: message) }
+    private func logDebug(_ message: String) { NativeLog.shared.debug(tag: Self.logTag, message: message) }
+
     init(sampleRate: Int, channels: Int, bitDepth: Int, header: Data?) throws {
         self.sampleRate = sampleRate
         self.channels = channels
@@ -213,7 +220,7 @@ class FLACLibDecoder: NativeAudioDecoder {
                 guard let clientData = clientData else { return }
                 let selfRef = Unmanaged<FLACLibDecoder>.fromOpaque(clientData).takeUnretainedValue()
                 selfRef.lastError = status
-                print("🎵 FLACLibDecoder: Error callback - status \(status.rawValue)")
+                selfRef.logDebug("Error callback — status \(status.rawValue)")
             },
             clientData
         )
@@ -223,12 +230,12 @@ class FLACLibDecoder: NativeAudioDecoder {
             throw AudioDecoderError.decodingFailed("FLAC decoder init failed: \(initStatus.rawValue)")
         }
         
-        print("🎵 FLACLibDecoder: ✅ Created decoder for \(sampleRate)Hz, \(channels)ch, \(bitDepth)bit")
+        logInfo("Created decoder for \(sampleRate)Hz, \(channels)ch, \(bitDepth)bit")
         
         // If we have a codec header, add it to pending data
         if let header = header {
             pendingData.append(header)
-            print("🎵 FLACLibDecoder: Added \(header.count) bytes codec header")
+            logDebug("Added \(header.count) bytes codec header")
         }
     }
     
@@ -241,7 +248,7 @@ class FLACLibDecoder: NativeAudioDecoder {
         pendingData.append(data)
 
         if pendingData.count > maxPendingSize {
-            print("🎵 FLACLibDecoder: ⚠️ Pending buffer exceeded \(maxPendingSize) bytes (\(pendingData.count)), resetting")
+            logWarn("Pending buffer exceeded \(maxPendingSize) bytes (\(pendingData.count)), resetting")
             pendingData.removeAll(keepingCapacity: true)
             readOffset = 0
         }
@@ -262,7 +269,7 @@ class FLACLibDecoder: NativeAudioDecoder {
             let state = FLAC__stream_decoder_get_state(decoder)
             
             guard success != 0 else {
-                print("🎵 FLACLibDecoder: process_single returned false, state=\(state.rawValue)")
+                logDebug("process_single returned false, state=\(state.rawValue)")
                 break
             }
             

--- a/iosApp/NativeAudioController.swift
+++ b/iosApp/NativeAudioController.swift
@@ -42,9 +42,17 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
     // have running before the interruption.
     private var pausedByInterruption = false
 
+    // MARK: - Logging
+    // Routes through Kermit (NativeLog) so these reach the shareable in-memory buffer
+    // and os.Logger
+    private static let logTag = "NativeAudioController"
+    private func logInfo(_ message: String) { NativeLog.shared.info(tag: Self.logTag, message: message) }
+    private func logError(_ message: String) { NativeLog.shared.error(tag: Self.logTag, message: message) }
+    private func logDebug(_ message: String) { NativeLog.shared.debug(tag: Self.logTag, message: message) }
+
     override init() {
         super.init()
-        print("🎵 NativeAudioController: Initialized")
+        logDebug("Initialized")
 
         // Handle audio session interruptions (phone calls, Siri, alarms)
         NotificationCenter.default.addObserver(
@@ -76,10 +84,10 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
             // System auto-pauses AudioQueue. Tell the server to pause too so playback
             // resumes from the same position afterwards instead of skipping ahead while
             // the call held the audio session.
-            print("🎵 NativeAudioController: Audio session interrupted")
+            logInfo("Audio session interrupted")
             if isPlaying {
                 pausedByInterruption = true
-                print("🎵 NativeAudioController: Pausing server playback due to interruption")
+                logInfo("Pausing server playback due to interruption")
                 remoteCommandHandler?.onCommand(command: "pause", source: "interruption")
             }
         case .ended:
@@ -91,10 +99,10 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
             // and once control is handed back, if another app is now using the
             // audio device exclusively.
             if !AVAudioSession.sharedInstance().secondaryAudioShouldBeSilencedHint {
-                print("🎵 NativeAudioController: Resuming server playback after interruption")
+                logInfo("Resuming server playback after interruption")
                 remoteCommandHandler?.onCommand(command: "play", source: "interruption")
             } else {
-                print("🎵 NativeAudioController: Another app holds audio — staying paused")
+                logInfo("Another app holds audio — staying paused")
             }
         @unknown default:
             break
@@ -107,7 +115,7 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
               let reason = AVAudioSession.RouteChangeReason(rawValue: reasonValue) else { return }
 
         if reason == .oldDeviceUnavailable {
-            print("🎵 NativeAudioController: Audio output device disconnected")
+            logInfo("Audio output device disconnected")
             let previousRoute = userInfo[AVAudioSessionRouteChangePreviousRouteKey]
                 as? AVAudioSessionRouteDescription
             handleOldDeviceUnavailable(previousRoute: previousRoute)
@@ -126,7 +134,7 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
     private func handleOldDeviceUnavailable(previousRoute: AVAudioSessionRouteDescription?) {
         guard streamStarted else { return }
         let prev = previousRoute?.outputs.first?.portType.rawValue ?? "unknown"
-        print("🎵 NativeAudioController: \(prev) disappeared — pausing playback")
+        logInfo("\(prev) disappeared — pausing playback")
         shouldPlay = false
         streamStarted = false
         stopAudioQueue()
@@ -139,7 +147,7 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
     // MARK: - PlatformAudioPlayer Protocol
 
     func prepareStream(codec: String, sampleRate: Int32, channels: Int32, bitDepth: Int32, codecHeader: String?, listener: MediaPlayerListener) {
-        print("🎵 NativeAudioController: prepareStream - codec=\(codec), rate=\(sampleRate), ch=\(channels), bit=\(bitDepth)")
+        logInfo("prepareStream - codec=\(codec), rate=\(sampleRate), ch=\(channels), bit=\(bitDepth)")
 
         self.listener = listener
         self.currentCodec = codec.lowercased()
@@ -152,7 +160,7 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
         // Decode codec header if present
         if let headerBase64 = codecHeader, let headerData = Data(base64Encoded: headerBase64) {
             self.codecHeader = headerData
-            print("🎵 NativeAudioController: Decoded codec header: \(headerData.count) bytes")
+            logDebug("Decoded codec header: \(headerData.count) bytes")
         } else {
             self.codecHeader = nil
         }
@@ -174,9 +182,9 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
                 bitDepth: Int(bitDepth),
                 codecHeader: self.codecHeader
             )
-            print("🎵 NativeAudioController: Created decoder for \(codec)")
+            logInfo("Created decoder for \(codec)")
         } catch {
-            print("🎵 NativeAudioController: ❌ Failed to create decoder: \(error)")
+            logError("Failed to create decoder: \(error)")
             listener.onError(error: KotlinThrowable(message: error.localizedDescription))
             return
         }
@@ -209,13 +217,13 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
         // Start audio queue on first data
         if !streamStarted {
             streamStarted = true
-            print("🎵 NativeAudioController: First data received (\(swiftData.count) bytes)")
+            logDebug("First data received (\(swiftData.count) bytes)")
             NowPlayingManager.shared.activatePlayback()
             startAudioQueue()
         }
 
         guard let decoder = decoder else {
-            print("🎵 NativeAudioController: ❌ No decoder available")
+            logDebug("No decoder available — dropping packet")
             return
         }
 
@@ -225,12 +233,12 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
             pcmBuffer.append(pcmData)
             bufferLock.unlock()
         } catch {
-            print("🎵 NativeAudioController: ❌ Decode error: \(error)")
+            logDebug("Decode error: \(error)")
         }
     }
 
     func stopRawPcmStream() {
-        print("🎵 NativeAudioController: Stopping stream")
+        logInfo("Stopping stream")
         shouldPlay = false
         streamStarted = false
         stopAudioQueue()
@@ -245,7 +253,7 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
     /// in-flight audio so the consumer can't immediately rebuild the queue;
     /// resume then rebuilds clean on the next packet, like a cold start.
     func pauseSink() {
-        print("🎵 NativeAudioController: pauseSink")
+        logInfo("pauseSink")
         shouldPlay = false
         streamStarted = false
         tearDownQueue()
@@ -255,7 +263,7 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
     /// `shouldPlay = true` re-opens the write gate; the queue rebuilds on the next
     /// audio packet, or is started here if one still exists (gapless restart).
     func resumeSink() {
-        print("🎵 NativeAudioController: resumeSink")
+        logInfo("resumeSink")
         shouldPlay = true
         NowPlayingManager.shared.activatePlayback()
         isPlaying = true
@@ -313,7 +321,7 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
         audioFormat.mBytesPerFrame = UInt32(currentChannels) * UInt32(bytesPerSample)
         audioFormat.mBytesPerPacket = audioFormat.mBytesPerFrame
 
-        print("🎵 NativeAudioController: Audio format - \(currentSampleRate)Hz, \(currentChannels)ch, \(effectiveBitDepth)bit")
+        logDebug("Audio format - \(currentSampleRate)Hz, \(currentChannels)ch, \(effectiveBitDepth)bit")
 
         // Create AudioQueue
         let selfPointer = Unmanaged.passUnretained(self).toOpaque()
@@ -330,7 +338,7 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
         )
 
         guard status == noErr, let queue = queue else {
-            print("🎵 NativeAudioController: ❌ Failed to create AudioQueue: \(status)")
+            logError("Failed to create AudioQueue: \(status)")
             return
         }
 
@@ -350,9 +358,9 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
         let startStatus = AudioQueueStart(queue, nil)
         if startStatus == noErr {
             isPlaying = true
-            print("🎵 NativeAudioController: ✅ AudioQueue started")
+            logInfo("AudioQueue started")
         } else {
-            print("🎵 NativeAudioController: ❌ Failed to start AudioQueue: \(startStatus)")
+            logError("Failed to start AudioQueue: \(startStatus)")
         }
     }
 
@@ -372,7 +380,7 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
 
         audioQueue = nil
         isPlaying = false
-        print("🎵 NativeAudioController: AudioQueue stopped")
+        logInfo("AudioQueue stopped")
     }
 
     fileprivate func fillBuffer(queue: AudioQueueRef, buffer: AudioQueueBufferRef) {
@@ -436,7 +444,7 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
         self.remoteCommandHandler = handler
 
         NowPlayingManager.shared.setCommandHandler { [weak self] command in
-            print("🎵 NativeAudioController: Remote command: \(command)")
+            self?.logInfo("Remote command: \(command)")
             self?.remoteCommandHandler?.onCommand(command: command, source: "remote")
         }
     }

--- a/iosApp/NowPlayingManager.swift
+++ b/iosApp/NowPlayingManager.swift
@@ -25,8 +25,14 @@ class NowPlayingManager {
     private var currentArtist: String?
     private var currentAlbum: String?
 
+    // MARK: - Logging
+    private static let logTag = "NowPlayingManager"
+    private func logInfo(_ message: String) { NativeLog.shared.info(tag: Self.logTag, message: message) }
+    private func logError(_ message: String) { NativeLog.shared.error(tag: Self.logTag, message: message) }
+    private func logDebug(_ message: String) { NativeLog.shared.debug(tag: Self.logTag, message: message) }
+
     init() {
-        print("🎵 NowPlayingManager: Initializing...")
+        logDebug("Initializing")
         configureAudioSession()
         setupRemoteCommands() // Setup commands once
         printDebugState("After init")
@@ -39,9 +45,9 @@ class NowPlayingManager {
         do {
             let session = AVAudioSession.sharedInstance()
             try session.setCategory(.playback, mode: .default, options: [])
-            print("🎵 NowPlayingManager: Audio session category configured")
+            logDebug("Audio session category configured")
         } catch {
-            print("🎵 NowPlayingManager: ❌ Failed to configure audio session: \(error)")
+            logError("Failed to configure audio session: \(error)")
         }
     }
 
@@ -51,7 +57,7 @@ class NowPlayingManager {
             let session = AVAudioSession.sharedInstance()
             try session.setActive(true, options: .notifyOthersOnDeactivation)
         } catch {
-            print("🎵 NowPlayingManager: ❌ Failed to activate playback: \(error)")
+            logError("Failed to activate playback: \(error)")
         }
     }
 
@@ -59,7 +65,7 @@ class NowPlayingManager {
     /// We now support dynamic handler updates without re-registering commands
     func setCommandHandler(_ handler: @escaping CommandHandler) {
         self.commandHandler = handler
-        print("🎵 NowPlayingManager: Command handler updated")
+        logDebug("Command handler updated")
     }
 
     // Track pending update to handle race conditions
@@ -137,7 +143,7 @@ class NowPlayingManager {
         // If it's a new track, we want to PREVENT FLICKER.
         // Strategy: Keep showing OLD metadata until NEW artwork is ready.
 
-        print("🎵 NowPlayingManager: Detected new track. Waiting for artwork to prevent flicker...")
+        logDebug("Detected new track — waiting for artwork to prevent flicker")
 
         // Mark this as the pending update
         self.pendingIdentifier = newIdentifier
@@ -183,7 +189,7 @@ class NowPlayingManager {
 
             // Check if this result is still relevant
             if self.pendingIdentifier != newIdentifier {
-                print("🎵 NowPlayingManager: Ignoring stale artwork load for \(newIdentifier)")
+                logDebug("Ignoring stale artwork load for \(newIdentifier)")
                 return
             }
 
@@ -199,7 +205,7 @@ class NowPlayingManager {
                     contentId: newIdentifier,
                     isNewTrack: true
                 )
-                print("🎵 NowPlayingManager: Artwork loaded. Metadata updated.")
+                self.logDebug("Artwork loaded, metadata updated")
             }
         }
     }
@@ -277,7 +283,7 @@ class NowPlayingManager {
 
     /// Clears the Now Playing info
     func clearNowPlayingInfo() {
-        print("🎵 NowPlayingManager: Clearing Now Playing info")
+        logInfo("Clearing Now Playing info")
         DispatchQueue.main.async { [weak self] in
             MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
             self?.cachedArtwork = nil
@@ -294,13 +300,13 @@ class NowPlayingManager {
 
     private func setupRemoteCommands() {
         let commandCenter = MPRemoteCommandCenter.shared()
-        print("🎵 NowPlayingManager: Setting up remote commands (Once)")
+        logDebug("Setting up remote commands (once)")
 
         // Helper to attach targets
         func addTarget(_ command: MPRemoteCommand, cmd: String) {
             command.isEnabled = true
             command.addTarget { [weak self] _ in
-                print("🎵 NowPlayingManager: Remote command received: \(cmd)")
+                self?.logDebug("Remote command received: \(cmd)")
                 self?.commandHandler?(cmd)
                 return .success
             }


### PR DESCRIPTION
This is a direct result of me trying to debug some CarPlay issues, which by definition mean my phone can't be connected to the Xcode debugger, so I have to rely on what's persisted to the system log + 'share logs' inside the app.

Commit message:

Make the in-app diagnostic buffer able to reconstruct network and playback issues for a longer period of time. Clean up logging overall.

- InMemoryLogWriter: own Info severity floor (independent of the console/verbose level) and larger capacity, retaining ~30+ min of Info+ history
- Event.kt: stop dumping full payloads for unmodeled server events (tasks_updated carries multi-KB embedded server logs); record the type at Debug instead.
- iOS: new NativeLog bridge routes Swift logs through Kermit (in-memory buffer + os.Logger) instead of Xcode-only print(); convert NativeAudioController, NowPlayingManager, and AudioDecoders with state/commands/errors at Info+ and per-packet/hot-path detail at Debug.
- Kotlin Info audit: promote commands sent/received, websocket close, stream metadata, and token-clear-on-auth-failure to Info; demote the 2s state-report heartbeat to Debug (with an explicit Info at the Buffering -> Synchronized transition); reclassify a stray Logger.e seek log.