### PR TITLE
Fix startup crash on Android < 12 (NoClassDefFoundError: AudioManager.OnModeChangedListener)

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/music_assistant/client/player/MediaPlayerController.android.kt
+++ b/composeApp/src/androidMain/kotlin/io/music_assistant/client/player/MediaPlayerController.android.kt
@@ -70,19 +70,24 @@ actual class MediaPlayerController actual constructor(platformContext: PlatformC
     // deliver AUDIOFOCUS_LOSS_TRANSIENT cleanly on incoming calls. OnModeChangedListener
     // (API 31+) fires on MODE_IN_CALL / MODE_IN_COMMUNICATION transitions and needs no
     // runtime permission, so we use it as a redundant signal.
-    @RequiresApi(Build.VERSION_CODES.S)
-    private val modeChangedListener = AudioManager.OnModeChangedListener { mode ->
-        val inCall = mode == AudioManager.MODE_IN_CALL ||
-            mode == AudioManager.MODE_IN_COMMUNICATION
-        if (inCall && shouldPlayAudio) {
-            logger.i { "Telephony mode=$mode — pausing server playback (focus backup)" }
-            shouldPlayAudio = false
-            pausedByFocusLoss = true
-            audioTrack?.pause()
-            onRemoteCommand?.invoke("pause")
+    // Lazy so the API 31 OnModeChangedListener type is only referenced on API >= 31.
+    // An eager initializer runs in the constructor on every API level and throws
+    // NoClassDefFoundError on Android < 12, even though registration is SDK-guarded.
+    @get:RequiresApi(Build.VERSION_CODES.S)
+    private val modeChangedListener by lazy {
+        AudioManager.OnModeChangedListener { mode ->
+            val inCall = mode == AudioManager.MODE_IN_CALL ||
+                mode == AudioManager.MODE_IN_COMMUNICATION
+            if (inCall && shouldPlayAudio) {
+                logger.i { "Telephony mode=$mode — pausing server playback (focus backup)" }
+                shouldPlayAudio = false
+                pausedByFocusLoss = true
+                audioTrack?.pause()
+                onRemoteCommand?.invoke("pause")
+            }
+            // Resume is driven by AUDIOFOCUS_GAIN only — mode can return to NORMAL before
+            // focus is restored, and we only auto-resume what we paused.
         }
-        // Resume is driven by AUDIOFOCUS_GAIN only — mode can return to NORMAL before
-        // focus is restored, and we only auto-resume what we paused.
     }
     private var isModeChangedListenerRegistered = false
 


### PR DESCRIPTION
## Problem

The app crashes on launch on every device running **Android < 12 (API < 31)**, despite declaring `minSdk 28`:

```
java.lang.NoClassDefFoundError: Failed resolution of: Landroid/media/AudioManager$OnModeChangedListener;
  ... Caused by: java.lang.ClassNotFoundException: android.media.AudioManager$OnModeChangedListener
  at io.music_assistant.client.MainActivity.getDataSource
  at io.music_assistant.client.MainActivity.onCreate
```

`AudioManager.OnModeChangedListener` was added in **API 31**.

## Root cause

In `MediaPlayerController.android.kt`, `modeChangedListener` is an eager `val`:

```kotlin
@RequiresApi(Build.VERSION_CODES.S)
private val modeChangedListener = AudioManager.OnModeChangedListener { mode -> ... }
```

Being a non-lazy property, it's initialized in the constructor on **every** API level, and instantiating the listener resolves the API-31 type → `NoClassDefFoundError` on Android < 12. `@RequiresApi` only affects lint, not runtime. The `register`/`unregister` call sites are already correctly guarded with `SDK_INT >= S`, so the field initializer was the only unguarded reference.

## Fix

Make the listener `by lazy`, so the API-31 type is only referenced on first access — which happens exclusively inside `registerModeChangedListener()` (guarded by `SDK_INT >= S`). No behavioural change on API 31+.

```kotlin
@get:RequiresApi(Build.VERSION_CODES.S)
private val modeChangedListener by lazy { AudioManager.OnModeChangedListener { mode -> ... } }
```

## Testing

- Built `:androidApp:assembleDebug` and installed on a **Meta Portal (Android 10 / API 29)**.
- Before: instant crash on launch with the trace above.
- After: app launches normally and reaches the connection screen.
- No change on API 31+ (listener still registered/unregistered behind the existing SDK guards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)