### PR TITLE
fix(logging): trim shared-log cruft and make state/sync/commands easy to follow

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Event.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Event.kt
@@ -46,28 +46,33 @@ data class Event(
     @Suppress("MemberNameEqualsClassName") // TODO: rename to `decode()` (touches several callers)
     fun event(): Event<out Any>? = try {
         when (type) {
-            EventType.PLAYER_ADDED -> myJson.decodeFromJsonElement<PlayerAddedEvent>(json)
-            EventType.PLAYER_REMOVED -> myJson.decodeFromJsonElement<PlayerRemovedEvent>(json)
-            EventType.PLAYER_UPDATED -> myJson.decodeFromJsonElement<PlayerUpdatedEvent>(json)
-            EventType.MEDIA_ITEM_UPDATED -> myJson.decodeFromJsonElement<MediaItemUpdatedEvent>(json)
             EventType.MEDIA_ITEM_ADDED -> myJson.decodeFromJsonElement<MediaItemAddedEvent>(json)
             EventType.MEDIA_ITEM_DELETED -> myJson.decodeFromJsonElement<MediaItemDeletedEvent>(json)
             EventType.MEDIA_ITEM_PLAYED -> myJson.decodeFromJsonElement<MediaItemPlayedEvent>(json)
+            EventType.MEDIA_ITEM_UPDATED -> myJson.decodeFromJsonElement<MediaItemUpdatedEvent>(json)
+            EventType.PLAYER_ADDED -> myJson.decodeFromJsonElement<PlayerAddedEvent>(json)
+            EventType.PLAYER_REMOVED -> myJson.decodeFromJsonElement<PlayerRemovedEvent>(json)
+            EventType.PLAYER_UPDATED -> myJson.decodeFromJsonElement<PlayerUpdatedEvent>(json)
             EventType.QUEUE_ADDED -> myJson.decodeFromJsonElement<QueueAddedEvent>(json)
-            EventType.QUEUE_UPDATED -> myJson.decodeFromJsonElement<QueueUpdatedEvent>(json)
-            EventType.QUEUE_TIME_UPDATED -> myJson.decodeFromJsonElement<QueueTimeUpdatedEvent>(json)
             EventType.QUEUE_ITEMS_UPDATED -> myJson.decodeFromJsonElement<QueueItemsUpdatedEvent>(json)
-            EventType.PLAYER_SETTINGS_UPDATED,
-            EventType.QUEUE_SETTINGS_UPDATED,
-            EventType.SHUTDOWN,
-            EventType.PROVIDERS_UPDATED,
-            EventType.PLAYER_CONFIG_UPDATED,
-            EventType.SYNC_TASKS_UPDATED,
-            EventType.TASKS_UPDATED,
+            EventType.QUEUE_TIME_UPDATED -> myJson.decodeFromJsonElement<QueueTimeUpdatedEvent>(json)
+            EventType.QUEUE_UPDATED -> myJson.decodeFromJsonElement<QueueUpdatedEvent>(json)
+            EventType.ALL,
             EventType.AUTH_SESSION,
             EventType.CONNECTED,
+            EventType.CORE_STATE_UPDATED,
             EventType.DISCONNECTED,
-            EventType.ALL,
+            EventType.DSP_PRESETS_UPDATED,
+            EventType.MUSIC_SYNC_COMPLETED,
+            EventType.PLAYER_CONFIG_UPDATED,
+            EventType.PLAYER_DSP_CONFIG_UPDATED,
+            EventType.PLAYER_OPTIONS_UPDATED,
+            EventType.PLAYER_SETTINGS_UPDATED,
+            EventType.PROVIDERS_UPDATED,
+            EventType.QUEUE_SETTINGS_UPDATED,
+            EventType.SHUTDOWN,
+            EventType.SYNC_TASKS_UPDATED,
+            EventType.TASKS_UPDATED,
             -> {
                 logger.d { "Ignoring unmodeled event: $type" }
                 null

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -1196,6 +1196,7 @@ class KtorServiceClient(
             ?: args?.stringArg("queue_id")
             ?: args?.stringArg("queue_item_id")
         return buildString {
+            append('#').append(messageId.substringBefore('-')).append(' ')
             append(command)
             targetId?.let { append(" target=").append(it) }
         }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/Enums.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/Enums.kt
@@ -63,6 +63,9 @@ enum class EventType {
     @SerialName("application_shutdown")
     SHUTDOWN,
 
+    @SerialName("core_state_updated")
+    CORE_STATE_UPDATED,
+
     @SerialName("media_item_added")
     MEDIA_ITEM_ADDED,
 
@@ -81,11 +84,23 @@ enum class EventType {
     @SerialName("player_config_updated")
     PLAYER_CONFIG_UPDATED,
 
+    @SerialName("player_dsp_config_updated")
+    PLAYER_DSP_CONFIG_UPDATED,
+
+    @SerialName("player_options_updated")
+    PLAYER_OPTIONS_UPDATED,
+
+    @SerialName("dsp_presets_updated")
+    DSP_PRESETS_UPDATED,
+
     @SerialName("sync_tasks_updated")
     SYNC_TASKS_UPDATED,
 
     @SerialName("tasks_updated")
     TASKS_UPDATED,
+
+    @SerialName("music_sync_completed")
+    MUSIC_SYNC_COMPLETED,
 
     @SerialName("auth_session")
     AUTH_SESSION,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/SendspinClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/SendspinClient.kt
@@ -301,7 +301,8 @@ class SendspinClient(
                 // Update playback state based on sync quality
                 if (clockSynchronizer.currentQuality == SyncQuality.GOOD) {
                     if (_state.value is SendspinState.Buffering) {
-                        logger.i { "Playback synchronized (sync quality good)" }
+                        val stats = clockSynchronizer.getStats()
+                        logger.i { "Playback synchronized (offset=${stats.offsetMs}ms, rtt=${stats.rttMs}ms)" }
                         _state.update { SendspinState.Synchronized }
                         stateReporter?.reportNow(PlayerStateValue.SYNCHRONIZED)
                     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/Sync.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/Sync.kt
@@ -4,8 +4,10 @@
 
 package io.music_assistant.client.player.sendspin
 
+import co.touchlab.kermit.Logger
 import kotlin.concurrent.Volatile
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.microseconds
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlin.time.TimeSource
@@ -17,12 +19,17 @@ enum class SyncQuality {
 }
 
 data class ClockStats(
-    val offset: Long,
-    val rtt: Long,
+    val offset: Long, // μs
+    val rtt: Long, // μs
     val quality: SyncQuality,
-)
+) {
+    val offsetMs: Long get() = offset.microseconds.inWholeMilliseconds
+    val rttMs: Long get() = rtt.microseconds.inWholeMilliseconds
+}
 
 class ClockSynchronizer {
+    private val logger = Logger.withTag("ClockSync")
+
     // Shared monotonic time base — created once so MessageDispatcher and AudioStreamManager
     // both read from the same epoch, keeping currentLocalTime in the same domain used
     // by the Kalman-smoothed offset.
@@ -42,6 +49,12 @@ class ClockSynchronizer {
 
     @Volatile
     private var quality: SyncQuality = SyncQuality.LOST
+        set(value) {
+            if (value != field) {
+                logger.i { "Clock sync quality: $field -> $value (rtt=${getStats().rttMs}ms)" }
+            }
+            field = value
+        }
     private var lastSyncTime: Instant? = null
     private var lastSyncMicros: Long = 0
     private var sampleCount: Int = 0

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/protocol/MessageDispatcher.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/protocol/MessageDispatcher.kt
@@ -74,6 +74,9 @@ class MessageDispatcher(
     private var messageListenerJob: Job? = null
     private var clockSyncJob: Job? = null
 
+    // Last state value we logged; the heartbeat sends every ~2s but we only log on change.
+    private var lastLoggedState: PlayerStateValue? = null
+
     private val _serverHelloEvent = MutableSharedFlow<ServerHelloPayload>(extraBufferCapacity = 1)
     val serverHelloEvent: Flow<ServerHelloPayload> = _serverHelloEvent.asSharedFlow()
 
@@ -98,6 +101,7 @@ class MessageDispatcher(
 
     fun start() {
         logger.i { "Starting MessageDispatcher" }
+        lastLoggedState = null
         startMessageListener()
     }
 
@@ -243,7 +247,10 @@ class MessageDispatcher(
             payload = ClientStatePayload(player = state),
         )
         val json = myJson.encodeToString(message)
-        logger.i { "Sending client/state: $json" }
+        if (state.state != lastLoggedState) {
+            logger.i { "Sending client/state: ${state.state}" }
+            lastLoggedState = state.state
+        }
         transport.sendText(json)
     }
 

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
@@ -131,7 +131,7 @@ object KmpHelper : KoinComponent {
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Throwable) {
-                log.w(e) { "loadArtworkBytes failed for $urlString" }
+                log.w { "loadArtworkBytes failed for $urlString: ${e.message}" }
                 null
             }
             completion(bytes?.toNSData())


### PR DESCRIPTION
Follow-up to the share-log work after running it for a day and checking to see what I'd logged / what still needed cleaning.

- client/state: log the single state value, and only on change — the heartbeat sends every ~2s but no longer logs unless the state actually moves (reset per connection).
- Artwork ATS failure: drop the throwable so the ~25-line Kotlin/Native stack trace is gone, but keep the NSURLErrorDomain -1022 reason for diagnosis.
- Sync: report offset/rtt on the Synchronized milestone and log clock-sync quality at the source on every GOOD/DEGRADED/LOST change, so a downgrade surfaces in the line itself. μs->ms rendering lives once on ClockStats
- Player control logs: prefix the request's message-id segment so sent/acked pair unambiguously under concurrency and per-command latency is readable.
- Events: model every server EventType (reconciled against music_assistant_models) so known events route to debug instead of the unknown-type warn; sort the decode branches alphabetically. Genuinely unknown types still warn.