### PR TITLE
Fixup some test names that do not compile on iOS

### DIFF
--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/BrowseFolderMappingTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/BrowseFolderMappingTest.kt
@@ -59,7 +59,7 @@ class BrowseFolderMappingTest {
     }
 
     @Test
-    fun `the parent entry is flagged, real folders are not`() {
+    fun `the parent entry is flagged but real folders are not`() {
         assertTrue(folder(name = "..", path = "root").isParentLink)
         assertFalse(folder(name = "", path = "tidal--6rdvd8iR://tracks").isParentLink)
         assertFalse(folder(name = "Tidal", path = "tidal--6rdvd8iR://").isParentLink)

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/library/LibraryCategoryConfigTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/library/LibraryCategoryConfigTest.kt
@@ -17,7 +17,7 @@ class LibraryCategoryConfigTest {
     }
 
     @Test
-    fun `category missing from a stored config is appended at the end, enabled`() {
+    fun `category missing from a stored config is appended at the end and enabled`() {
         // A pre-BROWSE config: every category except the newly-added one, in a custom order.
         val stored = listOf(
             pref(LibraryCategory.ALBUMS, enabled = true),


### PR DESCRIPTION
Test names can't have commas in them, according to the iOS + kotlin build pipeline, so these break local tests.