### PR TITLE
Fix top bar cutting off item details content

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -80,8 +80,8 @@ import io.music_assistant.client.ui.compose.common.items.lazyListKey
 import io.music_assistant.client.ui.compose.common.moveToEnabledBoundary
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.nav.BackHandler
-import io.music_assistant.client.ui.compose.nav.Screen
 import io.music_assistant.client.ui.compose.nav.ScreenState
+import io.music_assistant.client.ui.compose.nav.TopBarLayout
 import io.music_assistant.client.utils.SessionState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -159,7 +159,7 @@ fun HomeScreen(
 
     BackHandler(enabled = editMode) { editMode = false }
 
-    Screen(
+    TopBarLayout(
         topBar = {
             LandingPageTopBar(
                 editMode = editMode,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -494,7 +494,7 @@ private fun mainNavEntryProvider(
                         ),
                     )
                 },
-                contentPadding = contentPadding,
+                screenPadding = contentPadding,
             )
         }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -110,7 +110,7 @@ fun ItemDetailsScreen(
     actionsViewModel: ActionsViewModel,
     onBack: () -> Unit,
     onNavigateToItem: (String, MediaType, String) -> Unit,
-    contentPadding: PaddingValues,
+    screenPadding: PaddingValues,
 ) {
     val state by itemDetailsViewModel.state.collectAsStateWithLifecycle()
     val toastState = rememberToastState()
@@ -123,7 +123,7 @@ fun ItemDetailsScreen(
     }
 
     ItemDetails(
-        contentPadding = contentPadding,
+        screenPadding = screenPadding,
         state = state,
         onBack = onBack,
         viewModeProvider = { type ->
@@ -156,7 +156,7 @@ fun ItemDetailsScreen(
 
 @Composable
 fun ItemDetails(
-    contentPadding: PaddingValues = PaddingValues(),
+    screenPadding: PaddingValues = PaddingValues(),
     state: ItemDetailsViewModel.State,
     onBack: () -> Unit = {},
     viewModeProvider: @Composable (MediaType) -> ViewMode = { ViewMode.LIST },
@@ -245,7 +245,7 @@ fun ItemDetails(
         onAlbumsSortChanged = onAlbumsSortChanged,
         onPlayableItemsSortChanged = onPlayableItemsSortChanged,
         onTabSelected = onTabSelected,
-        contentPadding = contentPadding,
+        screenPadding = screenPadding,
     )
 }
 
@@ -279,7 +279,7 @@ private fun ItemChildren(
     onAlbumsSortChanged: (SubItemContext, SortOption) -> Unit,
     onPlayableItemsSortChanged: (SubItemContext, SortOption) -> Unit,
     onTabSelected: (ItemDetailsTab) -> Unit,
-    contentPadding: PaddingValues,
+    screenPadding: PaddingValues,
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         when (val itemState = state.itemState) {
@@ -315,7 +315,7 @@ private fun ItemChildren(
                     onToggleViewMode = onToggleViewMode,
                     onAlbumsSortChanged = onAlbumsSortChanged,
                     onPlayableItemsSortChanged = onPlayableItemsSortChanged,
-                    contentPadding = contentPadding,
+                    screenPadding = screenPadding,
                     onTabSelected = onTabSelected,
                 )
             }
@@ -351,7 +351,7 @@ private fun ItemContent(
     onToggleViewMode: (MediaType) -> Unit,
     onAlbumsSortChanged: (SubItemContext, SortOption) -> Unit,
     onPlayableItemsSortChanged: (SubItemContext, SortOption) -> Unit,
-    contentPadding: PaddingValues,
+    screenPadding: PaddingValues,
     onTabSelected: (ItemDetailsTab) -> Unit,
 ) {
     // Tabs, the loading gate, and the selected tab are all derived in ItemDetailsViewModel.State.
@@ -373,13 +373,14 @@ private fun ItemContent(
         fetchColors = resolvedFetchColors,
     )
 
-    val heroSlot: @Composable () -> Unit = {
+    val heroSlot: @Composable (PaddingValues) -> Unit = { contentPadding ->
         ProvideClickActions(ClickContext.DETAIL) {
             ItemHeader(
                 item = item,
                 colors = colors,
                 providerIconFetcher = providerIconFetcher,
                 onPlayClick = onPlayItemClick,
+                contentPadding = contentPadding,
             )
         }
     }
@@ -395,20 +396,21 @@ private fun ItemContent(
                 navigateToItem = onNavigateClick,
             )
         },
-    ) {
+        contentUnderTopBar = true,
+    ) { contentPadding ->
         Column(modifier = Modifier.fillMaxSize()) {
             // selectedTab is null exactly while sub-lists load (for an item that has tabs), so it
             // doubles as the loading gate: show the hero + a single spinner, tabs hidden.
             val currentTab = state.selectedTab
             if (tabs.isEmpty()) {
-                heroSlot()
+                heroSlot(contentPadding)
             } else {
                 val gridState = rememberLazyGridState()
                 if (currentTab == null) {
                     Box(modifier = Modifier.weight(1f)) {
                         DetailGrid(
-                            contentPadding = contentPadding,
-                            heroSlot = heroSlot,
+                            contentPadding = screenPadding,
+                            heroSlot = { heroSlot(contentPadding) },
                             tabsSlot = null,
                             gridState = gridState,
                         ) {
@@ -447,8 +449,8 @@ private fun ItemContent(
                                 onRemoveFromPlaylist = onRemoveFromPlaylist,
                                 libraryActions = libraryActions,
                                 providerIconFetcher = providerIconFetcher,
-                                contentPadding = contentPadding,
-                                heroSlot = heroSlot,
+                                contentPadding = screenPadding,
+                                heroSlot = { heroSlot(contentPadding) },
                                 tabsSlot = tabsSlot,
                                 gridState = gridState,
                             )

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -89,7 +89,7 @@ import io.music_assistant.client.ui.compose.common.rememberAnimatedPlayerColors
 import io.music_assistant.client.ui.compose.common.rememberExtractedColorsFetcher
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
-import io.music_assistant.client.ui.compose.nav.Screen
+import io.music_assistant.client.ui.compose.nav.TopBarLayout
 import io.music_assistant.client.ui.fullBleed
 import io.music_assistant.client.ui.theme.AppTheme
 import io.music_assistant.client.utils.gridItemMinSize
@@ -385,7 +385,7 @@ private fun ItemContent(
         }
     }
 
-    Screen(
+    TopBarLayout(
         topBar = {
             ItemTopBar(
                 item = item,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -87,6 +88,7 @@ fun ItemHeader(
     ),
     providerIconFetcher: (@Composable (Modifier, String) -> Unit)? = null,
     onPlayClick: (QueueOption, Boolean) -> Unit = { _, _ -> },
+    contentPadding: PaddingValues = PaddingValues(),
 ) {
     // Art color on top, fading down to the surface the Screen actually paints, so the
     // wash dissolves seamlessly where the tabs begin. Mirrors the player gradient (inverted).
@@ -97,7 +99,7 @@ fun ItemHeader(
                 Brush.verticalGradient(
                     listOf(colors.dominant.inactive(), MaterialTheme.colorScheme.surface),
                 ),
-            ),
+            ).padding(contentPadding),
     ) {
         val image = @Composable {
             Image(
@@ -150,44 +152,34 @@ internal fun ItemTopBar(
     playlistActions: PlaylistActions?,
     navigateToItem: (AppMediaItem) -> Unit,
 ) {
-    // Flat fill equal to the header gradient's top color, so the bar reads as one
-    // continuous wash with the header below it. Back/overflow icons are NOT control-tinted
-    // — just black or white per the composited bar luminance, keeping them legible.
-    val barBg = colors.dominant.inactive()
     val onBar = lerp(MaterialTheme.colorScheme.surface, colors.dominant, INACTIVE_ALPHA)
         .contentColorByLuminance()
-    // Paint barBg directly on the wrapping Box rather than via TopAppBar's containerColor:
-    // TopAppBar runs its own animateColorAsState on the container, which would stack a second
-    // tween on top of our color animation and visibly lag the header. Transparent container =
-    // single-pass color change, in lockstep with the header gradient.
-    Box(modifier = Modifier.background(barBg)) {
-        TopAppBar(
-            title = {},
-            colors = TopAppBarDefaults.topAppBarColors(
-                containerColor = Color.Transparent,
-                scrolledContainerColor = Color.Transparent,
-                navigationIconContentColor = onBar,
-                actionIconContentColor = onBar,
-                titleContentColor = onBar,
-            ),
-            navigationIcon = {
-                IconButton(onClick = onBack) {
-                    Icon(
-                        Icons.AutoMirrored.Filled.ArrowBack,
-                        stringResource(Res.string.common_back),
-                    )
-                }
-            },
-            actions = {
-                ItemOverflow(
-                    item = item,
-                    libraryActions = libraryActions,
-                    playlistActions = playlistActions,
-                    navigateToItem = navigateToItem,
+    TopAppBar(
+        title = {},
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = Color.Transparent,
+            scrolledContainerColor = Color.Transparent,
+            navigationIconContentColor = onBar,
+            actionIconContentColor = onBar,
+            titleContentColor = onBar,
+        ),
+        navigationIcon = {
+            IconButton(onClick = onBack) {
+                Icon(
+                    Icons.AutoMirrored.Filled.ArrowBack,
+                    stringResource(Res.string.common_back),
                 )
-            },
-        )
-    }
+            }
+        },
+        actions = {
+            ItemOverflow(
+                item = item,
+                libraryActions = libraryActions,
+                playlistActions = playlistActions,
+                navigateToItem = navigateToItem,
+            )
+        },
+    )
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/BrowseScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/BrowseScreen.kt
@@ -28,7 +28,7 @@ import io.music_assistant.client.ui.compose.common.ToastHost
 import io.music_assistant.client.ui.compose.common.items.ProvideClickActions
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
-import io.music_assistant.client.ui.compose.nav.Screen
+import io.music_assistant.client.ui.compose.nav.TopBarLayout
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.common_back
 import musicassistantclient.composeapp.generated.resources.library_empty
@@ -58,7 +58,7 @@ fun BrowseScreen(
 
     val dataState by browseViewModel.state.collectAsStateWithLifecycle()
 
-    Screen(
+    TopBarLayout(
         topBar = {
             TopAppBar(
                 title = { Text(title ?: stringResource(Res.string.nav_browse)) },

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemListScreen.kt
@@ -73,7 +73,7 @@ import io.music_assistant.client.ui.compose.common.items.ProgressActions
 import io.music_assistant.client.ui.compose.common.items.ProvideClickActions
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
-import io.music_assistant.client.ui.compose.nav.Screen
+import io.music_assistant.client.ui.compose.nav.TopBarLayout
 import io.music_assistant.client.ui.compose.nav.TwoRowTopAppBar
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.cd_add_playlist
@@ -124,7 +124,7 @@ fun ItemListScreen(
 
     val state by itemListViewModel.state.collectAsStateWithLifecycle()
 
-    Screen(
+    TopBarLayout(
         topBar = {
             ItemListTopBar(
                 onBack = onBack,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryScreen.kt
@@ -39,8 +39,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import io.music_assistant.client.ui.compose.nav.Screen
 import io.music_assistant.client.ui.compose.nav.ScreenState
+import io.music_assistant.client.ui.compose.nav.TopBarLayout
 import io.music_assistant.client.utils.libraryItemMinWidth
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -68,7 +68,7 @@ fun LibraryScreen(
         )
     }
 
-    Screen(
+    TopBarLayout(
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(Res.string.nav_library)) },

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/Screen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/Screen.kt
@@ -2,8 +2,9 @@ package io.music_assistant.client.ui.compose.nav
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Surface
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.TopAppBarState
@@ -12,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.layout.layout
 import kotlin.math.roundToInt
 
@@ -30,18 +32,49 @@ import kotlin.math.roundToInt
 fun Screen(
     topBar: @Composable () -> Unit,
     topAppBarState: TopAppBarState = rememberTopAppBarState(),
-    content: @Composable () -> Unit,
+    contentUnderTopBar: Boolean = false,
+    content: @Composable (contentPadding: PaddingValues) -> Unit,
 ) {
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(state = topAppBarState)
+    SubcomposeLayout(modifier = Modifier.fillMaxSize()) { constraints ->
+        val looseConstraints = constraints.copy(minWidth = 0, minHeight = 0)
 
-    Surface {
-        Column(
-            modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-        ) {
-            Box(modifier = Modifier.collapsingTopBar(scrollBehavior)) {
-                topBar()
+        val topBarPlaceable =
+            subcompose("topBar") {
+                Box(modifier = Modifier.collapsingTopBar(scrollBehavior)) {
+                    topBar()
+                }
             }
-            content()
+                .first()
+                .measure(looseConstraints)
+
+        val contentPlaceable = subcompose("content") {
+            Column(
+                modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+            ) {
+                val contentPadding = if (contentUnderTopBar) {
+                    PaddingValues(top = topBarPlaceable.height.toDp())
+                } else {
+                    PaddingValues()
+                }
+
+                content(contentPadding)
+            }
+        }
+            .first()
+            .measure(looseConstraints)
+
+        val layoutWidth = constraints.maxWidth
+        val layoutHeight = constraints.maxHeight
+        layout(layoutWidth, layoutHeight) {
+            val contentYPosition = if (contentUnderTopBar) {
+                0
+            } else {
+                topBarPlaceable.height
+            }
+
+            contentPlaceable.place(0, contentYPosition)
+            topBarPlaceable.place(0, 0)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/TopBarLayout.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/TopBarLayout.kt
@@ -18,18 +18,20 @@ import androidx.compose.ui.layout.layout
 import kotlin.math.roundToInt
 
 /**
- * Simplified version of [androidx.compose.material3.Scaffold] that just supports a top bar. Can be
- * nested in a [androidx.compose.material3.Scaffold] with a bottom bar without introducing the
- * extra recomposition of a nesting set [androidx.compose.material3.Scaffold] composables.
+ * Layout for content with collapsing [topBar] (which doesn't need to be a
+ * [androidx.compose.material3.TopAppBar]). If [contentUnderTopBar] is true, the content will be
+ * displayed under the [topBar] and the [PaddingValues] passed to [content] can be used to keep
+ * important elements below it.
  *
  * The top bar collapses as one unit: the whole [topBar] slot translates up at the same speed as the
  * scrolling content (a 1:1 slide-off) and the content below rises to fill. This is centralized here
- * — bars passed to [topBar] must NOT take a [TopAppBarScrollBehavior] themselves, otherwise they'd
- * collapse a second time on top of this.
+ * — a [androidx.compose.material3.TopAppBar] passed to [topBar] must NOT take a
+ * [TopAppBarScrollBehavior] themselves, otherwise they'd collapse a second time on top of this.
+ *
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun Screen(
+fun TopBarLayout(
     topBar: @Composable () -> Unit,
     topAppBarState: TopAppBarState = rememberTopAppBarState(),
     contentUnderTopBar: Boolean = false,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/TwoRowTopAppBar.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/TwoRowTopAppBar.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.Modifier
  * [TopAppBar] with row below the navigation icon, title and actions. Not an official component
  * within Material Design 3.
  *
- * Collapsing is owned by the surrounding [Screen]; this composable is a plain two-row stack and
+ * Collapsing is owned by the surrounding [TopBarLayout]; this composable is a plain two-row stack and
  * does not deal with scroll behavior itself.
  */
 @Composable

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
@@ -72,8 +72,8 @@ import io.music_assistant.client.ui.compose.common.providers.ProviderIcon
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.home.CategoryRow
-import io.music_assistant.client.ui.compose.nav.Screen
 import io.music_assistant.client.ui.compose.nav.ScreenState
+import io.music_assistant.client.ui.compose.nav.TopBarLayout
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import musicassistantclient.composeapp.generated.resources.Res
@@ -112,7 +112,7 @@ fun SearchScreen(
         }
     }
 
-    Screen(
+    TopBarLayout(
         topBar = {
             SearchTopBar(
                 searchState.searchState,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
@@ -71,7 +71,7 @@ import io.music_assistant.client.ui.compose.common.OverflowMenuOption
 import io.music_assistant.client.ui.compose.common.clearFocusOnScroll
 import io.music_assistant.client.ui.compose.common.localizedTitle
 import io.music_assistant.client.ui.compose.nav.BackHandler
-import io.music_assistant.client.ui.compose.nav.Screen
+import io.music_assistant.client.ui.compose.nav.TopBarLayout
 import io.music_assistant.client.ui.theme.ThemeSetting
 import io.music_assistant.client.ui.theme.ThemeViewModel
 import io.music_assistant.client.utils.DataConnectionState
@@ -164,7 +164,7 @@ fun SettingsScreen(goHome: () -> Unit, exitApp: () -> Unit) {
         }
     }
 
-    Screen(
+    TopBarLayout(
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(Res.string.nav_settings)) },


### PR DESCRIPTION
Just a quick one after I noticed the top bar cutting things off on item details:

<img width="270" height="600" alt="Screenshot_20260617_232015" src="https://github.com/user-attachments/assets/58381a89-ebe7-47b7-9afc-4dc8d8e53864" />

Now it's like this:

<img width="270" height="600" alt="Screenshot_20260617_232109" src="https://github.com/user-attachments/assets/63f3bf01-9cd4-42a2-87f5-c19a89789175" />

I've made this an optional feature of our `TopBarLayout` (the Composable formerly known as `Screen`), so other screens are all unaffected as they use a solid rather than a transparent top bar.
