### PR TITLE
Reset screens when tapping nav item on root

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -288,14 +288,6 @@ private fun LandingPageTopBar(
     TopAppBar(
         title = { Text(stringResource(Res.string.nav_home)) },
         actions = {
-            if (!editMode) {
-                IconButton(onClick = onRefresh) {
-                    Icon(
-                        imageVector = Icons.Default.Refresh,
-                        contentDescription = stringResource(Res.string.refresh),
-                    )
-                }
-            }
             IconButton(onClick = onToggleEditMode) {
                 Icon(
                     imageVector = if (editMode) Icons.Default.Done else Icons.Default.Edit,
@@ -303,6 +295,15 @@ private fun LandingPageTopBar(
                         if (editMode) Res.string.home_save_rows else Res.string.home_edit_rows,
                     ),
                 )
+            }
+
+            if (!editMode) {
+                IconButton(onClick = onRefresh) {
+                    Icon(
+                        imageVector = Icons.Default.Refresh,
+                        contentDescription = stringResource(Res.string.refresh),
+                    )
+                }
             }
         },
     )

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -32,11 +32,13 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -79,7 +81,10 @@ import io.music_assistant.client.ui.compose.common.moveToEnabledBoundary
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.nav.BackHandler
 import io.music_assistant.client.ui.compose.nav.Screen
+import io.music_assistant.client.ui.compose.nav.ScreenState
 import io.music_assistant.client.utils.SessionState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.all_albums
 import musicassistantclient.composeapp.generated.resources.all_artists
@@ -109,8 +114,7 @@ fun HomeScreen(
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
     homeRowsConfig: List<SettingsRepository.HomeRowPref>,
     actionsViewModel: ActionsViewModel,
-    scrollState: LazyListState,
-    scrollBehaviour: TopAppBarScrollBehavior,
+    state: HomeScreenState,
 ) {
     var editMode by remember { mutableStateOf(false) }
 
@@ -147,7 +151,7 @@ fun HomeScreen(
     val displayedData =
         if (editMode) items.map { it.first } else working.filter { it.second }.map { it.first }
 
-    val reorderableState = rememberReorderableLazyListState(scrollState) { from, to ->
+    val reorderableState = rememberReorderableLazyListState(state.lazyListState) { from, to ->
         // Constrain reorder to the contiguous enabled section.
         if (from.index >= enabledCount || to.index >= enabledCount) return@rememberReorderableLazyListState
         items = items.toMutableList().apply { add(to.index, removeAt(from.index)) }
@@ -178,7 +182,7 @@ fun HomeScreen(
                 },
             )
         },
-        scrollBehavior = scrollBehaviour,
+        scrollBehavior = state.topAppBarScrollBehavior,
     ) {
         val rowContent: @Composable (RecommendationFolder) -> Unit = { row ->
             CategoryRow(
@@ -198,7 +202,7 @@ fun HomeScreen(
         }
         ProvideClickActions(ClickContext.HOME) {
             LazyColumn(
-                state = scrollState,
+                state = state.lazyListState,
                 contentPadding = contentPadding,
             ) {
                 if (connectionState !is SessionState.Connected || dataState !is DataState.Data) {
@@ -463,4 +467,28 @@ fun allItemsTitle(type: MediaType) = when (type) {
     MediaType.RADIO -> stringResource(Res.string.all_radio)
     MediaType.GENRE -> stringResource(Res.string.all_genres)
     else -> null
+}
+
+class HomeScreenState(
+    val topAppBarScrollBehavior: TopAppBarScrollBehavior,
+    val lazyListState: LazyListState,
+    val coroutineScope: CoroutineScope,
+) : ScreenState {
+    override fun reset() {
+        coroutineScope.launch {
+            topAppBarScrollBehavior.state.heightOffset = 0f
+            lazyListState.animateScrollToItem(0)
+        }
+    }
+
+    companion object {
+        @Composable
+        fun create(): HomeScreenState {
+            return HomeScreenState(
+                TopAppBarDefaults.enterAlwaysScrollBehavior(),
+                rememberLazyListState(),
+                rememberCoroutineScope(),
+            )
+        }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -31,6 +32,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -107,6 +109,8 @@ fun HomeScreen(
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
     homeRowsConfig: List<SettingsRepository.HomeRowPref>,
     actionsViewModel: ActionsViewModel,
+    scrollState: LazyListState,
+    scrollBehaviour: TopAppBarScrollBehavior,
 ) {
     var editMode by remember { mutableStateOf(false) }
 
@@ -140,10 +144,10 @@ fun HomeScreen(
     val enabledCount = items.count { it.second }
     val enabledByKey = remember(items) { items.associate { it.first.lazyListKey() to it.second } }
 
-    val displayedData = if (editMode) items.map { it.first } else working.filter { it.second }.map { it.first }
+    val displayedData =
+        if (editMode) items.map { it.first } else working.filter { it.second }.map { it.first }
 
-    val listState = rememberLazyListState()
-    val reorderableState = rememberReorderableLazyListState(listState) { from, to ->
+    val reorderableState = rememberReorderableLazyListState(scrollState) { from, to ->
         // Constrain reorder to the contiguous enabled section.
         if (from.index >= enabledCount || to.index >= enabledCount) return@rememberReorderableLazyListState
         items = items.toMutableList().apply { add(to.index, removeAt(from.index)) }
@@ -159,7 +163,12 @@ fun HomeScreen(
                 onToggleEditMode = {
                     if (editMode) {
                         homeScreenViewModel.saveHomeRows(
-                            items.map { SettingsRepository.HomeRowPref(it.first.itemId, it.second) },
+                            items.map {
+                                SettingsRepository.HomeRowPref(
+                                    it.first.itemId,
+                                    it.second,
+                                )
+                            },
                         )
                         editMode = false
                     } else {
@@ -169,6 +178,7 @@ fun HomeScreen(
                 },
             )
         },
+        scrollBehavior = scrollBehaviour,
     ) {
         val rowContent: @Composable (RecommendationFolder) -> Unit = { row ->
             CategoryRow(
@@ -187,79 +197,80 @@ fun HomeScreen(
             )
         }
         ProvideClickActions(ClickContext.HOME) {
-        LazyColumn(
-            state = listState,
-            contentPadding = contentPadding,
-        ) {
-            if (connectionState !is SessionState.Connected || dataState !is DataState.Data) {
-                item {
-                    Box(
-                        modifier = modifier.fillMaxWidth().height(200.dp),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        CircularProgressIndicator()
+            LazyColumn(
+                state = scrollState,
+                contentPadding = contentPadding,
+            ) {
+                if (connectionState !is SessionState.Connected || dataState !is DataState.Data) {
+                    item {
+                        Box(
+                            modifier = modifier.fillMaxWidth().height(200.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            CircularProgressIndicator()
+                        }
                     }
-                }
-            } else {
-                items(
-                    items = displayedData,
-                    key = { it.lazyListKey() },
-                ) { row ->
-                    if (editMode) {
-                        val enabled = enabledByKey[row.lazyListKey()] ?: true
-                        ReorderableItem(reorderableState, key = row.lazyListKey()) {
-                            Box(modifier = Modifier.fillMaxWidth()) {
-                                rowContent(row)
-                                Box(
-                                    modifier = Modifier
-                                        .matchParentSize()
-                                        .background(
-                                            MaterialTheme.colorScheme.background.copy(
-                                                alpha = if (enabled) 0.60f else 0.80f,
-                                            ),
-                                        )
-                                        .pointerInput(Unit) {
-                                            // Swallow taps & long-presses on the row;
-                                            // vertical drags pass through so the
-                                            // LazyColumn can still scroll.
-                                            detectTapGestures(onTap = {}, onLongPress = {})
-                                        },
-                                )
-                                Row(
-                                    modifier = Modifier
-                                        .align(Alignment.CenterEnd)
-                                        .padding(end = 16.dp),
-                                    verticalAlignment = Alignment.CenterVertically,
-                                ) {
-                                    // Keep at least one row visible: block disabling the last enabled one.
-                                    Switch(
-                                        checked = enabled,
-                                        enabled = !enabled || enabledCount > 1,
-                                        onCheckedChange = { newEnabled ->
-                                            items = moveToEnabledBoundary(items, row, newEnabled)
-                                        },
-                                    )
-                                    Icon(
+                } else {
+                    items(
+                        items = displayedData,
+                        key = { it.lazyListKey() },
+                    ) { row ->
+                        if (editMode) {
+                            val enabled = enabledByKey[row.lazyListKey()] ?: true
+                            ReorderableItem(reorderableState, key = row.lazyListKey()) {
+                                Box(modifier = Modifier.fillMaxWidth()) {
+                                    rowContent(row)
+                                    Box(
                                         modifier = Modifier
-                                            .padding(start = 12.dp)
-                                            .then(
-                                                if (enabled) Modifier.draggableHandle() else Modifier,
+                                            .matchParentSize()
+                                            .background(
+                                                MaterialTheme.colorScheme.background.copy(
+                                                    alpha = if (enabled) 0.60f else 0.80f,
+                                                ),
                                             )
-                                            .alpha(if (enabled) 1f else 0.3f)
-                                            .size(24.dp),
-                                        imageVector = TablerIcons.GripVertical,
-                                        contentDescription = null,
-                                        tint = MaterialTheme.colorScheme.secondary,
+                                            .pointerInput(Unit) {
+                                                // Swallow taps & long-presses on the row;
+                                                // vertical drags pass through so the
+                                                // LazyColumn can still scroll.
+                                                detectTapGestures(onTap = {}, onLongPress = {})
+                                            },
                                     )
+                                    Row(
+                                        modifier = Modifier
+                                            .align(Alignment.CenterEnd)
+                                            .padding(end = 16.dp),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        // Keep at least one row visible: block disabling the last enabled one.
+                                        Switch(
+                                            checked = enabled,
+                                            enabled = !enabled || enabledCount > 1,
+                                            onCheckedChange = { newEnabled ->
+                                                items =
+                                                    moveToEnabledBoundary(items, row, newEnabled)
+                                            },
+                                        )
+                                        Icon(
+                                            modifier = Modifier
+                                                .padding(start = 12.dp)
+                                                .then(
+                                                    if (enabled) Modifier.draggableHandle() else Modifier,
+                                                )
+                                                .alpha(if (enabled) 1f else 0.3f)
+                                                .size(24.dp),
+                                            imageVector = TablerIcons.GripVertical,
+                                            contentDescription = null,
+                                            tint = MaterialTheme.colorScheme.secondary,
+                                        )
+                                    }
                                 }
                             }
+                        } else {
+                            rowContent(row)
                         }
-                    } else {
-                        rowContent(row)
                     }
                 }
             }
-        }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -32,8 +32,8 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.material3.TopAppBarState
+import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -182,7 +182,7 @@ fun HomeScreen(
                 },
             )
         },
-        scrollBehavior = state.topAppBarScrollBehavior,
+        topAppBarState = state.topAppBarState,
     ) {
         val rowContent: @Composable (RecommendationFolder) -> Unit = { row ->
             CategoryRow(
@@ -470,13 +470,13 @@ fun allItemsTitle(type: MediaType) = when (type) {
 }
 
 class HomeScreenState(
-    val topAppBarScrollBehavior: TopAppBarScrollBehavior,
+    val topAppBarState: TopAppBarState,
     val lazyListState: LazyListState,
     val coroutineScope: CoroutineScope,
 ) : ScreenState {
     override fun reset() {
         coroutineScope.launch {
-            topAppBarScrollBehavior.state.heightOffset = 0f
+            topAppBarState.heightOffset = 0f
             lazyListState.animateScrollToItem(0)
         }
     }
@@ -485,7 +485,7 @@ class HomeScreenState(
         @Composable
         fun create(): HomeScreenState {
             return HomeScreenState(
-                TopAppBarDefaults.enterAlwaysScrollBehavior(),
+                rememberTopAppBarState(),
                 rememberLazyListState(),
                 rememberCoroutineScope(),
             )

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
@@ -19,11 +21,14 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
@@ -75,6 +80,7 @@ import io.music_assistant.client.ui.compose.search.SearchViewModel
 import io.music_assistant.client.utils.DataConnectionState
 import io.music_assistant.client.utils.SessionState
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
@@ -116,7 +122,8 @@ fun MainNavigationRoot(
         }
     }
 
-    val recommendationsState = homeScreenViewModel.recommendationsState.collectAsStateWithLifecycle()
+    val recommendationsState =
+        homeScreenViewModel.recommendationsState.collectAsStateWithLifecycle()
     val playersState by homeScreenViewModel.playersState.collectAsStateWithLifecycle()
     // Single pager state used across all views
     val data = playersState as? HomeScreenViewModel.PlayersState.Data
@@ -197,11 +204,21 @@ fun MainNavigationRoot(
         deepLinkBus.consume(dest)
     }
 
+    val scope = rememberCoroutineScope()
+    val homeScreenScrollState = rememberLazyListState()
+    val homeScreenTopAppBarScrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+
     val navigationItems = listOf(
         multiBackStack.createNavigationItem(
             backStack = 0,
             icon = Icons.Default.Home,
             label = stringResource(Res.string.nav_home),
+            onReset = {
+                scope.launch {
+                    homeScreenTopAppBarScrollBehavior.state.heightOffset = 0f
+                    homeScreenScrollState.animateScrollToItem(0)
+                }
+            },
         ),
         multiBackStack.createNavigationItem(
             backStack = 1,
@@ -222,83 +239,85 @@ fun MainNavigationRoot(
     )
 
     Box(modifier = Modifier.fillMaxSize()) {
-    AdaptiveNavigationScaffold(
-        showNavBar = !playerExpanded,
-        navigationItems = navigationItems,
-    ) { scaffoldContentPadding ->
-        val bottomPadding = scaffoldContentPadding.calculateBottomPadding()
+        AdaptiveNavigationScaffold(
+            showNavBar = !playerExpanded,
+            navigationItems = navigationItems,
+        ) { scaffoldContentPadding ->
+            val bottomPadding = scaffoldContentPadding.calculateBottomPadding()
 
-        FloatingBarLayout(
-            floatingBar = {
-                FloatingBar(
-                    collapsedBottomPadding = bottomPadding,
-                    expanded = playerExpanded,
-                    onExpand = onExpandPlayer,
-                    content = { expanded, contentPadding ->
-                        PlayersPager(
-                            playerPagerState = playerPagerState,
-                            state = playersState,
-                            homeScreenViewModel = homeScreenViewModel,
-                            actionsViewModel = actionsViewModel,
-                            dspSettingsViewModel = dspSettingsViewModel,
-                            expanded = expanded,
-                            onClose = { playerExpanded = false },
-                            contentPadding = contentPadding,
-                        ) { item ->
-                            multiBackStack.add(
-                                MainNav.ItemDetails(
-                                    itemId = item.itemId,
-                                    mediaType = item.mediaType,
-                                    providerId = item.provider,
+            FloatingBarLayout(
+                floatingBar = {
+                    FloatingBar(
+                        collapsedBottomPadding = bottomPadding,
+                        expanded = playerExpanded,
+                        onExpand = onExpandPlayer,
+                        content = { expanded, contentPadding ->
+                            PlayersPager(
+                                playerPagerState = playerPagerState,
+                                state = playersState,
+                                homeScreenViewModel = homeScreenViewModel,
+                                actionsViewModel = actionsViewModel,
+                                dspSettingsViewModel = dspSettingsViewModel,
+                                expanded = expanded,
+                                onClose = { playerExpanded = false },
+                                contentPadding = contentPadding,
+                            ) { item ->
+                                multiBackStack.add(
+                                    MainNav.ItemDetails(
+                                        itemId = item.itemId,
+                                        mediaType = item.mediaType,
+                                        providerId = item.provider,
+                                    ),
+                                )
+                            }
+                        },
+                    )
+                },
+            ) { floatingBarContentPadding ->
+                BackHandler(playerExpanded) {
+                    playerExpanded = !playerExpanded
+                }
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.background),
+                ) {
+                    ConditionalBackNavDisplay(
+                        entries = rememberDecoratedNavEntries(
+                            entryDecorators = listOf(
+                                rememberSaveableStateHolderNavEntryDecorator(),
+                                rememberViewModelStoreNavEntryDecorator(),
+                            ),
+                            entries = multiBackStack.toEntries(
+                                mainNavEntryProvider(
+                                    floatingBarContentPadding,
+                                    connectionState,
+                                    dataState,
+                                    homeRowsConfig,
+                                    multiBackStack,
+                                    homeScreenViewModel,
+                                    actionsViewModel,
+                                    homeScreenScrollState,
+                                    homeScreenTopAppBarScrollBehavior,
                                 ),
-                            )
-                        }
-                    },
-                )
-            },
-        ) { floatingBarContentPadding ->
-            BackHandler(playerExpanded) {
-                playerExpanded = !playerExpanded
-            }
-
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.background),
-            ) {
-                ConditionalBackNavDisplay(
-                    entries = rememberDecoratedNavEntries(
-                        entryDecorators = listOf(
-                            rememberSaveableStateHolderNavEntryDecorator(),
-                            rememberViewModelStoreNavEntryDecorator(),
-                        ),
-                        entries = multiBackStack.toEntries(
-                            mainNavEntryProvider(
-                                floatingBarContentPadding,
-                                connectionState,
-                                dataState,
-                                homeRowsConfig,
-                                multiBackStack,
-                                homeScreenViewModel,
-                                actionsViewModel,
                             ),
                         ),
-                    ),
-                    onBack = {
-                        multiBackStack.removeLastOrNull()
-                    },
-                    backEnabled = !playerExpanded,
-                    // Workaround for CMP 1.10.3 iOS crash: LazyLayout measured inside
-                    // AnimatedContent + CupertinoOverscroll trips a SubcomposeLayout
-                    // precondition on first frame. Disabling transitions removes the
-                    // animating measure path.
-                    transitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
-                    popTransitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
-                    predictivePopTransitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
-                )
+                        onBack = {
+                            multiBackStack.removeLastOrNull()
+                        },
+                        backEnabled = !playerExpanded,
+                        // Workaround for CMP 1.10.3 iOS crash: LazyLayout measured inside
+                        // AnimatedContent + CupertinoOverscroll trips a SubcomposeLayout
+                        // precondition on first frame. Disabling transitions removes the
+                        // animating measure path.
+                        transitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
+                        popTransitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
+                        predictivePopTransitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
+                    )
+                }
             }
         }
-    }
         ToastHost(toastState = toastState)
     }
 }
@@ -312,6 +331,8 @@ private fun mainNavEntryProvider(
     multiBackStack: MultiBackStack<NavKey>,
     homeScreenViewModel: HomeScreenViewModel,
     actionsViewModel: ActionsViewModel,
+    homeScreenScrollState: LazyListState,
+    homeScreenScrollBehavior: TopAppBarScrollBehavior,
 ): (NavKey) -> NavEntry<NavKey> {
     // Hoisted here (outlives the per-NavEntry SearchViewModel) to carry an empty-quick-search
     // escalation from the library tab to the Search tab. Set by ItemList, consumed by SearchScreen.
@@ -331,7 +352,7 @@ private fun mainNavEntryProvider(
                         is Podcast,
                         is Audiobook,
                         is Genre,
-                        -> {
+                            -> {
                             multiBackStack.add(
                                 MainNav.ItemDetails(
                                     itemId = item.itemId,
@@ -353,6 +374,8 @@ private fun mainNavEntryProvider(
                 },
                 homeRowsConfig = homeRowsConfig,
                 actionsViewModel = actionsViewModel,
+                scrollState = homeScreenScrollState,
+                scrollBehaviour = homeScreenScrollBehavior,
             )
         }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -63,6 +63,7 @@ import io.music_assistant.client.ui.compose.library.ItemListScreen
 import io.music_assistant.client.ui.compose.library.ItemListViewModel
 import io.music_assistant.client.ui.compose.library.LibraryCategoriesViewModel
 import io.music_assistant.client.ui.compose.library.LibraryScreen
+import io.music_assistant.client.ui.compose.library.LibraryScreenState
 import io.music_assistant.client.ui.compose.nav.AdaptiveNavigationScaffold
 import io.music_assistant.client.ui.compose.nav.BackHandler
 import io.music_assistant.client.ui.compose.nav.ConditionalBackNavDisplay
@@ -199,6 +200,7 @@ fun MainNavigationRoot(
     }
 
     val homeScreenState = HomeScreenState.create()
+    val libraryScreenState = LibraryScreenState.create()
 
     val navigationItems = listOf(
         multiBackStack.createNavigationItem(
@@ -211,6 +213,7 @@ fun MainNavigationRoot(
             backStack = 1,
             icon = Icons.Default.LibraryMusic,
             label = stringResource(Res.string.nav_library),
+            screenState = libraryScreenState,
         ),
         multiBackStack.createNavigationItem(
             backStack = 2,
@@ -286,6 +289,7 @@ fun MainNavigationRoot(
                                     homeScreenViewModel,
                                     actionsViewModel,
                                     homeScreenState,
+                                    libraryScreenState,
                                 ),
                             ),
                         ),
@@ -318,6 +322,7 @@ private fun mainNavEntryProvider(
     homeScreenViewModel: HomeScreenViewModel,
     actionsViewModel: ActionsViewModel,
     homeScreenState: HomeScreenState,
+    libraryScreenState: LibraryScreenState,
 ): (NavKey) -> NavEntry<NavKey> {
     // Hoisted here (outlives the per-NavEntry SearchViewModel) to carry an empty-quick-search
     // escalation from the library tab to the Search tab. Set by ItemList, consumed by SearchScreen.
@@ -369,6 +374,7 @@ private fun mainNavEntryProvider(
             LibraryScreen(
                 libraryCategoriesViewModel,
                 contentPadding = contentPadding,
+                state = libraryScreenState,
                 onTypeClick = {
                     multiBackStack.add(MainNav.ItemList(it))
                 },

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
@@ -21,14 +19,11 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
@@ -80,7 +75,6 @@ import io.music_assistant.client.ui.compose.search.SearchViewModel
 import io.music_assistant.client.utils.DataConnectionState
 import io.music_assistant.client.utils.SessionState
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
@@ -204,21 +198,14 @@ fun MainNavigationRoot(
         deepLinkBus.consume(dest)
     }
 
-    val scope = rememberCoroutineScope()
-    val homeScreenScrollState = rememberLazyListState()
-    val homeScreenTopAppBarScrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+    val homeScreenState = HomeScreenState.create()
 
     val navigationItems = listOf(
         multiBackStack.createNavigationItem(
             backStack = 0,
             icon = Icons.Default.Home,
             label = stringResource(Res.string.nav_home),
-            onReset = {
-                scope.launch {
-                    homeScreenTopAppBarScrollBehavior.state.heightOffset = 0f
-                    homeScreenScrollState.animateScrollToItem(0)
-                }
-            },
+            screenState = homeScreenState,
         ),
         multiBackStack.createNavigationItem(
             backStack = 1,
@@ -298,8 +285,7 @@ fun MainNavigationRoot(
                                     multiBackStack,
                                     homeScreenViewModel,
                                     actionsViewModel,
-                                    homeScreenScrollState,
-                                    homeScreenTopAppBarScrollBehavior,
+                                    homeScreenState,
                                 ),
                             ),
                         ),
@@ -331,8 +317,7 @@ private fun mainNavEntryProvider(
     multiBackStack: MultiBackStack<NavKey>,
     homeScreenViewModel: HomeScreenViewModel,
     actionsViewModel: ActionsViewModel,
-    homeScreenScrollState: LazyListState,
-    homeScreenScrollBehavior: TopAppBarScrollBehavior,
+    homeScreenState: HomeScreenState,
 ): (NavKey) -> NavEntry<NavKey> {
     // Hoisted here (outlives the per-NavEntry SearchViewModel) to carry an empty-quick-search
     // escalation from the library tab to the Search tab. Set by ItemList, consumed by SearchScreen.
@@ -374,8 +359,7 @@ private fun mainNavEntryProvider(
                 },
                 homeRowsConfig = homeRowsConfig,
                 actionsViewModel = actionsViewModel,
-                scrollState = homeScreenScrollState,
-                scrollBehaviour = homeScreenScrollBehavior,
+                state = homeScreenState,
             )
         }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -72,6 +72,7 @@ import io.music_assistant.client.ui.compose.nav.NavigationItem
 import io.music_assistant.client.ui.compose.nav.createNavigationItem
 import io.music_assistant.client.ui.compose.search.GlobalSearchRequest
 import io.music_assistant.client.ui.compose.search.SearchScreen
+import io.music_assistant.client.ui.compose.search.SearchScreenState
 import io.music_assistant.client.ui.compose.search.SearchViewModel
 import io.music_assistant.client.utils.DataConnectionState
 import io.music_assistant.client.utils.SessionState
@@ -201,6 +202,7 @@ fun MainNavigationRoot(
 
     val homeScreenState = HomeScreenState.create()
     val libraryScreenState = LibraryScreenState.create()
+    val searchScreenState = SearchScreenState.create()
 
     val navigationItems = listOf(
         multiBackStack.createNavigationItem(
@@ -219,6 +221,7 @@ fun MainNavigationRoot(
             backStack = 2,
             icon = Icons.Default.Search,
             label = stringResource(Res.string.nav_search),
+            screenState = searchScreenState,
         ),
         NavigationItem(
             selected = false,
@@ -290,6 +293,7 @@ fun MainNavigationRoot(
                                     actionsViewModel,
                                     homeScreenState,
                                     libraryScreenState,
+                                    searchScreenState,
                                 ),
                             ),
                         ),
@@ -323,6 +327,7 @@ private fun mainNavEntryProvider(
     actionsViewModel: ActionsViewModel,
     homeScreenState: HomeScreenState,
     libraryScreenState: LibraryScreenState,
+    searchScreenState: SearchScreenState,
 ): (NavKey) -> NavEntry<NavKey> {
     // Hoisted here (outlives the per-NavEntry SearchViewModel) to carry an empty-quick-search
     // escalation from the library tab to the Search tab. Set by ItemList, consumed by SearchScreen.
@@ -458,6 +463,7 @@ private fun mainNavEntryProvider(
                 },
                 contentPadding = contentPadding,
                 actionsViewModel = actionsViewModel,
+                state = searchScreenState,
                 pendingSearch = pendingSearch,
                 onSearchConsumed = { pendingSearch = null },
             )

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryScreen.kt
@@ -24,10 +24,13 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarState
+import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -38,7 +41,10 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.ui.compose.nav.Screen
+import io.music_assistant.client.ui.compose.nav.ScreenState
 import io.music_assistant.client.utils.libraryItemMinWidth
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.cd_customize_tabs
 import musicassistantclient.composeapp.generated.resources.nav_library
@@ -49,20 +55,19 @@ import org.jetbrains.compose.resources.stringResource
 fun LibraryScreen(
     libraryCategoriesViewModel: LibraryCategoriesViewModel,
     contentPadding: PaddingValues,
+    state: LibraryScreenState,
     onTypeClick: (MediaType) -> Unit,
 ) {
-    val state by libraryCategoriesViewModel.state.collectAsStateWithLifecycle()
+    val categoriesState by libraryCategoriesViewModel.state.collectAsStateWithLifecycle()
 
     var showCustomizeDialog by remember { mutableStateOf(false) }
     if (showCustomizeDialog) {
         CustomizeLibraryCategoriesDialog(
-            initialConfig = state.categories.map { it.libraryCategory to it.enabled },
+            initialConfig = categoriesState.categories.map { it.libraryCategory to it.enabled },
             onDismissRequest = { showCustomizeDialog = false },
             onConfirm = libraryCategoriesViewModel::onTabsConfigChanged,
         )
     }
-
-    val gridState = rememberLazyGridState()
 
     Screen(
         topBar = {
@@ -78,13 +83,14 @@ fun LibraryScreen(
                 },
             )
         },
+        topAppBarState = state.topAppBarState,
     ) {
-        val libraryCategories = remember(state.categories) {
-            state.categories.filter { it.enabled }.map { it.libraryCategory }
+        val libraryCategories = remember(categoriesState.categories) {
+            categoriesState.categories.filter { it.enabled }.map { it.libraryCategory }
         }
 
         LibraryGrid(
-            gridState = gridState,
+            gridState = state.lazyGridState,
             paddingValues = contentPadding,
             libraryCategories = libraryCategories,
             onTypeClick = onTypeClick,
@@ -138,6 +144,30 @@ private fun LibraryGrid(
                     )
                 }
             }
+        }
+    }
+}
+
+class LibraryScreenState(
+    val topAppBarState: TopAppBarState,
+    val lazyGridState: LazyGridState,
+    val coroutineScope: CoroutineScope,
+) : ScreenState {
+    override fun reset() {
+        topAppBarState.heightOffset = 0f
+        coroutineScope.launch {
+            lazyGridState.animateScrollToItem(0)
+        }
+    }
+
+    companion object {
+        @Composable
+        fun create(): LibraryScreenState {
+            return LibraryScreenState(
+                rememberTopAppBarState(),
+                rememberLazyGridState(),
+                rememberCoroutineScope(),
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/AdaptiveNavigationScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/AdaptiveNavigationScaffold.kt
@@ -92,12 +92,13 @@ fun <T : NavKey> MultiBackStack<T>.createNavigationItem(
     backStack: Int,
     icon: ImageVector,
     label: String? = null,
+    onReset: (() -> Unit)? = null,
 ): NavigationItem {
     return NavigationItem(
         selected = currentBackStack == backStack,
         onClick = {
             if (this.currentBackStack == backStack) {
-                resetCurrentBackStack()
+                resetCurrentBackStack(onReset)
             } else {
                 currentBackStack = backStack
             }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/AdaptiveNavigationScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/AdaptiveNavigationScaffold.kt
@@ -92,13 +92,13 @@ fun <T : NavKey> MultiBackStack<T>.createNavigationItem(
     backStack: Int,
     icon: ImageVector,
     label: String? = null,
-    onReset: (() -> Unit)? = null,
+    screenState: ScreenState? = null,
 ): NavigationItem {
     return NavigationItem(
         selected = currentBackStack == backStack,
         onClick = {
             if (this.currentBackStack == backStack) {
-                resetCurrentBackStack(onReset)
+                resetCurrentBackStack(screenState)
             } else {
                 currentBackStack = backStack
             }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/MultiBackStack.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/MultiBackStack.kt
@@ -23,10 +23,14 @@ class MultiBackStack<T : NavKey>(private val backStacks: List<MutableList<T>>) {
     /**
      * Clear the current back stack and reset it back to its original state
      */
-    fun resetCurrentBackStack() {
+    fun resetCurrentBackStack(onReset: (() -> Unit)? = null) {
         backStacks[currentBackStack].apply {
-            clear()
-            add(roots[currentBackStack])
+            if (size == 1) {
+                onReset?.invoke()
+            } else {
+                clear()
+                add(roots[currentBackStack])
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/MultiBackStack.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/MultiBackStack.kt
@@ -21,12 +21,13 @@ class MultiBackStack<T : NavKey>(private val backStacks: List<MutableList<T>>) {
     private val roots = backStacks.map { it.first() }
 
     /**
-     * Clear the current back stack and reset it back to its original state
+     * Clear the current back stack and reset it back to its original state. Optionally takes a
+     * [ScreenState] that can be reset if the current back stack is already at the root.
      */
-    fun resetCurrentBackStack(onReset: (() -> Unit)? = null) {
+    fun resetCurrentBackStack(screenState: ScreenState? = null) {
         backStacks[currentBackStack].apply {
             if (size == 1) {
-                onReset?.invoke()
+                screenState?.reset()
             } else {
                 clear()
                 add(roots[currentBackStack])
@@ -58,4 +59,8 @@ class MultiBackStack<T : NavKey>(private val backStacks: List<MutableList<T>>) {
             backStack.map { entryProvider(it) }
         }
     }
+}
+
+interface ScreenState {
+    fun reset()
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/Screen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/Screen.kt
@@ -6,6 +6,8 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Surface
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.material3.TopAppBarState
+import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
@@ -27,9 +29,11 @@ import kotlin.math.roundToInt
 @Composable
 fun Screen(
     topBar: @Composable () -> Unit,
-    scrollBehavior: TopAppBarScrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(),
+    topAppBarState: TopAppBarState = rememberTopAppBarState(),
     content: @Composable () -> Unit,
 ) {
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(state = topAppBarState)
+
     Surface {
         Column(
             modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/Screen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/Screen.kt
@@ -25,9 +25,12 @@ import kotlin.math.roundToInt
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun Screen(topBar: @Composable () -> Unit, content: @Composable () -> Unit) {
+fun Screen(
+    topBar: @Composable () -> Unit,
+    scrollBehavior: TopAppBarScrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(),
+    content: @Composable () -> Unit,
+) {
     Surface {
-        val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
         Column(
             modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         ) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
@@ -15,7 +15,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
@@ -23,10 +25,13 @@ import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarState
+import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
@@ -68,6 +73,9 @@ import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.home.CategoryRow
 import io.music_assistant.client.ui.compose.nav.Screen
+import io.music_assistant.client.ui.compose.nav.ScreenState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.search_error
 import musicassistantclient.composeapp.generated.resources.search_in_library_only
@@ -82,10 +90,11 @@ fun SearchScreen(
     onNavigateToItem: (String, MediaType, String) -> Unit,
     actionsViewModel: ActionsViewModel,
     contentPadding: PaddingValues,
+    state: SearchScreenState,
     pendingSearch: GlobalSearchRequest? = null,
     onSearchConsumed: () -> Unit = {},
 ) {
-    val state by searchViewModel.state.collectAsStateWithLifecycle()
+    val searchState by searchViewModel.state.collectAsStateWithLifecycle()
     val toastState = rememberToastState()
 
     LaunchedEffect(Unit) {
@@ -106,17 +115,18 @@ fun SearchScreen(
     Screen(
         topBar = {
             SearchTopBar(
-                state.searchState,
+                searchState.searchState,
                 onQueryChanged = searchViewModel::onQueryChanged,
                 onSearchTriggered = searchViewModel::onSearchTriggered,
                 onMediaTypeToggled = searchViewModel::onMediaTypeToggled,
                 onLibraryOnlyToggled = searchViewModel::onLibraryOnlyToggled,
             )
         },
+        topAppBarState = state.topAppBarState,
     ) {
         ProvideClickActions(ClickContext.SEARCH) {
         SearchContent(
-            state = state,
+            state = searchState,
             toastState = toastState,
             onItemClick = { item ->
                 when (item) {
@@ -143,6 +153,7 @@ fun SearchScreen(
                     ?.let { ProviderIcon(modifier, it) }
             },
             contentPadding = contentPadding,
+            lazyListState = state.lazyListState,
         )
         }
     }
@@ -197,6 +208,7 @@ private fun SearchContent(
     progressActions: ProgressActions? = null,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
     contentPadding: PaddingValues,
+    lazyListState: LazyListState,
 ) {
     Box(Modifier.fillMaxSize()) {
         Column(Modifier.fillMaxSize()) {
@@ -244,6 +256,7 @@ private fun SearchContent(
                                 .fillMaxSize()
                                 .padding(16.dp)
                                 .clearFocusOnScroll(),
+                            state = lazyListState,
                             contentPadding = contentPadding,
                         ) {
                             val (title, items) = results.nonEmptyLists.first()
@@ -345,6 +358,7 @@ private fun SearchContent(
                                 modifier = Modifier
                                     .fillMaxSize()
                                     .clearFocusOnScroll(),
+                                state = lazyListState,
                                 contentPadding = contentPadding,
                             ) {
                                 preparedItems.forEach { (stringTitle, items) ->
@@ -434,6 +448,30 @@ private fun SearchFilters(
                         style = MaterialTheme.typography.bodySmall,
                     )
                 },
+            )
+        }
+    }
+}
+
+class SearchScreenState(
+    val topAppBarState: TopAppBarState,
+    val lazyListState: LazyListState,
+    val coroutineScope: CoroutineScope,
+) : ScreenState {
+    override fun reset() {
+        topAppBarState.heightOffset = 0f
+        coroutineScope.launch {
+            lazyListState.animateScrollToItem(0)
+        }
+    }
+
+    companion object {
+        @Composable
+        fun create(): SearchScreenState {
+            return SearchScreenState(
+                rememberTopAppBarState(),
+                rememberLazyListState(),
+                rememberCoroutineScope(),
             )
         }
     }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/nav/MultiBackStackTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/nav/MultiBackStackTest.kt
@@ -3,15 +3,38 @@ package io.music_assistant.client.ui.compose.nav
 import androidx.navigation3.runtime.NavKey
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class MultiBackStackTest {
     @Test
     fun `resetCurrentBackStack restores back stack to original root`() {
         val backStack = mutableListOf(TestNavKey("root"), TestNavKey("top"))
         val multiBackStack = MultiBackStack(listOf(backStack))
-        multiBackStack.resetCurrentBackStack()
+
+        val screenState = MockScreenState()
+        multiBackStack.resetCurrentBackStack(screenState)
         assertEquals(listOf(TestNavKey("root")), backStack)
+        assertFalse(screenState.isReset)
+    }
+
+    @Test
+    fun `resetCurrentBackStack resets ScreenState if the back stack is at its root`() {
+        val backStack = mutableListOf(TestNavKey("root"))
+        val multiBackStack = MultiBackStack(listOf(backStack))
+
+        val screenState = MockScreenState()
+        multiBackStack.resetCurrentBackStack(screenState)
+        assertTrue(screenState.isReset)
     }
 }
 
 private data class TestNavKey(val id: String) :  NavKey
+private class MockScreenState : ScreenState {
+    var isReset: Boolean = false
+        private set
+
+    override fun reset() {
+        isReset = true
+    }
+}


### PR DESCRIPTION
Closes #408

One difference from the issue:

> On "Search", the results and input should be cleared as well.

After playing with just resetting scroll, I was less confident we wanted this. It's quite nice to be able to quickly reset back to the top of the screen and change filters or add to the search field. We can always add the additional feature (and complexity) of clearing the search field as well later if we still feel like we want it.
