### PR TITLE
Simplify Android build setup

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -57,11 +57,6 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
-      - name: Restore debug keystore
-        run: |
-          mkdir -p ~/.android
-          echo "${{ secrets.DEBUG_KEYSTORE_BASE64 }}" | base64 -d > ~/.android/debug.keystore
-
       - name: Restore release keystore
         run: |
           echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > androidApp/upload-keystore.jks

--- a/.github/workflows/debug-apk-release.yml
+++ b/.github/workflows/debug-apk-release.yml
@@ -48,7 +48,7 @@ jobs:
           keyPassword=${{ secrets.KEY_PASSWORD }}
           EOF
 
-      - name: Build self-signed release APKs (per-ABI + universal)
+      - name: Build self-signed release APK
         run: ./gradlew :androidApp:assembleSelfSignedRelease
 
       - name: Get vars
@@ -80,17 +80,9 @@ jobs:
 
             ${{ github.event.pull_request.body }}
 
-            ### Installation
-            Pick the APK that matches your device:
-            - **`*-arm64-v8a-*.apk`** — recommended for all modern Android devices (2017+).
-            - **`*-armeabi-v7a-*.apk`** — older 32-bit ARM devices only.
-            - **`*-universal-*.apk`** — fallback containing all ABIs (larger).
-
             Signed with the consistent debug keystore, so installing over a previous build does not require uninstall.
           files: |
-            androidApp/build/outputs/apk/selfSignedRelease/androidApp-arm64-v8a-selfSignedRelease.apk
-            androidApp/build/outputs/apk/selfSignedRelease/androidApp-armeabi-v7a-selfSignedRelease.apk
-            androidApp/build/outputs/apk/selfSignedRelease/androidApp-universal-selfSignedRelease.apk
+            androidApp/build/outputs/apk/selfSignedRelease/androidApp-selfSignedRelease.apk
           generate_release_notes: true
           draft: false
           prerelease: true

--- a/.github/workflows/debug-apk-release.yml
+++ b/.github/workflows/debug-apk-release.yml
@@ -38,16 +38,6 @@ jobs:
           mkdir -p ~/.android
           echo "${{ secrets.DEBUG_KEYSTORE_BASE64 }}" | base64 -d > ~/.android/debug.keystore
 
-      - name: Restore release keystore
-        run: |
-          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > androidApp/upload-keystore.jks
-          cat > androidApp/keystore.properties <<EOF
-          storeFile=upload-keystore.jks
-          storePassword=${{ secrets.KEYSTORE_PASSWORD }}
-          keyAlias=${{ secrets.KEY_ALIAS }}
-          keyPassword=${{ secrets.KEY_PASSWORD }}
-          EOF
-
       - name: Build self-signed release APK
         run: ./gradlew :androidApp:assembleSelfSignedRelease
 

--- a/.github/workflows/debug-apk-release.yml
+++ b/.github/workflows/debug-apk-release.yml
@@ -72,7 +72,7 @@ jobs:
 
             Signed with the consistent debug keystore, so installing over a previous build does not require uninstall.
           files: |
-            androidApp/build/outputs/apk/selfSignedRelease/androidApp-selfSignedRelease.apk
+            androidApp/build/outputs/apk/selfSignedRelease/androidApp-arm64-v8a-selfSignedRelease.apk
           generate_release_notes: true
           draft: false
           prerelease: true

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -53,12 +53,6 @@ android {
             )
         }
 
-        create("selfSignedDebug") {
-            isDebuggable = true
-            isMinifyEnabled = false
-            signingConfig = signingConfigs.getByName("selfSigned")
-        }
-
         create("selfSignedRelease") {
             isDebuggable = false
             isMinifyEnabled = true

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -65,6 +65,18 @@ android {
         }
     }
 
+    // ABI splits for the GitHub-distributed APK only. The Play AAB path
+    // (bundleRelease) handles per-device delivery natively, so leave it alone.
+    splits {
+        abi {
+            isEnable = gradle.startParameter.taskNames.any {
+                it.contains("SelfSignedRelease", ignoreCase = true)
+            }
+            reset()
+            include("arm64-v8a")
+        }
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -71,18 +71,6 @@ android {
         }
     }
 
-    // ABI splits for the GitHub-distributed APK only. The Play AAB path
-    // (bundleRelease) handles per-device delivery natively, so leave it alone.
-    splits {
-        abi {
-            isEnable = gradle.startParameter.taskNames.any {
-                it.contains("SelfSignedRelease", ignoreCase = true)
-            }
-            reset()
-            include("arm64-v8a", "armeabi-v7a")
-            isUniversalApk = true
-        }
-    }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
This removes the split APK build and just build a universal one. I don't think the download size difference isn't really worth the complexity here for a Github APK release - the actual Play Store App Bundle will always be much smaller. Alternatively, we could just build an `arm64-v8a` APK, but that's still extra configuration.

I've also removed some unused config/workflow steps.