### PR TITLE
Freeze playback position during seek/track-change until audio confirms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ iosApp/Frameworks/
 
 # Google Play developer-verification token (per-account, do not commit)
 androidApp/src/selfSignedRelease/assets/adi-registration.properties
+
+# Logs and other junk files
+tmp/

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerController.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerController.kt
@@ -75,6 +75,7 @@ class LocalPlayerController(
     private val mediaPlayerController: MediaPlayerController,
     private val sendspinClientFactory: SendspinClientFactory,
     private val playerRequestFactory: PlayerRequestFactory,
+    private val positionTracker: PlayerPositionTracker,
 ) : CoroutineScope {
     private val log = Logger.withTag("LocalPlayerCtrl")
 
@@ -82,6 +83,9 @@ class LocalPlayerController(
     override val coroutineContext: CoroutineContext = supervisorJob + Dispatchers.IO
 
     private val _localPlayerData = MutableStateFlow<PlayerData?>(null)
+
+    // Backstop that clears a stuck resume spinner if the server never confirms play.
+    private var pendingPlayTimeoutJob: Job? = null
 
     // Exposed view applies [withNowPlayingFallback] so the now-playing surfaces (AA /
     // notification / phone card, all of which read `player.currentMedia`) show the queued
@@ -154,30 +158,63 @@ class LocalPlayerController(
 
     // --- Optimistic UI updates ---
 
+    /** Backstop for a play request that never gets a positive server confirmation. */
+    private fun armPendingPlayTimeout() {
+        pendingPlayTimeoutJob?.cancel()
+        pendingPlayTimeoutJob = launch {
+            delay(PENDING_PLAY_TIMEOUT_MS)
+            _localPlayerData.update { current ->
+                if (current?.pendingPlay == true && current.player.isPlaying.not()) {
+                    log.w { "Pending play timed out without server confirmation; clearing spinner" }
+                    current.copy(pendingPlay = false)
+                } else {
+                    current
+                }
+            }
+        }
+    }
+
+    private fun cancelPendingPlayTimeout() {
+        pendingPlayTimeoutJob?.cancel()
+        pendingPlayTimeoutJob = null
+    }
+
     private fun applyOptimisticUpdate(data: PlayerData, action: PlayerAction) {
         when (action) {
             PlayerAction.TogglePlayPause -> {
                 val wasPlaying = data.player.isPlaying
-                if (wasPlaying) mediaPlayerController.pauseSink() else mediaPlayerController.resumeSink()
-                _localPlayerData.update { current ->
-                    current?.copy(
-                        player = current.player.copy(isPlaying = !wasPlaying),
-                        pendingPlay = !wasPlaying,
-                    )
+                if (wasPlaying) {
+                    cancelPendingPlayTimeout()
+                    mediaPlayerController.pauseSink()
+                    _localPlayerData.update { current ->
+                        current?.copy(
+                            player = current.player.copy(isPlaying = false),
+                            pendingPlay = false,
+                        )
+                    }
+                } else {
+                    if (!apiClient.isReadyForCommands.value) {
+                        log.i { "Suppressing pending local play while command transport is not ready" }
+                        return
+                    }
+                    mediaPlayerController.resumeSink()
+                    _localPlayerData.update { current -> current?.copy(pendingPlay = true) }
+                    armPendingPlayTimeout()
                 }
             }
 
             PlayerAction.Play -> {
-                mediaPlayerController.resumeSink()
-                _localPlayerData.update { current ->
-                    current?.copy(
-                        player = current.player.copy(isPlaying = true),
-                        pendingPlay = true,
-                    )
+                if (!apiClient.isReadyForCommands.value) {
+                    log.i { "Suppressing pending local play while command transport is not ready" }
+                    return
                 }
+                mediaPlayerController.resumeSink()
+                _localPlayerData.update { current -> current?.copy(pendingPlay = true) }
+                armPendingPlayTimeout()
             }
 
             PlayerAction.Pause -> {
+                cancelPendingPlayTimeout()
                 mediaPlayerController.pauseSink()
                 _localPlayerData.update { current ->
                     current?.copy(
@@ -205,12 +242,33 @@ class LocalPlayerController(
             }
 
             is PlayerAction.SeekTo -> {
-                // Optimistic anchor jump so the slider doesn't snap back to the pre-seek
-                // position while waiting for the server's QueueTimeUpdatedEvent to confirm.
+                // Freeze until Sendspin confirms audio, not merely until the server echoes the seek.
                 updateOptimisticQueueInfo { it.copy(elapsedTime = action.position.toDouble()) }
+                data.queueInfo?.id?.let { queueId ->
+                    positionTracker.setOptimisticSeek(
+                        queueId = queueId,
+                        elapsedSec = action.position.toDouble(),
+                        durationSec = data.queueInfo.currentItem?.track?.duration,
+                        speed = data.queueInfo.playbackSpeed,
+                    )
+                }
             }
 
-            // Next/Previous: no optimistic UI change (we don't know the next track)
+            PlayerAction.Next,
+            PlayerAction.Previous,
+            -> {
+                // Queue events for the next track can arrive before its audio; keep the
+                // boundary frozen until Sendspin confirms the new stream.
+                data.queueInfo?.id?.let { queueId ->
+                    positionTracker.setOptimisticTrackChange(
+                        queueId = queueId,
+                        elapsedSec = 0.0,
+                        durationSec = data.queueInfo.currentItem?.track?.duration,
+                        speed = data.queueInfo.playbackSpeed,
+                    )
+                }
+            }
+
             else -> {}
         }
     }
@@ -246,13 +304,11 @@ class LocalPlayerController(
     // --- Server event reconciliation ---
 
     fun onServerPlayerUpdate(player: Player) {
+        if (player.isPlaying) cancelPendingPlayTimeout()
         _localPlayerData.update { current ->
-            current?.copy(
-                player = player,
-                pendingPlay = if (player.isPlaying) false else current.pendingPlay,
-            ) ?: run {
+            if (current == null) {
                 if (!settings.sendspinEnabled.value) return@update null
-                PlayerData(
+                return@update PlayerData(
                     player = player,
                     queue = DataState.NoData(),
                     parentBind = null,
@@ -260,6 +316,19 @@ class LocalPlayerController(
                     isLocal = true,
                 )
             }
+            // Mask transient server pauses during a frozen handoff; real local pauses
+            // already flipped current.player.isPlaying before this reconciliation runs.
+            val queueId = current.queueInfo?.id
+            val maskHandoffPause = !player.isPlaying &&
+                current.player.isPlaying &&
+                queueId != null &&
+                positionTracker.isFrozenUntilConfirmed(queueId)
+            val resolvedPlayer = if (maskHandoffPause) player.copy(isPlaying = true) else player
+            current.copy(
+                player = resolvedPlayer,
+                // Do not let stale not-playing echoes clear a pending resume.
+                pendingPlay = if (player.isPlaying) false else current.pendingPlay,
+            )
         }
     }
 
@@ -513,6 +582,10 @@ class LocalPlayerController(
                         sendspinClientFactory.getOrCreatePipeline().first.onNetworkDisconnected()
                     }
 
+                    is SendspinState.Synchronized -> {
+                        localPlayerData.value?.queueInfo?.id?.let(positionTracker::confirmPlaying)
+                    }
+
                     is SendspinState.Reconnecting -> Unit
                     else -> Unit
                 }
@@ -661,5 +734,8 @@ class LocalPlayerController(
 
         /** Optimistic-bump offset; safely below any realistic server-confirmation RTT. */
         const val OPTIMISTIC_BUMP_EPSILON_S = 0.0001
+
+        /** Backstop for play requests that neither confirm nor fail. */
+        private const val PENDING_PLAY_TIMEOUT_MS = 10_000L
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -289,14 +289,6 @@ class MainDataSource(
                         value + queueInfo
                     }
                 }
-                queueInfo.elapsedTime?.let {
-                    positionTracker.setAnchor(
-                        queueId = queueInfo.id,
-                        elapsedSec = it,
-                        durationSec = queueInfo.currentItem?.track?.duration,
-                        speed = queueInfo.playbackSpeed,
-                    )
-                }
             }
         }
 
@@ -696,6 +688,7 @@ class MainDataSource(
                                 positionTracker.effectiveSec(it)
                             } ?: pd.queueInfo.elapsedTime,
                             isPlaying = pd.player.isPlaying,
+                            isPositionFrozen = positionTracker.isFrozenUntilConfirmed(pd.queueInfo.id),
                         )
                     }
                 }
@@ -710,7 +703,7 @@ class MainDataSource(
                             artworkUrl = snapshot.artworkUrl,
                             duration = snapshot.duration,
                             elapsedTime = snapshot.elapsedTime,
-                            playbackRate = if (snapshot.isPlaying) 1.0 else 0.0,
+                            playbackRate = if (snapshot.isPlaying && !snapshot.isPositionFrozen) 1.0 else 0.0,
                         )
                     }
                 }
@@ -744,6 +737,7 @@ class MainDataSource(
             val duration: Double?,
             val elapsedTime: Double?,
             val isPlaying: Boolean,
+            val isPositionFrozen: Boolean = false,
         ) : NowPlayingSnapshot
 
         companion object {
@@ -778,6 +772,7 @@ class MainDataSource(
                 if (a.artworkUrl != b.artworkUrl) return false
                 if (a.duration != b.duration) return false
                 if (a.isPlaying != b.isPlaying) return false
+                if (a.isPositionFrozen != b.isPositionFrozen) return false
                 val ae = a.elapsedTime
                 val be = b.elapsedTime
                 return when {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/PlayerPositionTracker.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/PlayerPositionTracker.kt
@@ -42,14 +42,22 @@ class PlayerPositionTracker {
          * interpolated delta to match, or the slider drifts then snaps each anchor.
          */
         val speed: Double = 1.0,
+        /** Hold the optimistic position until Sendspin confirms audio is flowing. */
+        val freezeReason: FreezeReason? = null,
     ) {
         /** Position right now: anchor + speed-scaled wall-time since anchor (capped at duration). */
         fun effectiveNow(): Double {
-            if (!isPlaying) return elapsedSec
+            if (!isPlaying || freezeReason != null) return elapsedSec
             val advanced = elapsedSec + (currentTimeMillis() - wallMs) / 1000.0 * speed
             return durationSec?.let { advanced.coerceAtMost(it) } ?: advanced
         }
     }
+
+    /**
+     * Optimistic anchors wait for [confirmPlaying], not server queue echoes: MA can
+     * report the seek target or next-track position before Sendspin has audio.
+     */
+    enum class FreezeReason { SEEK, TRACK_CHANGE }
 
     private val anchors = MutableStateFlow<Map<String, Anchor>>(emptyMap())
 
@@ -67,6 +75,8 @@ class PlayerPositionTracker {
     ) {
         anchors.update { existing ->
             val current = existing[queueId]
+            // Server anchors are noisy during handoff; Sendspin sync is the confirmation.
+            if (current?.freezeReason != null) return@update existing
             existing + (
                 queueId to Anchor(
                     elapsedSec = elapsedSec,
@@ -74,6 +84,7 @@ class PlayerPositionTracker {
                     isPlaying = isPlaying ?: current?.isPlaying ?: false,
                     durationSec = durationSec ?: current?.durationSec,
                     speed = speed ?: current?.speed ?: 1.0,
+                    freezeReason = null,
                 )
             )
         }
@@ -99,8 +110,72 @@ class PlayerPositionTracker {
         }
     }
 
+    /** User-dropped seek anchor; server echoes do not release the freeze. */
+    fun setOptimisticSeek(
+        queueId: String,
+        elapsedSec: Double,
+        durationSec: Double? = null,
+        speed: Double? = null,
+    ) {
+        anchors.update { existing ->
+            val current = existing[queueId]
+            existing + (
+                queueId to Anchor(
+                    elapsedSec = elapsedSec,
+                    wallMs = currentTimeMillis(),
+                    isPlaying = current?.isPlaying ?: false,
+                    durationSec = durationSec ?: current?.durationSec,
+                    speed = speed ?: current?.speed ?: 1.0,
+                    freezeReason = FreezeReason.SEEK,
+                )
+            )
+        }
+    }
+
+    /** Next/Previous boundary; wait for new-stream sync before ticking again. */
+    fun setOptimisticTrackChange(
+        queueId: String,
+        elapsedSec: Double,
+        durationSec: Double? = null,
+        speed: Double? = null,
+    ) {
+        anchors.update { existing ->
+            val current = existing[queueId]
+            existing + (
+                queueId to Anchor(
+                    elapsedSec = elapsedSec,
+                    wallMs = currentTimeMillis(),
+                    isPlaying = current?.isPlaying ?: false,
+                    durationSec = durationSec ?: current?.durationSec,
+                    speed = speed ?: current?.speed ?: 1.0,
+                    freezeReason = FreezeReason.TRACK_CHANGE,
+                )
+            )
+        }
+    }
+
+    /** Release an optimistic freeze once Sendspin reports synchronized audio. */
+    fun confirmPlaying(queueId: String) {
+        anchors.update { existing ->
+            val current = existing[queueId] ?: return@update existing
+            if (current.freezeReason == null) return@update existing
+            existing + (
+                queueId to current.copy(
+                    elapsedSec = current.effectiveNow(),
+                    wallMs = currentTimeMillis(),
+                    isPlaying = true,
+                    freezeReason = null,
+                )
+            )
+        }
+    }
+
     /** O(1) read of latest interpolated position. */
     fun effectiveSec(queueId: String): Double? = anchors.value[queueId]?.effectiveNow()
+
+    /** True while an optimistic seek or track-change is waiting for confirmation. */
+    fun isFrozenUntilConfirmed(queueId: String): Boolean =
+        anchors.value[queueId]?.freezeReason != null
 
     /**
      * Cold flow of interpolated position. Emits immediately on subscription,
@@ -123,7 +198,7 @@ class PlayerPositionTracker {
                 flow {
                     while (currentCoroutineContext().isActive) {
                         emit(anchor.effectiveNow())
-                        if (!anchor.isPlaying) break
+                        if (!anchor.isPlaying || anchor.freezeReason != null) break
                         delay(TICK_MS)
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerControls.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerControls.kt
@@ -111,11 +111,11 @@ fun PlayerControls(
             ) { playerAction(playerData, PlayerAction.Previous) }
         }
 
-        if (playerData.pendingPlay && player.isPlaying) {
+        if (playerData.pendingPlay && !player.isPlaying) {
             IconButton(
                 modifier = Modifier
                     .size(mainButtonSize),
-                onClick = { playerAction(playerData, PlayerAction.TogglePlayPause) },
+                onClick = { playerAction(playerData, PlayerAction.Pause) },
                 enabled = playerEnabled && buttonsEnabled,
             ) {
                 CircularProgressIndicator(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -78,6 +79,8 @@ import musicassistantclient.composeapp.generated.resources.players_nothing
 import musicassistantclient.composeapp.generated.resources.queue_cannot_play
 import org.jetbrains.compose.resources.stringResource
 import kotlin.time.DurationUnit
+
+private const val SEEK_STICK_EPSILON_SECONDS = 0.5f
 
 @Composable
 fun CompactPlayerItem(
@@ -332,11 +335,18 @@ fun FullPlayerItem(
             ?: item.queueInfo?.elapsedTime?.toFloat()
             ?: 0f
 
-        // Track user drag state separately
+        // Latch the released seek until the tracker publishes its frozen anchor.
         var userDragPosition by remember { mutableStateOf<Float?>(null) }
+        var releasedSeekPosition by remember { mutableStateOf<Float?>(null) }
 
-        // Use user drag position if dragging, otherwise use calculated position
-        val sliderPosition = userDragPosition ?: displayPosition
+        LaunchedEffect(displayPosition, releasedSeekPosition) {
+            val released = releasedSeekPosition ?: return@LaunchedEffect
+            if (kotlin.math.abs(displayPosition - released) < SEEK_STICK_EPSILON_SECONDS) {
+                releasedSeekPosition = null
+            }
+        }
+
+        val sliderPosition = userDragPosition ?: releasedSeekPosition ?: displayPosition
 
         val progressSliderColors = SliderDefaults.colors().copy(
             thumbColor = controlTint,
@@ -355,7 +365,10 @@ fun FullPlayerItem(
                 },
                 onValueChangeFinished = {
                     userDragPosition?.let { seekPos ->
-                        playerAction(item, PlayerAction.SeekTo(seekPos.toLong()))
+                        // Match the server/tracker whole-second seek target to avoid thumb snapback.
+                        val seekSeconds = seekPos.toLong()
+                        releasedSeekPosition = seekSeconds.toFloat()
+                        playerAction(item, PlayerAction.SeekTo(seekSeconds))
                         userDragPosition = null  // Clear drag state
                     }
                 },

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/NowPlayingSnapshotDedupTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/NowPlayingSnapshotDedupTest.kt
@@ -85,6 +85,15 @@ class NowPlayingSnapshotDedupTest {
     }
 
     @Test
+    fun frozenStateChangeEmits() {
+        // Frozen optimistic seeks use the same elapsed anchor but a different
+        // playback rate for iOS Now Playing, so the dict must be rewritten.
+        assertFalse(
+            NowPlayingSnapshot.sameDictWriteWouldBe(sample, sample.copy(isPositionFrozen = true)),
+        )
+    }
+
+    @Test
     fun subSecondElapsedDriftDedupes() {
         // Position-tracker tick (500 ms) plus dispatch jitter — well under the
         // anchor epsilon. iOS's own interpolator covers this.

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/PlayerPositionTrackerTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/PlayerPositionTrackerTest.kt
@@ -1,0 +1,150 @@
+package io.music_assistant.client.data
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PlayerPositionTrackerTest {
+    @Test
+    fun optimisticSeekIgnoresStaleServerAnchorFarFromSeekTarget() {
+        val tracker = PlayerPositionTracker()
+        val queueId = "queue"
+
+        tracker.setAnchor(
+            queueId = queueId,
+            elapsedSec = 65.0,
+            isPlaying = true,
+            durationSec = 218.0,
+            speed = 1.0,
+        )
+        tracker.setOptimisticSeek(
+            queueId = queueId,
+            elapsedSec = 149.0,
+            durationSec = 218.0,
+            speed = 1.0,
+        )
+        assertTrue(tracker.isFrozenUntilConfirmed(queueId))
+
+        tracker.setAnchor(
+            queueId = queueId,
+            elapsedSec = 67.9,
+            durationSec = 218.0,
+            speed = 1.0,
+        )
+
+        assertEquals(149.0, tracker.effectiveSec(queueId))
+        assertTrue(tracker.isFrozenUntilConfirmed(queueId))
+    }
+
+    @Test
+    fun optimisticSeekIgnoresServerAnchorsUntilAudioConfirm() {
+        // Server can echo the seek target before audio resumes; that must not unfreeze.
+        val tracker = PlayerPositionTracker()
+        val queueId = "queue"
+
+        tracker.setAnchor(
+            queueId = queueId,
+            elapsedSec = 65.0,
+            isPlaying = true,
+            durationSec = 218.0,
+            speed = 1.0,
+        )
+        tracker.setOptimisticSeek(
+            queueId = queueId,
+            elapsedSec = 149.0,
+            durationSec = 218.0,
+            speed = 1.0,
+        )
+        assertTrue(tracker.isFrozenUntilConfirmed(queueId))
+
+        // Echo at the target still arrives too early.
+        tracker.setAnchor(queueId = queueId, elapsedSec = 149.5)
+        assertEquals(149.0, tracker.effectiveSec(queueId))
+        assertTrue(tracker.isFrozenUntilConfirmed(queueId))
+
+        // Audio sync is the release signal.
+        tracker.confirmPlaying(queueId)
+        assertTrue(!tracker.isFrozenUntilConfirmed(queueId))
+        val pos = tracker.effectiveSec(queueId) ?: error("missing position")
+        assertTrue(pos >= 149.0)
+    }
+
+    @Test
+    fun trackChangeFreezeIgnoresServerAnchorAtBoundaryWhileOldAudioPlays() {
+        // Next-track queue metadata can arrive while old audio is still draining.
+        val tracker = PlayerPositionTracker()
+        val queueId = "queue"
+
+        tracker.setAnchor(queueId = queueId, elapsedSec = 53.0, isPlaying = true)
+        tracker.setOptimisticTrackChange(queueId = queueId, elapsedSec = 0.0)
+        assertTrue(tracker.isFrozenUntilConfirmed(queueId))
+        assertEquals(0.0, tracker.effectiveSec(queueId))
+
+        // Boundary echoes are not audio confirmation.
+        tracker.setAnchor(queueId = queueId, elapsedSec = 0.5)
+
+        assertEquals(0.0, tracker.effectiveSec(queueId))
+        assertTrue(tracker.isFrozenUntilConfirmed(queueId))
+
+        // Later pre-audio echoes stay frozen too.
+        tracker.setAnchor(queueId = queueId, elapsedSec = 1.2)
+
+        assertEquals(0.0, tracker.effectiveSec(queueId))
+        assertTrue(tracker.isFrozenUntilConfirmed(queueId))
+    }
+
+    @Test
+    fun trackChangeFreezeUnfreezesOnAudioConfirm() {
+        // New-stream sync releases the boundary freeze.
+        val tracker = PlayerPositionTracker()
+        val queueId = "queue"
+
+        tracker.setAnchor(queueId = queueId, elapsedSec = 53.0, isPlaying = true)
+        tracker.setOptimisticTrackChange(queueId = queueId, elapsedSec = 0.0)
+        assertTrue(tracker.isFrozenUntilConfirmed(queueId))
+
+        tracker.confirmPlaying(queueId)
+
+        assertTrue(!tracker.isFrozenUntilConfirmed(queueId))
+    }
+
+    @Test
+    fun trackChangeFreezeIgnoresAllServerAnchorsUntilAudioConfirm() {
+        // Neither old-track nor pre-audio new-track positions are confirmation.
+        val tracker = PlayerPositionTracker()
+        val queueId = "queue"
+
+        tracker.setAnchor(queueId = queueId, elapsedSec = 53.0, isPlaying = true)
+        tracker.setOptimisticTrackChange(queueId = queueId, elapsedSec = 0.0)
+        assertTrue(tracker.isFrozenUntilConfirmed(queueId))
+
+        // Late old-track position is still not confirmation.
+        tracker.setAnchor(queueId = queueId, elapsedSec = 53.0)
+        assertEquals(0.0, tracker.effectiveSec(queueId))
+        assertTrue(tracker.isFrozenUntilConfirmed(queueId))
+
+        // Pre-audio new-track position is also not confirmation.
+        tracker.setAnchor(queueId = queueId, elapsedSec = 2.0, isPlaying = true)
+        assertEquals(0.0, tracker.effectiveSec(queueId))
+        assertTrue(tracker.isFrozenUntilConfirmed(queueId))
+
+        // New-stream audio sync releases the freeze.
+        tracker.confirmPlaying(queueId)
+        assertTrue(!tracker.isFrozenUntilConfirmed(queueId))
+    }
+
+    @Test
+    fun seekFreezeStillUnfreezesOnAudioConfirm() {
+        // Seeks use the same Sendspin confirmation path as track changes.
+        val tracker = PlayerPositionTracker()
+        val queueId = "queue"
+
+        tracker.setAnchor(queueId = queueId, elapsedSec = 65.0, isPlaying = true)
+        tracker.setOptimisticSeek(queueId = queueId, elapsedSec = 149.0)
+        assertTrue(tracker.isFrozenUntilConfirmed(queueId))
+
+        tracker.confirmPlaying(queueId)
+
+        assertTrue(!tracker.isFrozenUntilConfirmed(queueId))
+    }
+}

--- a/iosApp/NowPlayingManager.swift
+++ b/iosApp/NowPlayingManager.swift
@@ -298,6 +298,17 @@ class NowPlayingManager {
 
     // MARK: - Private
 
+    private func applyRemoteSeekPosition(_ position: TimeInterval) {
+        DispatchQueue.main.async {
+            var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
+            let duration = (info[MPMediaItemPropertyPlaybackDuration] as? Double) ?? .greatestFiniteMagnitude
+            info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = max(0, min(position, duration))
+            // Stop iOS interpolation immediately; KMP will publish the confirmed rate.
+            info[MPNowPlayingInfoPropertyPlaybackRate] = 0.0
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+        }
+    }
+
     private func setupRemoteCommands() {
         let commandCenter = MPRemoteCommandCenter.shared()
         logDebug("Setting up remote commands (once)")
@@ -321,7 +332,12 @@ class NowPlayingManager {
         commandCenter.changePlaybackPositionCommand.isEnabled = true
         commandCenter.changePlaybackPositionCommand.addTarget { [weak self] event in
             guard let positionEvent = event as? MPChangePlaybackPositionCommandEvent else { return .commandFailed }
-            self?.commandHandler?("seek:\(positionEvent.positionTime)")
+            // Floor to the same whole-second target KMP freezes at; otherwise the
+            // lock-screen thumb can correct backward when the KMP snapshot lands.
+            let seekPosition = positionEvent.positionTime.rounded(.down)
+            self?.logInfo("Remote seek command received: \(seekPosition)")
+            self?.applyRemoteSeekPosition(seekPosition)
+            self?.commandHandler?("seek:\(seekPosition)")
             return .success
         }
 


### PR DESCRIPTION
This is the revamp of our progress bar and play/pause button for the local player that I mentioned in the Discord. I've been testing it for a couple of days and it seems to be *much* better. It has (virtually) eliminated the 'snap back' jumps when using the slider to jump around in a song, and the 'jittery' / bouncing when pausing or at the start of a track after track skip. This is *purely* for the local player, as I could use "do we actually have audio flowing to us right this second?" as a pretty good signal for whether we should start advancing the timer or not (for instance). And of course, for remote players we don't get that. That'll be a separate PR.

Commit message:

Local seeks and Next/Previous now freeze the progress bar at the target/boundary and resume only when the Sendspin stream actually syncs (confirmPlaying); server position updates are ignored while frozen, so the bar no longer ticks off the old stream or snaps on pre-audio queue updates. Also mask the play/pause button through the handoff (no pause->play->pause flicker), floor lock-screen seeks to whole seconds, and add a pendingPlay timeout backstop.