### PR TITLE
Add shortcuts to Home screen

### DIFF
--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/HomeTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/HomeTest.kt
@@ -27,7 +27,7 @@ class HomeTest {
     val serviceClient: FakeServiceClient by inject(ServiceClient::class.java)
 
     @Test
-    fun `can refresh home`() {
+    fun `can refresh home recommendations`() {
         val album1 = ServerMediaItemFixtures.album()
         serviceClient.addToLibrary(album1)
 
@@ -39,5 +39,18 @@ class HomeTest {
 
         homePage.refresh()
             .assertMediaDisplayed(album2.name)
+    }
+
+    @Test
+    fun `can refresh home shortcuts`() {
+        val album = ServerMediaItemFixtures.album()
+        serviceClient.addToLibrary(album)
+
+        val homePage = launchLoggedInApp(composeTestRule, serviceClient)
+
+        serviceClient.addShortcut(album)
+
+        homePage.refresh()
+            .assertShortcutDisplayed(album)
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/HomeTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/HomeTest.kt
@@ -8,6 +8,7 @@ import io.music_assistant.client.support.Qualifiers
 import io.music_assistant.client.support.ServerMediaItemFixtures
 import io.music_assistant.client.support.launchLoggedInApp
 import io.music_assistant.client.support.pages.assertMediaDisplayed
+import io.music_assistant.client.support.pages.assertMediaNotDisplayed
 import io.music_assistant.client.support.rules.createTestRuleChain
 import org.junit.Rule
 import org.junit.Test
@@ -52,5 +53,21 @@ class HomeTest {
 
         homePage.refresh()
             .assertShortcutDisplayed(album)
+    }
+
+    @Test
+    fun `shows error if data can't be loaded and can recover with refresh`() {
+        val album = ServerMediaItemFixtures.album()
+        serviceClient.addToLibrary(album)
+        val homePage = launchLoggedInApp(composeTestRule, serviceClient)
+
+        serviceClient.setRequestErrors(true)
+        homePage.refresh()
+            .assertErrorLoadingData()
+            .assertMediaNotDisplayed(album.name)
+
+        serviceClient.setRequestErrors(false)
+        homePage.refresh()
+            .assertMediaDisplayed(album.name)
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ShortcutsTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ShortcutsTest.kt
@@ -1,0 +1,38 @@
+package io.music_assistant.client.feature
+
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.music_assistant.client.api.ServiceClient
+import io.music_assistant.client.support.FakeServiceClient
+import io.music_assistant.client.support.Qualifiers
+import io.music_assistant.client.support.ServerMediaItemFixtures
+import io.music_assistant.client.support.launchLoggedInApp
+import io.music_assistant.client.support.rules.createTestRuleChain
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.java.KoinJavaComponent.inject
+import org.robolectric.annotation.Config
+import kotlin.getValue
+
+@RunWith(AndroidJUnit4::class)
+@Config(qualifiers = Qualifiers.MEDIUM_PHONE)
+class ShortcutsTest {
+    @get:Rule
+    val testRuleChain = createTestRuleChain()
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    val serviceClient: FakeServiceClient by inject(ServiceClient::class.java)
+
+    @Test
+    fun `can view shortcuts`() {
+        val album = ServerMediaItemFixtures.album()
+        serviceClient.addToLibrary(album)
+        serviceClient.addShortcut(album)
+
+        launchLoggedInApp(composeTestRule, serviceClient)
+            .assertShortcutDisplayed(album)
+    }
+}

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ShortcutsTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ShortcutsTest.kt
@@ -1,6 +1,8 @@
 package io.music_assistant.client.feature
 
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.music_assistant.client.api.ServiceClient
 import io.music_assistant.client.support.FakeServiceClient
@@ -8,10 +10,13 @@ import io.music_assistant.client.support.FakeServiceClient.LegacyVersion
 import io.music_assistant.client.support.Qualifiers
 import io.music_assistant.client.support.ServerMediaItemFixtures
 import io.music_assistant.client.support.ServerPlayerFixtures
+import io.music_assistant.client.support.get
 import io.music_assistant.client.support.launchLoggedInApp
 import io.music_assistant.client.support.pages.assertMediaDisplayed
 import io.music_assistant.client.support.pages.assertPlayer
 import io.music_assistant.client.support.rules.createTestRuleChain
+import musicassistantclient.composeapp.generated.resources.Res
+import musicassistantclient.composeapp.generated.resources.home_shortcuts
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -62,5 +67,11 @@ class ShortcutsTest {
 
         launchLoggedInApp(composeTestRule, serviceClient)
             .assertMediaDisplayed(album.name)
+    }
+
+    @Test
+    fun `does not show shortcuts if there aren't any`() {
+        launchLoggedInApp(composeTestRule, serviceClient)
+        composeTestRule.onNodeWithText(Res.string.home_shortcuts.get()).assertIsNotDisplayed()
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ShortcutsTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ShortcutsTest.kt
@@ -27,12 +27,12 @@ class ShortcutsTest {
     val serviceClient: FakeServiceClient by inject(ServiceClient::class.java)
 
     @Test
-    fun `can view shortcuts`() {
+    fun `can navigate to shortcut items`() {
         val album = ServerMediaItemFixtures.album()
         serviceClient.addToLibrary(album)
         serviceClient.addShortcut(album)
 
         launchLoggedInApp(composeTestRule, serviceClient)
-            .assertShortcutDisplayed(album)
+            .clickOnShortcut(album)
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ShortcutsTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ShortcutsTest.kt
@@ -6,7 +6,9 @@ import io.music_assistant.client.api.ServiceClient
 import io.music_assistant.client.support.FakeServiceClient
 import io.music_assistant.client.support.Qualifiers
 import io.music_assistant.client.support.ServerMediaItemFixtures
+import io.music_assistant.client.support.ServerPlayerFixtures
 import io.music_assistant.client.support.launchLoggedInApp
+import io.music_assistant.client.support.pages.assertPlayer
 import io.music_assistant.client.support.rules.createTestRuleChain
 import org.junit.Rule
 import org.junit.Test
@@ -34,5 +36,19 @@ class ShortcutsTest {
 
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickOnShortcut(album)
+    }
+
+    @Test
+    fun `can play shortcut items`() {
+        val track = ServerMediaItemFixtures.track()
+        serviceClient.addToLibrary(track)
+        serviceClient.addShortcut(track)
+
+        val player = ServerPlayerFixtures.player()
+        serviceClient.addPlayers(player)
+
+        launchLoggedInApp(composeTestRule, serviceClient)
+            .playShortcut(track)
+            .assertPlayer(player.displayName, playing = true, item = track.name)
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ShortcutsTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ShortcutsTest.kt
@@ -4,10 +4,12 @@ import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.music_assistant.client.api.ServiceClient
 import io.music_assistant.client.support.FakeServiceClient
+import io.music_assistant.client.support.FakeServiceClient.LegacyVersion
 import io.music_assistant.client.support.Qualifiers
 import io.music_assistant.client.support.ServerMediaItemFixtures
 import io.music_assistant.client.support.ServerPlayerFixtures
 import io.music_assistant.client.support.launchLoggedInApp
+import io.music_assistant.client.support.pages.assertMediaDisplayed
 import io.music_assistant.client.support.pages.assertPlayer
 import io.music_assistant.client.support.rules.createTestRuleChain
 import org.junit.Rule
@@ -15,7 +17,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.koin.java.KoinJavaComponent.inject
 import org.robolectric.annotation.Config
-import kotlin.getValue
 
 @RunWith(AndroidJUnit4::class)
 @Config(qualifiers = Qualifiers.MEDIUM_PHONE)
@@ -50,5 +51,16 @@ class ShortcutsTest {
         launchLoggedInApp(composeTestRule, serviceClient)
             .playShortcut(track)
             .assertPlayer(player.displayName, playing = true, item = track.name)
+    }
+
+    @Test
+    fun `still loads home screen if shortcuts not supported by server`() {
+        serviceClient.setLegacyVersion(LegacyVersion.V2_8)
+
+        val album = ServerMediaItemFixtures.album()
+        serviceClient.addToLibrary(album)
+
+        launchLoggedInApp(composeTestRule, serviceClient)
+            .assertMediaDisplayed(album.name)
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -45,6 +45,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.encodeToJsonElement
 
 class FakeServiceClient(private val settingsRepository: SettingsRepository) : ServiceClient {
+    private var legacyVersion: LegacyVersion? = null
     private var requestErrors: Boolean = false
 
     private val uniqueIdGenerator = UniqueIdGenerator()
@@ -122,12 +123,21 @@ class FakeServiceClient(private val settingsRepository: SettingsRepository) : Se
             }
 
             APICommands.AUTH_ME -> {
-                Result.success(
-                    answer(
-                        request = request,
-                        result = ServerUser(preferences = ServerUserPreferences(shortcuts)),
-                    ),
-                )
+                if (legacyVersion == LegacyVersion.V2_8) {
+                    Result.success(
+                        answer(
+                            request = request,
+                            result = emptyMap<String, String>(),
+                        ),
+                    )
+                } else {
+                    Result.success(
+                        answer(
+                            request = request,
+                            result = ServerUser(preferences = ServerUserPreferences(shortcuts)),
+                        ),
+                    )
+                }
             }
 
             APICommands.AUTH_PROVIDERS -> {
@@ -667,6 +677,14 @@ class FakeServiceClient(private val settingsRepository: SettingsRepository) : Se
 
     fun setRequestErrors(reachable: Boolean) {
         this.requestErrors = reachable
+    }
+
+    fun setLegacyVersion(version: LegacyVersion) {
+        this.legacyVersion = version
+    }
+
+    enum class LegacyVersion {
+        V2_8,
     }
 }
 

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -139,6 +139,11 @@ class FakeServiceClient(private val settingsRepository: SettingsRepository) : Se
                 )
             }
 
+            APICommands.MUSIC_ITEM_BY_URI -> {
+                val item = items.find { it.uri == request.getArg("uri") }!!
+                Result.success(answer(request = request, result = item))
+            }
+
             APICommands.MUSIC_RECOMMENDATIONS -> {
                 Result.success(
                     answer(

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -45,6 +45,8 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.encodeToJsonElement
 
 class FakeServiceClient(private val settingsRepository: SettingsRepository) : ServiceClient {
+    private var requestErrors: Boolean = false
+
     private val uniqueIdGenerator = UniqueIdGenerator()
 
     private val players = mutableListOf<ServerPlayer>()
@@ -105,6 +107,10 @@ class FakeServiceClient(private val settingsRepository: SettingsRepository) : Se
     override val isReadyForCommands: StateFlow<Boolean> = _isReadyForCommands
 
     override suspend fun sendRequest(request: Request): Result<Answer> {
+        if (requestErrors) {
+            return Result.failure(Exception())
+        }
+
         return when (request.command) {
             APICommands.PROVIDERS_MANIFESTS -> {
                 Result.success(
@@ -657,6 +663,10 @@ class FakeServiceClient(private val settingsRepository: SettingsRepository) : Se
 
     fun setPlaylist(playlist: ServerMediaItem, vararg tracks: ServerMediaItem) {
         playlistItems[playlist.itemId] = tracks.map { it.itemId }
+    }
+
+    fun setRequestErrors(reachable: Boolean) {
+        this.requestErrors = reachable
     }
 }
 

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -17,6 +17,8 @@ import io.music_assistant.client.data.model.server.ServerPlayer
 import io.music_assistant.client.data.model.server.ServerPlayerMedia
 import io.music_assistant.client.data.model.server.ServerQueue
 import io.music_assistant.client.data.model.server.ServerQueueItem
+import io.music_assistant.client.data.model.server.ServerUser
+import io.music_assistant.client.data.model.server.ServerUserPreferences
 import io.music_assistant.client.data.model.server.User
 import io.music_assistant.client.data.model.server.events.Event
 import io.music_assistant.client.data.model.server.events.PlayerUpdatedEvent
@@ -90,6 +92,7 @@ class FakeServiceClient(private val settingsRepository: SettingsRepository) : Se
         }
 
     private val playlistItems = mutableMapOf<String, List<String>>()
+    private val shortcuts = mutableListOf<String>()
 
     val username = "user"
     val password = "password"
@@ -108,6 +111,15 @@ class FakeServiceClient(private val settingsRepository: SettingsRepository) : Se
                     answer(
                         request = request,
                         result = emptyList<ProviderManifest>(),
+                    ),
+                )
+            }
+
+            APICommands.AUTH_ME -> {
+                Result.success(
+                    answer(
+                        request = request,
+                        result = ServerUser(preferences = ServerUserPreferences(shortcuts)),
                     ),
                 )
             }
@@ -311,9 +323,11 @@ class FakeServiceClient(private val settingsRepository: SettingsRepository) : Se
 
                             albumTracks.drop(startIndex)
                         }
+
                         MediaType.TRACK -> listOf(item)
                         MediaType.PLAYLIST -> {
-                            val playlistTracks = tracks.filter { playlistItems[item.itemId]!!.contains(it.itemId) }
+                            val playlistTracks =
+                                tracks.filter { playlistItems[item.itemId]!!.contains(it.itemId) }
                             val startIndex = if (startItemId != null) {
                                 playlistTracks.indexOfFirst { it.itemId == startItemId }
                             } else {
@@ -322,6 +336,7 @@ class FakeServiceClient(private val settingsRepository: SettingsRepository) : Se
 
                             playlistTracks.drop(startIndex)
                         }
+
                         else -> TODO()
                     }
                 } ?: emptyList()
@@ -504,7 +519,12 @@ class FakeServiceClient(private val settingsRepository: SettingsRepository) : Se
     private val _serverBaseUrl = MutableStateFlow<String?>(null)
     override val serverBaseUrl: StateFlow<String?> = _serverBaseUrl
 
-    override fun resolveImageUrl(path: String, provider: String, isRemotelyAccessible: Boolean, proxyId: String?): String? = null
+    override fun resolveImageUrl(
+        path: String,
+        provider: String,
+        isRemotelyAccessible: Boolean,
+        proxyId: String?,
+    ): String? = null
 
     override fun rebaseServerImageUrl(rawUrl: String): String? = null
 
@@ -584,6 +604,10 @@ class FakeServiceClient(private val settingsRepository: SettingsRepository) : Se
         }
 
         this.players.addAll(players)
+    }
+
+    fun addShortcut(item: ServerMediaItem) {
+        shortcuts.add(item.uri!!)
     }
 
     fun getState(playerId: String): PlayerState? {

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/HomePage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/HomePage.kt
@@ -49,4 +49,9 @@ class HomePage(composeTestRule: ComposeTestRule) : ComposePage(composeTestRule) 
         playMedia(item, withinTag = HomeScreenSemantics.SHORTCUTS_ROW_TAG)
         return this
     }
+
+    fun assertShortcutDisplayed(item: ServerMediaItem): HomePage {
+        assertMediaDisplayed(item.name, withinTag = HomeScreenSemantics.SHORTCUTS_ROW_TAG)
+        return this
+    }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/HomePage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/HomePage.kt
@@ -39,9 +39,11 @@ class HomePage(composeTestRule: ComposeTestRule) : ComposePage(composeTestRule) 
         return this
     }
 
-    fun assertShortcutDisplayed(item: ServerMediaItem) {
+    fun clickOnShortcut(item: ServerMediaItem): ItemPage {
         composeTestRule
             .onNode(withinTag(HomeScreenSemantics.SHORTCUTS_ROW_TAG).and(hasText(item.name)))
-            .assertIsDisplayed()
+            .performClick()
+
+        return ItemPage(item, Res.string.nav_home.get(), composeTestRule)
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/HomePage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/HomePage.kt
@@ -9,6 +9,7 @@ import io.music_assistant.client.data.model.server.ServerMediaItem
 import io.music_assistant.client.support.get
 import io.music_assistant.client.ui.compose.home.HomeScreenSemantics
 import musicassistantclient.composeapp.generated.resources.Res
+import musicassistantclient.composeapp.generated.resources.library_error
 import musicassistantclient.composeapp.generated.resources.nav_home
 import musicassistantclient.composeapp.generated.resources.nav_library
 import musicassistantclient.composeapp.generated.resources.nav_search
@@ -52,6 +53,11 @@ class HomePage(composeTestRule: ComposeTestRule) : ComposePage(composeTestRule) 
 
     fun assertShortcutDisplayed(item: ServerMediaItem): HomePage {
         assertMediaDisplayed(item.name, withinTag = HomeScreenSemantics.SHORTCUTS_ROW_TAG)
+        return this
+    }
+
+    fun assertErrorLoadingData(): HomePage {
+        composeTestRule.onNodeWithText(Res.string.library_error.get()).assertIsDisplayed()
         return this
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/HomePage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/HomePage.kt
@@ -1,12 +1,15 @@
 package io.music_assistant.client.support.pages
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import io.music_assistant.client.data.model.server.ServerMediaItem
 import io.music_assistant.client.support.get
+import io.music_assistant.client.support.withinTag
+import io.music_assistant.client.ui.compose.home.HomeScreenSemantics
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.nav_home
 import musicassistantclient.composeapp.generated.resources.nav_library
@@ -34,5 +37,11 @@ class HomePage(composeTestRule: ComposeTestRule) : ComposePage(composeTestRule) 
     fun refresh(): HomePage {
         composeTestRule.onNodeWithContentDescription("Refresh").performClick()
         return this
+    }
+
+    fun assertShortcutDisplayed(item: ServerMediaItem) {
+        composeTestRule
+            .onNode(withinTag(HomeScreenSemantics.SHORTCUTS_ROW_TAG).and(hasText(item.name)))
+            .assertIsDisplayed()
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/HomePage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/HomePage.kt
@@ -1,14 +1,12 @@
 package io.music_assistant.client.support.pages
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import io.music_assistant.client.data.model.server.ServerMediaItem
 import io.music_assistant.client.support.get
-import io.music_assistant.client.support.withinTag
 import io.music_assistant.client.ui.compose.home.HomeScreenSemantics
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.nav_home
@@ -40,10 +38,10 @@ class HomePage(composeTestRule: ComposeTestRule) : ComposePage(composeTestRule) 
     }
 
     fun clickOnShortcut(item: ServerMediaItem): ItemPage {
-        composeTestRule
-            .onNode(withinTag(HomeScreenSemantics.SHORTCUTS_ROW_TAG).and(hasText(item.name)))
-            .performClick()
-
-        return ItemPage(item, Res.string.nav_home.get(), composeTestRule)
+        return clickOnMedia(
+            item,
+            Res.string.nav_home.get(),
+            withinTag = HomeScreenSemantics.SHORTCUTS_ROW_TAG,
+        )
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/HomePage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/HomePage.kt
@@ -44,4 +44,9 @@ class HomePage(composeTestRule: ComposeTestRule) : ComposePage(composeTestRule) 
             withinTag = HomeScreenSemantics.SHORTCUTS_ROW_TAG,
         )
     }
+
+    fun playShortcut(item: ServerMediaItem): HomePage {
+        playMedia(item, withinTag = HomeScreenSemantics.SHORTCUTS_ROW_TAG)
+        return this
+    }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -15,6 +16,7 @@ import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.server.ServerMediaItem
 import io.music_assistant.client.support.get
 import io.music_assistant.client.support.isTab
+import io.music_assistant.client.support.withinTag
 import io.music_assistant.client.ui.compose.home.FloatingBarSemantics
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.action_pause
@@ -29,19 +31,29 @@ import musicassistantclient.composeapp.generated.resources.players_nothing
 fun ComposePage.clickOnMedia(
     serverMediaItem: ServerMediaItem,
     navigationItem: String,
+    withinTag: String? = null,
 ): ItemPage {
     return clickOnMedia(
         serverMediaItem.name,
         MediaType.fromServer(serverMediaItem.mediaType) ?: MediaType.UNKNOWN,
         navigationItem,
+        withinTag,
     )
 }
 
-fun ComposePage.clickOnMedia(name: String, type: MediaType, navigationItem: String): ItemPage {
-    composeTestRule.onNodeWithText(name)
-        .assertIsDisplayed()
-        .performClick()
+fun ComposePage.clickOnMedia(
+    name: String,
+    type: MediaType,
+    navigationItem: String,
+    withinTag: String? = null,
+): ItemPage {
+    val matcher = if (withinTag != null) {
+        withinTag(withinTag).and(hasText(name))
+    } else {
+        hasText(name)
+    }
 
+    composeTestRule.onNode(matcher).assertIsDisplayed().performClick()
     return ItemPage(name, type, navigationItem, composeTestRule).assertOnPage()
 }
 

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
@@ -102,8 +102,14 @@ fun <T : Page> ComposePage.clickLibrary(destination: T): T {
     return destination.assertOnPage()
 }
 
-fun <T : ComposePage> T.assertMediaDisplayed(name: String): T {
-    composeTestRule.onNodeWithText(name).assertIsDisplayed()
+fun <T : ComposePage> T.assertMediaDisplayed(name: String, withinTag: String? = null): T {
+    val matcher = if (withinTag != null) {
+        withinTag(withinTag).and(hasText(name))
+    } else {
+        hasText(name)
+    }
+
+    composeTestRule.onNode(matcher).assertIsDisplayed()
     return this
 }
 

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
@@ -112,8 +112,14 @@ fun <T : ComposePage> T.assertMediaNotDisplayed(name: String): T {
     return this
 }
 
-fun <T : ComposePage> T.playMedia(item: ServerMediaItem): T {
-    composeTestRule.onNodeWithText(item.name).performClick()
+fun <T : ComposePage> T.playMedia(item: ServerMediaItem, withinTag: String? = null): T {
+    val matcher = if (withinTag != null) {
+        withinTag(withinTag).and(hasText(item.name))
+    } else {
+        hasText(item.name)
+    }
+
+    composeTestRule.onNode(matcher).performClick()
     return this
 }
 

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -105,6 +105,7 @@
   <string name="filter_favorites">Favorites</string>
   <string name="home_edit_rows">Edit rows</string>
   <string name="home_save_rows">Save rows</string>
+  <string name="home_shortcuts">Shortcuts</string>
   <string name="item_error">Error loading item</string>
   <string name="item_no_data">No data available</string>
   <string name="item_subtitle_genre">Genre</string>

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/APICommands.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/APICommands.kt
@@ -79,6 +79,9 @@ object APICommands {
     const val MUSIC_RECOMMENDATIONS = "music/recommendations"
     const val PROVIDERS_MANIFESTS = "providers/manifests"
 
+    // Items
+    const val MUSIC_ITEM_BY_URI = "music/item_by_uri"
+
     // Auth commands
     const val AUTH_PROVIDERS = "auth/providers"
     const val AUTH_AUTHORIZATION_URL = "auth/authorization_url"

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/APICommands.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/APICommands.kt
@@ -84,6 +84,7 @@ object APICommands {
     const val AUTH_AUTHORIZATION_URL = "auth/authorization_url"
     const val AUTH_LOGIN = "auth/login"
     const val AUTH_LOGOUT = "auth/logout"
+    const val AUTH_ME = "auth/me"
     const val AUTH = "auth"
 
     // DSP commands

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/Shortcut.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/Shortcut.kt
@@ -1,0 +1,5 @@
+package io.music_assistant.client.data.model.client
+
+import io.music_assistant.client.data.model.client.items.AppMediaItem
+
+data class Shortcut(val item: AppMediaItem)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerUser.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerUser.kt
@@ -1,0 +1,14 @@
+package io.music_assistant.client.data.model.server
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ServerUser(
+    @SerialName("preferences") val preferences: ServerUserPreferences? = null,
+)
+
+@Serializable
+data class ServerUserPreferences(
+    @SerialName("sidebar.shortcuts") val shortcuts: List<String>,
+)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/CenteredProgress.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/CenteredProgress.kt
@@ -1,0 +1,18 @@
+package io.music_assistant.client.ui.compose.common
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun CenteredProgress() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/CenteredText.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/CenteredText.kt
@@ -1,0 +1,19 @@
+package io.music_assistant.client.ui.compose.common
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+
+@Composable
+fun CenteredText(text: String, color: Color = Color.Unspecified) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(text = text, color = color)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/DisplayString.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/DisplayString.kt
@@ -1,0 +1,36 @@
+package io.music_assistant.client.ui.compose.common
+
+import androidx.compose.runtime.Composable
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Abstraction that allows params/properties to use [StringResource] or [String] without the actual
+ * underlying type needing to be known.
+ */
+sealed class DisplayString {
+    @Composable
+    abstract fun string(): String
+
+    class Raw(private val string: String) : DisplayString() {
+        @Composable
+        override fun string(): String {
+            return string
+        }
+    }
+
+    class Resource(private val stringResource: StringResource) : DisplayString() {
+        @Composable
+        override fun string(): String {
+            return stringResource(stringResource)
+        }
+    }
+}
+
+fun StringResource.toDisplayString(): DisplayString {
+    return DisplayString.Resource(this)
+}
+
+fun String.toDisplayString(): DisplayString {
+    return DisplayString.Raw(this)
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/GridButton.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/GridButton.kt
@@ -22,10 +22,10 @@ import androidx.compose.ui.unit.dp
 
 @Composable
 fun GridButton(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     text: String,
-    icon: ImageVector,
-    onClick: () -> Unit,
+    icon: ImageVector? = null,
+    onClick: () -> Unit = {},
 ) {
     Row(
         modifier = modifier
@@ -39,12 +39,14 @@ fun GridButton(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        Icon(
-            modifier = Modifier.size(30.dp),
-            imageVector = icon,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onPrimaryContainer,
-        )
+        if (icon != null) {
+            Icon(
+                modifier = Modifier.size(30.dp),
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+        }
 
         Text(
             text = text,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/GridButton.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/GridButton.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/GridButton.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/GridButton.kt
@@ -1,0 +1,57 @@
+package io.music_assistant.client.ui.compose.common
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun GridButton(
+    modifier: Modifier,
+    text: String,
+    icon: ImageVector,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = modifier
+            .clearAndSetSemantics {
+                contentDescription = text
+            }
+            .clickable(onClick = onClick)
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.primaryContainer)
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Icon(
+            modifier = Modifier.size(30.dp),
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+
+        Text(
+            text = text,
+            style = MaterialTheme.typography.titleMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/GridButton.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/GridButton.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -29,9 +28,6 @@ fun GridButton(
 ) {
     Row(
         modifier = modifier
-            .clearAndSetSemantics {
-                contentDescription = text
-            }
             .clickable(onClick = onClick)
             .clip(RoundedCornerShape(8.dp))
             .background(MaterialTheme.colorScheme.primaryContainer)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
@@ -1,0 +1,257 @@
+package io.music_assistant.client.ui.compose.common.items
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import io.music_assistant.client.data.model.client.MediaType
+import io.music_assistant.client.data.model.client.items.Album
+import io.music_assistant.client.data.model.client.items.AppMediaItem
+import io.music_assistant.client.data.model.client.items.Artist
+import io.music_assistant.client.data.model.client.items.Audiobook
+import io.music_assistant.client.data.model.client.items.Genre
+import io.music_assistant.client.data.model.client.items.Playlist
+import io.music_assistant.client.data.model.client.items.Podcast
+import io.music_assistant.client.data.model.client.items.PodcastEpisode
+import io.music_assistant.client.data.model.client.items.RadioStation
+import io.music_assistant.client.data.model.client.items.Track
+import musicassistantclient.composeapp.generated.resources.Res
+import musicassistantclient.composeapp.generated.resources.all_albums
+import musicassistantclient.composeapp.generated.resources.all_artists
+import musicassistantclient.composeapp.generated.resources.all_audiobooks
+import musicassistantclient.composeapp.generated.resources.all_genres
+import musicassistantclient.composeapp.generated.resources.all_playlists
+import musicassistantclient.composeapp.generated.resources.all_podcasts
+import musicassistantclient.composeapp.generated.resources.all_radio
+import musicassistantclient.composeapp.generated.resources.all_tracks
+import org.jetbrains.compose.resources.stringResource
+
+data class ItemCategory(
+    val id: String,
+    val title: String,
+    val items: List<AppMediaItem>,
+    val lazyListKey: Any,
+    val itemType: MediaType? = null,
+    val tag: String? = null,
+)
+
+@Composable
+fun CategoryRow(
+    itemCategory: ItemCategory,
+    onNavigateClick: (AppMediaItem) -> Unit,
+    onPlayClick: PlayHandler<AppMediaItem>,
+    onAllClick: () -> Unit = { },
+    playlistActions: PlaylistActions,
+    libraryActions: LibraryActions,
+    progressActions: ProgressActions? = null,
+    providerIconFetcher: (@Composable (Modifier, String) -> Unit),
+) {
+    CategoryRow(
+        title = itemCategory.title,
+        rowItemType = itemCategory.itemType,
+        onNavigateClick = onNavigateClick,
+        onPlayClick = onPlayClick,
+        onAllClick = onAllClick,
+        mediaItems = itemCategory.items,
+        playlistActions = playlistActions,
+        libraryActions = libraryActions,
+        progressActions = progressActions,
+        providerIconFetcher = providerIconFetcher,
+        rowTag = itemCategory.tag,
+    )
+}
+
+@Composable
+fun CategoryRow(
+    title: String,
+    rowItemType: MediaType? = null,
+    onNavigateClick: (AppMediaItem) -> Unit,
+    onPlayClick: PlayHandler<AppMediaItem>,
+    onAllClick: () -> Unit = { },
+    mediaItems: List<AppMediaItem>,
+    playlistActions: PlaylistActions,
+    libraryActions: LibraryActions,
+    progressActions: ProgressActions? = null,
+    providerIconFetcher: (@Composable (Modifier, String) -> Unit),
+    rowTag: String? = null,
+) {
+    val rowListState = rememberLazyListState()
+
+    Column {
+        RowTitle(
+            title = title,
+            link = {
+                rowItemType?.let { type ->
+                    val allTitle = allItemsTitle(type)
+                    allTitle?.let {
+                        TextButton(
+                            onClick = onAllClick,
+                            contentPadding = PaddingValues(start = 4.dp, end = 4.dp),
+                        ) {
+                            Text(allTitle, style = MaterialTheme.typography.labelLarge)
+                        }
+                    }
+                }
+            },
+        )
+
+        val modifier = if (rowTag != null) {
+            Modifier.testTag(rowTag)
+        } else {
+            Modifier
+        }
+
+        LazyRow(
+            modifier = modifier,
+            state = rowListState,
+            contentPadding = PaddingValues(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            items(
+                items = mediaItems,
+                key = { it.lazyListKey() },
+                contentType = { item ->
+                    when (item) {
+                        is Track -> "Track"
+                        is Artist -> "Artist"
+                        is Album -> "Album"
+                        is Playlist -> "Playlist"
+                        is Audiobook -> "Audiobook"
+                        is Podcast -> "Podcast"
+                        is PodcastEpisode -> "Episode"
+                        is RadioStation -> "RadioStation"
+                        is Genre -> "Genre"
+                        else -> "Unknown"
+                    }
+                },
+            ) { item ->
+                when (item) {
+                    is Artist -> ArtistWithMenu(
+                        item = item,
+                        onNavigateClick = onNavigateClick,
+                        onPlayOption = onPlayClick,
+                        libraryActions = libraryActions,
+                        providerIconFetcher = providerIconFetcher,
+                    )
+
+                    is Album -> AlbumWithMenu(
+                        item = item,
+                        onNavigateClick = onNavigateClick,
+                        onPlayOption = onPlayClick,
+                        playlistActions = playlistActions,
+                        libraryActions = libraryActions,
+                        providerIconFetcher = providerIconFetcher,
+                    )
+
+                    is Playlist -> PlaylistWithMenu(
+                        item = item,
+                        onNavigateClick = onNavigateClick,
+                        onPlayOption = onPlayClick,
+                        libraryActions = libraryActions,
+                        providerIconFetcher = providerIconFetcher,
+                    )
+
+                    is Podcast -> PodcastWithMenu(
+                        item = item,
+                        onNavigateClick = onNavigateClick,
+                        onPlayOption = onPlayClick,
+                        libraryActions = libraryActions,
+                        providerIconFetcher = providerIconFetcher,
+                    )
+
+                    is Track -> TrackWithMenu(
+                        item = item,
+                        onPlayOption = onPlayClick,
+                        playlistActions = playlistActions,
+                        libraryActions = libraryActions,
+                        providerIconFetcher = providerIconFetcher,
+                    )
+
+                    is PodcastEpisode -> PodcastEpisodeWithMenu(
+                        item = item,
+                        onPlayOption = onPlayClick,
+                        playlistActions = playlistActions,
+                        libraryActions = libraryActions,
+                        progressActions = progressActions,
+                        providerIconFetcher = providerIconFetcher,
+                    )
+
+                    is Audiobook -> AudiobookWithMenu(
+                        item = item,
+                        onNavigateClick = onNavigateClick,
+                        onPlayOption = onPlayClick,
+                        playlistActions = playlistActions,
+                        libraryActions = libraryActions,
+                        progressActions = progressActions,
+                        providerIconFetcher = providerIconFetcher,
+                    )
+
+                    is RadioStation -> RadioWithMenu(
+                        item = item,
+                        onPlayOption = onPlayClick,
+                        playlistActions = playlistActions,
+                        libraryActions = libraryActions,
+                        providerIconFetcher = providerIconFetcher,
+                    )
+
+                    is Genre -> GenreWithMenu(
+                        item = item,
+                        onNavigateClick = onNavigateClick,
+                        onPlayOption = onPlayClick,
+                        libraryActions = libraryActions,
+                        providerIconFetcher = providerIconFetcher,
+                    )
+
+                    else -> {}
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RowTitle(
+    title: String,
+    link: @Composable () -> Unit = {},
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleLarge,
+        )
+
+        link()
+    }
+}
+
+@Composable
+private fun allItemsTitle(type: MediaType) = when (type) {
+    MediaType.TRACK -> stringResource(Res.string.all_tracks)
+    MediaType.ALBUM -> stringResource(Res.string.all_albums)
+    MediaType.ARTIST -> stringResource(Res.string.all_artists)
+    MediaType.PLAYLIST -> stringResource(Res.string.all_playlists)
+    MediaType.AUDIOBOOK -> stringResource(Res.string.all_audiobooks)
+    MediaType.PODCAST -> stringResource(Res.string.all_podcasts)
+    MediaType.RADIO -> stringResource(Res.string.all_radio)
+    MediaType.GENRE -> stringResource(Res.string.all_genres)
+    else -> null
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
@@ -28,6 +28,7 @@ import io.music_assistant.client.data.model.client.items.Podcast
 import io.music_assistant.client.data.model.client.items.PodcastEpisode
 import io.music_assistant.client.data.model.client.items.RadioStation
 import io.music_assistant.client.data.model.client.items.Track
+import io.music_assistant.client.ui.compose.common.DisplayString
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.all_albums
 import musicassistantclient.composeapp.generated.resources.all_artists
@@ -41,7 +42,7 @@ import org.jetbrains.compose.resources.stringResource
 
 data class ItemCategory(
     val id: String,
-    val title: String,
+    val title: DisplayString,
     val items: List<AppMediaItem>,
     val lazyListKey: Any,
     val itemType: MediaType? = null,
@@ -60,7 +61,7 @@ fun CategoryRow(
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
 ) {
     CategoryRow(
-        title = itemCategory.title,
+        title = itemCategory.title.string(),
         rowItemType = itemCategory.itemType,
         onNavigateClick = onNavigateClick,
         onPlayClick = onPlayClick,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeRowsConfig.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeRowsConfig.kt
@@ -1,7 +1,7 @@
 package io.music_assistant.client.ui.compose.home
 
-import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.settings.SettingsRepository.HomeRowPref
+import io.music_assistant.client.ui.compose.common.items.ItemCategory
 
 /**
  * Reconciles the live server rows against the stored [config] into an
@@ -18,15 +18,22 @@ import io.music_assistant.client.settings.SettingsRepository.HomeRowPref
  * - Stored ids no longer present on the server are ignored.
  */
 internal fun reconcileHomeRows(
-    serverRows: List<RecommendationFolder>,
+    categories: List<ItemCategory>,
     config: List<HomeRowPref>,
-): List<Pair<RecommendationFolder, Boolean>> {
+): List<Pair<ItemCategory, Boolean>> {
     val enabledById = config.associate { it.id to it.enabled }
     val orderById = config.withIndex().associate { (index, pref) -> pref.id to index }
-    return serverRows
-        .map { row -> row to (enabledById[row.itemId] ?: true) }
+    val sortedCategories = categories
+        .map { category -> category to (enabledById[category.id] ?: true) }
         .sortedWith(
-            compareByDescending<Pair<RecommendationFolder, Boolean>> { it.second }
-                .thenBy { orderById[it.first.itemId] ?: Int.MAX_VALUE },
+            compareByDescending<Pair<ItemCategory, Boolean>> { it.second }
+                .thenBy { orderById[it.first.id] ?: Int.MAX_VALUE },
         )
+
+    return if (config.any { it.id == "shortcuts" }) {
+        sortedCategories
+    } else {
+        sortedCategories.filter { it.first.id == "shortcuts" } +
+                sortedCategories.filter { it.first.id != "shortcuts" }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeRowsConfig.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeRowsConfig.kt
@@ -20,6 +20,7 @@ import io.music_assistant.client.ui.compose.common.items.ItemCategory
 internal fun reconcileHomeRows(
     categories: List<ItemCategory>,
     config: List<HomeRowPref>,
+    onTop: String? = null,
 ): List<Pair<ItemCategory, Boolean>> {
     val enabledById = config.associate { it.id to it.enabled }
     val orderById = config.withIndex().associate { (index, pref) -> pref.id to index }
@@ -30,10 +31,10 @@ internal fun reconcileHomeRows(
                 .thenBy { orderById[it.first.id] ?: Int.MAX_VALUE },
         )
 
-    return if (config.any { it.id == "shortcuts" }) {
+    return if (onTop != null && config.any { it.id == onTop }) {
         sortedCategories
     } else {
-        sortedCategories.filter { it.first.id == "shortcuts" } +
-                sortedCategories.filter { it.first.id != "shortcuts" }
+        sortedCategories.filter { it.first.id == onTop } +
+                sortedCategories.filter { it.first.id != onTop }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -222,7 +222,7 @@ fun HomeScreen(
                 } else {
                     if (shortcutsState is DataState.Data) {
                         item {
-                            ShortcutsRow(shortcutsState.data)
+                            ShortcutsRow(shortcutsState.data) { onNavigateClick(it.item) }
                         }
                     }
 
@@ -291,7 +291,7 @@ fun HomeScreen(
 }
 
 @Composable
-private fun ShortcutsRow(shortcuts: List<Shortcut>) {
+private fun ShortcutsRow(shortcuts: List<Shortcut>, onClick: (Shortcut) -> Unit) {
     Column {
         RowTitle(title = "Shortcuts")
 
@@ -301,8 +301,8 @@ private fun ShortcutsRow(shortcuts: List<Shortcut>) {
                 .padding(horizontal = 16.dp, vertical = 8.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            items(shortcuts) {
-                GridButton(text = it.item.displayName)
+            items(shortcuts) { shortcut ->
+                GridButton(text = shortcut.item.displayName) { onClick(shortcut) }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -83,7 +83,6 @@ import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.nav.BackHandler
 import io.music_assistant.client.ui.compose.nav.ScreenState
 import io.music_assistant.client.ui.compose.nav.TopBarLayout
-import io.music_assistant.client.utils.SessionState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import musicassistantclient.composeapp.generated.resources.Res
@@ -108,16 +107,16 @@ fun HomeScreen(
     homeScreenViewModel: HomeScreenViewModel,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues,
-    connectionState: SessionState,
+    isConnected: Boolean,
     onNavigateClick: (AppMediaItem) -> Unit,
     onLibraryItemClick: (MediaType) -> Unit,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
     actionsViewModel: ActionsViewModel,
     state: HomeScreenState,
 ) {
-    val homeScreenState = homeScreenViewModel.recommendationsState.collectAsStateWithLifecycle()
-    val recommendationsState = homeScreenState.value.recommendations
-    val homeRowsConfig = homeScreenState.value.homeRowsConfig
+    val homeScreenState by homeScreenViewModel.recommendationsState.collectAsStateWithLifecycle()
+    val recommendationsState = homeScreenState.recommendations
+    val homeRowsConfig = homeScreenState.homeRowsConfig
     var editMode by remember { mutableStateOf(false) }
 
     val baseList = remember(recommendationsState) {
@@ -207,7 +206,7 @@ fun HomeScreen(
                 state = state.lazyListState,
                 contentPadding = contentPadding,
             ) {
-                if (connectionState !is SessionState.Connected || recommendationsState !is DataState.Data) {
+                if (!isConnected || recommendationsState !is DataState.Data) {
                     item {
                         Box(
                             modifier = modifier.fillMaxWidth().height(200.dp),

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -64,6 +64,7 @@ import io.music_assistant.client.ui.compose.common.items.ItemCategory
 import io.music_assistant.client.ui.compose.common.items.ProvideClickActions
 import io.music_assistant.client.ui.compose.common.items.lazyListKey
 import io.music_assistant.client.ui.compose.common.moveToEnabledBoundary
+import io.music_assistant.client.ui.compose.common.toDisplayString
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.nav.BackHandler
 import io.music_assistant.client.ui.compose.nav.ScreenState
@@ -73,6 +74,7 @@ import kotlinx.coroutines.launch
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.home_edit_rows
 import musicassistantclient.composeapp.generated.resources.home_save_rows
+import musicassistantclient.composeapp.generated.resources.home_shortcuts
 import musicassistantclient.composeapp.generated.resources.library_error
 import musicassistantclient.composeapp.generated.resources.nav_home
 import musicassistantclient.composeapp.generated.resources.refresh
@@ -115,7 +117,7 @@ fun HomeScreen(
                 .map {
                     ItemCategory(
                         id = it.itemId,
-                        title = it.displayName,
+                        title = it.displayName.toDisplayString(),
                         items = it.items.orEmpty(),
                         lazyListKey = it.lazyListKey(),
                         itemType = it.rowItemType,
@@ -125,10 +127,10 @@ fun HomeScreen(
             if (shortcutsState is DataState.Data && shortcutsState.data.isNotEmpty()) {
                 val shortcuts = shortcutsState.data
                 val shortcutsCategory = ItemCategory(
-                    id = "shortcuts",
-                    title = "Shortcuts",
+                    id = SHORTCUTS_CATEGORY_ID,
+                    title = Res.string.home_shortcuts.toDisplayString(),
                     items = shortcuts.map { it.item },
-                    lazyListKey = "shortcuts",
+                    lazyListKey = SHORTCUTS_CATEGORY_ID,
                     tag = HomeScreenSemantics.SHORTCUTS_ROW_TAG,
                 )
 
@@ -144,7 +146,7 @@ fun HomeScreen(
     // Reconciled, enabled-first ordering. Authoritative for normal-mode display.
     val homeRowsConfig = homeScreenState.homeRowsConfig
     val working = remember(baseList, homeRowsConfig) {
-        reconcileHomeRows(baseList, homeRowsConfig, onTop = "shortcuts")
+        reconcileHomeRows(baseList, homeRowsConfig, onTop = SHORTCUTS_CATEGORY_ID)
     }
 
     // Edit-mode working copy — isolated from external (real-time) updates while editing;
@@ -347,3 +349,5 @@ object HomeScreenSemantics {
     const val SHORTCUTS_ROW_TAG = "ShortcutsRow"
     const val LIST_TAG = "List"
 }
+
+private const val SHORTCUTS_CATEGORY_ID = "shortcuts"

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -91,12 +91,10 @@ fun HomeScreen(
     actionsViewModel: ActionsViewModel,
     state: HomeScreenState,
 ) {
-    val homeScreenState by homeScreenViewModel.recommendationsState.collectAsStateWithLifecycle()
-    val recommendationsState = homeScreenState.recommendations
-    val homeRowsConfig = homeScreenState.homeRowsConfig
-    val shortcutsState = homeScreenState.shortcuts
-    var editMode by remember { mutableStateOf(false) }
+    val homeScreenState by homeScreenViewModel.state.collectAsStateWithLifecycle()
 
+    val recommendationsState = homeScreenState.recommendations
+    val shortcutsState = homeScreenState.shortcuts
     val baseList = remember(recommendationsState, shortcutsState) {
         if (recommendationsState is DataState.Data) {
             val recommendations = recommendationsState.data
@@ -143,6 +141,7 @@ fun HomeScreen(
     }
 
     // Reconciled, enabled-first ordering. Authoritative for normal-mode display.
+    val homeRowsConfig = homeScreenState.homeRowsConfig
     val working = remember(baseList, homeRowsConfig) {
         reconcileHomeRows(baseList, homeRowsConfig, onTop = "shortcuts")
     }
@@ -153,6 +152,7 @@ fun HomeScreen(
     val enabledCount = items.count { it.second }
     val enabledByKey = remember(items) { items.associate { it.first.lazyListKey to it.second } }
 
+    var editMode by remember { mutableStateOf(false) }
     val displayedData =
         if (editMode) items.map { it.first } else working.filter { it.second }.map { it.first }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -122,7 +122,7 @@ fun HomeScreen(
                     )
                 }
 
-            if (shortcutsState is DataState.Data) {
+            if (shortcutsState is DataState.Data && shortcutsState.data.isNotEmpty()) {
                 val shortcuts = shortcutsState.data
                 val shortcutsCategory = ItemCategory(
                     id = "shortcuts",
@@ -131,6 +131,7 @@ fun HomeScreen(
                     lazyListKey = "shortcuts",
                     tag = HomeScreenSemantics.SHORTCUTS_ROW_TAG,
                 )
+
                 recommendations + shortcutsCategory
             } else {
                 recommendations

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import compose.icons.TablerIcons
@@ -117,6 +118,7 @@ fun HomeScreen(
     val homeScreenState by homeScreenViewModel.recommendationsState.collectAsStateWithLifecycle()
     val recommendationsState = homeScreenState.recommendations
     val homeRowsConfig = homeScreenState.homeRowsConfig
+    val shortcutsState = homeScreenState.shortcuts
     var editMode by remember { mutableStateOf(false) }
 
     val baseList = remember(recommendationsState) {
@@ -216,6 +218,16 @@ fun HomeScreen(
                         }
                     }
                 } else {
+                    if (shortcutsState is DataState.Data) {
+                        item {
+                            LazyRow(modifier = Modifier.testTag(HomeScreenSemantics.SHORTCUTS_ROW_TAG)) {
+                                items(shortcutsState.data) {
+                                    Text(it.item.displayName)
+                                }
+                            }
+                        }
+                    }
+
                     items(
                         items = displayedData,
                         key = { it.lazyListKey() },

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -20,7 +19,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -58,6 +56,8 @@ import io.music_assistant.client.data.model.client.items.PodcastEpisode
 import io.music_assistant.client.data.model.client.items.RadioStation
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.settings.SettingsRepository
+import io.music_assistant.client.ui.compose.common.CenteredProgress
+import io.music_assistant.client.ui.compose.common.CenteredText
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.items.CategoryRow
 import io.music_assistant.client.ui.compose.common.items.ItemCategory
@@ -73,6 +73,7 @@ import kotlinx.coroutines.launch
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.home_edit_rows
 import musicassistantclient.composeapp.generated.resources.home_save_rows
+import musicassistantclient.composeapp.generated.resources.library_error
 import musicassistantclient.composeapp.generated.resources.nav_home
 import musicassistantclient.composeapp.generated.resources.refresh
 import org.jetbrains.compose.resources.stringResource
@@ -82,7 +83,6 @@ import sh.calvin.reorderable.rememberReorderableLazyListState
 @Composable
 fun HomeScreen(
     homeScreenViewModel: HomeScreenViewModel,
-    modifier: Modifier = Modifier,
     contentPadding: PaddingValues,
     isConnected: Boolean,
     onNavigateClick: (AppMediaItem) -> Unit,
@@ -189,37 +189,37 @@ fun HomeScreen(
         },
         topAppBarState = state.topAppBarState,
     ) {
-        val rowContent: @Composable (ItemCategory) -> Unit = {
-            CategoryRow(
-                itemCategory = it,
-                onNavigateClick = onNavigateClick,
-                onPlayClick = { item, option, radio, _ ->
-                    homeScreenViewModel.onPlayClick(item, option, radio)
-                },
-                onAllClick = { it.itemType?.let { onLibraryItemClick(it) } },
-                playlistActions = actionsViewModel,
-                libraryActions = actionsViewModel,
-                progressActions = actionsViewModel,
-                providerIconFetcher = providerIconFetcher,
-            )
-        }
+        if (!isConnected || recommendationsState !is DataState.Data) {
+            if (recommendationsState is DataState.Loading) {
+                CenteredProgress()
+            } else {
+                CenteredText(
+                    text = stringResource(Res.string.library_error),
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        } else {
+            val rowContent: @Composable (ItemCategory) -> Unit = {
+                CategoryRow(
+                    itemCategory = it,
+                    onNavigateClick = onNavigateClick,
+                    onPlayClick = { item, option, radio, _ ->
+                        homeScreenViewModel.onPlayClick(item, option, radio)
+                    },
+                    onAllClick = { it.itemType?.let { onLibraryItemClick(it) } },
+                    playlistActions = actionsViewModel,
+                    libraryActions = actionsViewModel,
+                    progressActions = actionsViewModel,
+                    providerIconFetcher = providerIconFetcher,
+                )
+            }
 
-        ProvideClickActions(ClickContext.HOME) {
-            LazyColumn(
-                modifier = Modifier.testTag(HomeScreenSemantics.LIST_TAG),
-                state = state.lazyListState,
-                contentPadding = contentPadding,
-            ) {
-                if (!isConnected || recommendationsState !is DataState.Data) {
-                    item {
-                        Box(
-                            modifier = modifier.fillMaxWidth().height(200.dp),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            CircularProgressIndicator()
-                        }
-                    }
-                } else {
+            ProvideClickActions(ClickContext.HOME) {
+                LazyColumn(
+                    modifier = Modifier.testTag(HomeScreenSemantics.LIST_TAG),
+                    state = state.lazyListState,
+                    contentPadding = contentPadding,
+                ) {
                     items(
                         items = displayedData,
                         key = { it.lazyListKey },

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -51,6 +51,7 @@ import compose.icons.TablerIcons
 import compose.icons.tablericons.GripVertical
 import io.music_assistant.client.data.model.client.ClickContext
 import io.music_assistant.client.data.model.client.MediaType
+import io.music_assistant.client.data.model.client.Shortcut
 import io.music_assistant.client.data.model.client.items.Album
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Artist
@@ -64,6 +65,7 @@ import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.compose.common.DataState
+import io.music_assistant.client.ui.compose.common.GridButton
 import io.music_assistant.client.ui.compose.common.items.AlbumWithMenu
 import io.music_assistant.client.ui.compose.common.items.ArtistWithMenu
 import io.music_assistant.client.ui.compose.common.items.AudiobookWithMenu
@@ -220,11 +222,7 @@ fun HomeScreen(
                 } else {
                     if (shortcutsState is DataState.Data) {
                         item {
-                            LazyRow(modifier = Modifier.testTag(HomeScreenSemantics.SHORTCUTS_ROW_TAG)) {
-                                items(shortcutsState.data) {
-                                    Text(it.item.displayName)
-                                }
-                            }
+                            ShortcutsRow(shortcutsState.data)
                         }
                     }
 
@@ -293,6 +291,24 @@ fun HomeScreen(
 }
 
 @Composable
+private fun ShortcutsRow(shortcuts: List<Shortcut>) {
+    Column {
+        RowTitle(title = "Shortcuts")
+
+        LazyRow(
+            modifier = Modifier
+                .testTag(HomeScreenSemantics.SHORTCUTS_ROW_TAG)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            items(shortcuts) {
+                GridButton(text = it.item.displayName)
+            }
+        }
+    }
+}
+
+@Composable
 private fun LandingPageTopBar(
     editMode: Boolean,
     onRefresh: () -> Unit,
@@ -340,29 +356,23 @@ fun CategoryRow(
     val rowListState = rememberLazyListState()
 
     Column {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleLarge,
-            )
-            rowItemType?.let { type ->
-                val allTitle = allItemsTitle(type)
-                allTitle?.let {
-                    TextButton(
-                        onClick = onAllClick,
-                        contentPadding = PaddingValues(start = 4.dp, end = 4.dp),
-                    ) {
-                        Text(allTitle, style = MaterialTheme.typography.labelLarge)
+        RowTitle(
+            title = title,
+            link = {
+                rowItemType?.let { type ->
+                    val allTitle = allItemsTitle(type)
+                    allTitle?.let {
+                        TextButton(
+                            onClick = onAllClick,
+                            contentPadding = PaddingValues(start = 4.dp, end = 4.dp),
+                        ) {
+                            Text(allTitle, style = MaterialTheme.typography.labelLarge)
+                        }
                     }
                 }
-            }
-        }
+            },
+        )
+
         LazyRow(
             state = rowListState,
             contentPadding = PaddingValues(horizontal = 16.dp),
@@ -467,6 +477,27 @@ fun CategoryRow(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun RowTitle(
+    title: String,
+    link: @Composable () -> Unit = {},
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleLarge,
+        )
+
+        link()
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -51,7 +51,6 @@ import compose.icons.TablerIcons
 import compose.icons.tablericons.GripVertical
 import io.music_assistant.client.data.model.client.ClickContext
 import io.music_assistant.client.data.model.client.MediaType
-import io.music_assistant.client.data.model.client.Shortcut
 import io.music_assistant.client.data.model.client.items.Album
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Artist
@@ -65,7 +64,6 @@ import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.compose.common.DataState
-import io.music_assistant.client.ui.compose.common.GridButton
 import io.music_assistant.client.ui.compose.common.items.AlbumWithMenu
 import io.music_assistant.client.ui.compose.common.items.ArtistWithMenu
 import io.music_assistant.client.ui.compose.common.items.AudiobookWithMenu
@@ -222,7 +220,19 @@ fun HomeScreen(
                 } else {
                     if (shortcutsState is DataState.Data) {
                         item {
-                            ShortcutsRow(shortcutsState.data) { onNavigateClick(it.item) }
+                            CategoryRow(
+                                title = "Shortcuts",
+                                onNavigateClick = onNavigateClick,
+                                onPlayClick = { item, option, radio, _ ->
+                                    homeScreenViewModel.onPlayClick(item, option, radio)
+                                },
+                                mediaItems = shortcutsState.data.map { it.item },
+                                playlistActions = actionsViewModel,
+                                libraryActions = actionsViewModel,
+                                progressActions = actionsViewModel,
+                                providerIconFetcher = providerIconFetcher,
+                                rowTag = HomeScreenSemantics.SHORTCUTS_ROW_TAG,
+                            )
                         }
                     }
 
@@ -291,24 +301,6 @@ fun HomeScreen(
 }
 
 @Composable
-private fun ShortcutsRow(shortcuts: List<Shortcut>, onClick: (Shortcut) -> Unit) {
-    Column {
-        RowTitle(title = "Shortcuts")
-
-        LazyRow(
-            modifier = Modifier
-                .testTag(HomeScreenSemantics.SHORTCUTS_ROW_TAG)
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            items(shortcuts) { shortcut ->
-                GridButton(text = shortcut.item.displayName) { onClick(shortcut) }
-            }
-        }
-    }
-}
-
-@Composable
 private fun LandingPageTopBar(
     editMode: Boolean,
     onRefresh: () -> Unit,
@@ -343,15 +335,16 @@ private fun LandingPageTopBar(
 @Composable
 fun CategoryRow(
     title: String,
-    rowItemType: MediaType?,
+    rowItemType: MediaType? = null,
     onNavigateClick: (AppMediaItem) -> Unit,
     onPlayClick: PlayHandler<AppMediaItem>,
-    onAllClick: () -> Unit,
+    onAllClick: () -> Unit = { },
     mediaItems: List<AppMediaItem>,
     playlistActions: PlaylistActions,
     libraryActions: LibraryActions,
     progressActions: ProgressActions? = null,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
+    rowTag: String? = null,
 ) {
     val rowListState = rememberLazyListState()
 
@@ -373,7 +366,14 @@ fun CategoryRow(
             },
         )
 
+        val modifier = if (rowTag != null) {
+            Modifier.testTag(rowTag)
+        } else {
+            Modifier
+        }
+
         LazyRow(
+            modifier = modifier,
             state = rowListState,
             contentPadding = PaddingValues(horizontal = 16.dp),
             horizontalArrangement = Arrangement.spacedBy(4.dp),

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import compose.icons.TablerIcons
 import compose.icons.tablericons.GripVertical
 import io.music_assistant.client.data.model.client.ClickContext
@@ -108,19 +109,20 @@ fun HomeScreen(
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues,
     connectionState: SessionState,
-    dataState: DataState<List<RecommendationFolder>>,
     onNavigateClick: (AppMediaItem) -> Unit,
     onLibraryItemClick: (MediaType) -> Unit,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
-    homeRowsConfig: List<SettingsRepository.HomeRowPref>,
     actionsViewModel: ActionsViewModel,
     state: HomeScreenState,
 ) {
+    val homeScreenState = homeScreenViewModel.recommendationsState.collectAsStateWithLifecycle()
+    val recommendationsState = homeScreenState.value.recommendations
+    val homeRowsConfig = homeScreenState.value.homeRowsConfig
     var editMode by remember { mutableStateOf(false) }
 
-    val baseList = remember(dataState) {
-        if (dataState is DataState.Data) {
-            dataState.data
+    val baseList = remember(recommendationsState) {
+        if (recommendationsState is DataState.Data) {
+            recommendationsState.data
                 .filter {
                     it.items?.any { item ->
                         item is Track ||
@@ -205,7 +207,7 @@ fun HomeScreen(
                 state = state.lazyListState,
                 contentPadding = contentPadding,
             ) {
-                if (connectionState !is SessionState.Connected || dataState !is DataState.Data) {
+                if (connectionState !is SessionState.Connected || recommendationsState !is DataState.Data) {
                     item {
                         Box(
                             modifier = modifier.fillMaxWidth().height(200.dp),

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -45,6 +45,7 @@ import compose.icons.TablerIcons
 import compose.icons.tablericons.GripVertical
 import io.music_assistant.client.data.model.client.ClickContext
 import io.music_assistant.client.data.model.client.MediaType
+import io.music_assistant.client.data.model.client.Shortcut
 import io.music_assistant.client.data.model.client.items.Album
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Artist
@@ -54,6 +55,7 @@ import io.music_assistant.client.data.model.client.items.Playlist
 import io.music_assistant.client.data.model.client.items.Podcast
 import io.music_assistant.client.data.model.client.items.PodcastEpisode
 import io.music_assistant.client.data.model.client.items.RadioStation
+import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.compose.common.CenteredProgress
@@ -95,58 +97,12 @@ fun HomeScreen(
 ) {
     val homeScreenState by homeScreenViewModel.state.collectAsStateWithLifecycle()
 
+    // Reconciled, enabled-first ordering. Authoritative for normal-mode display.
     val recommendationsState = homeScreenState.recommendations
     val shortcutsState = homeScreenState.shortcuts
-    val baseList = remember(recommendationsState, shortcutsState) {
-        if (recommendationsState is DataState.Data) {
-            val recommendations = recommendationsState.data
-                .filter {
-                    it.items?.any { item ->
-                        item is Track ||
-                                item is Artist ||
-                                item is Album ||
-                                item is Playlist ||
-                                item is Audiobook ||
-                                item is Podcast ||
-                                item is PodcastEpisode ||
-                                item is RadioStation ||
-                                item is Genre
-                    } == true
-                }
-                .distinctBy { it.lazyListKey() }
-                .map {
-                    ItemCategory(
-                        id = it.itemId,
-                        title = it.displayName.toDisplayString(),
-                        items = it.items.orEmpty(),
-                        lazyListKey = it.lazyListKey(),
-                        itemType = it.rowItemType,
-                    )
-                }
-
-            if (shortcutsState is DataState.Data && shortcutsState.data.isNotEmpty()) {
-                val shortcuts = shortcutsState.data
-                val shortcutsCategory = ItemCategory(
-                    id = SHORTCUTS_CATEGORY_ID,
-                    title = Res.string.home_shortcuts.toDisplayString(),
-                    items = shortcuts.map { it.item },
-                    lazyListKey = SHORTCUTS_CATEGORY_ID,
-                    tag = HomeScreenSemantics.SHORTCUTS_ROW_TAG,
-                )
-
-                recommendations + shortcutsCategory
-            } else {
-                recommendations
-            }
-        } else {
-            emptyList()
-        }
-    }
-
-    // Reconciled, enabled-first ordering. Authoritative for normal-mode display.
     val homeRowsConfig = homeScreenState.homeRowsConfig
-    val working = remember(baseList, homeRowsConfig) {
-        reconcileHomeRows(baseList, homeRowsConfig, onTop = SHORTCUTS_CATEGORY_ID)
+    val working = remember(recommendationsState, shortcutsState, homeRowsConfig) {
+        getCategories(recommendationsState, shortcutsState, homeRowsConfig)
     }
 
     // Edit-mode working copy — isolated from external (real-time) updates while editing;
@@ -291,6 +247,60 @@ fun HomeScreen(
     }
 }
 
+private fun getCategories(
+    recommendationsState: DataState<List<RecommendationFolder>>,
+    shortcutsState: DataState<List<Shortcut>>,
+    homeRowsConfig: List<SettingsRepository.HomeRowPref>,
+): List<Pair<ItemCategory, Boolean>> {
+    val baseList = if (recommendationsState is DataState.Data) {
+        val recommendations = recommendationsState.data
+            .filter {
+                it.items?.any { item ->
+                    item is Track ||
+                            item is Artist ||
+                            item is Album ||
+                            item is Playlist ||
+                            item is Audiobook ||
+                            item is Podcast ||
+                            item is PodcastEpisode ||
+                            item is RadioStation ||
+                            item is Genre
+                } == true
+            }
+            .distinctBy { it.lazyListKey() }
+            .map {
+                ItemCategory(
+                    id = it.itemId,
+                    title = it.displayName.toDisplayString(),
+                    items = it.items.orEmpty(),
+                    lazyListKey = it.lazyListKey(),
+                    itemType = it.rowItemType,
+                )
+            }
+
+        if (shortcutsState is DataState.Data && shortcutsState.data.isNotEmpty()) {
+            val shortcuts = shortcutsState.data
+            val shortcutsCategory = ItemCategory(
+                id = SHORTCUTS_CATEGORY_ID,
+                title = Res.string.home_shortcuts.toDisplayString(),
+                items = shortcuts.map { it.item },
+                lazyListKey = SHORTCUTS_CATEGORY_ID,
+                tag = HomeScreenSemantics.SHORTCUTS_ROW_TAG,
+            )
+
+            recommendations + shortcutsCategory
+        } else {
+            recommendations
+        }
+    } else {
+        emptyList()
+    }
+
+    return reconcileHomeRows(baseList, homeRowsConfig, onTop = SHORTCUTS_CATEGORY_ID)
+}
+
+private const val SHORTCUTS_CATEGORY_ID = "shortcuts"
+
 @Composable
 private fun LandingPageTopBar(
     editMode: Boolean,
@@ -349,5 +359,3 @@ object HomeScreenSemantics {
     const val SHORTCUTS_ROW_TAG = "ShortcutsRow"
     const val LIST_TAG = "List"
 }
-
-private const val SHORTCUTS_CATEGORY_ID = "shortcuts"

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -5,9 +5,7 @@ package io.music_assistant.client.ui.compose.home
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -16,7 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
@@ -30,7 +27,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarState
 import androidx.compose.material3.rememberTopAppBarState
@@ -60,24 +56,12 @@ import io.music_assistant.client.data.model.client.items.Playlist
 import io.music_assistant.client.data.model.client.items.Podcast
 import io.music_assistant.client.data.model.client.items.PodcastEpisode
 import io.music_assistant.client.data.model.client.items.RadioStation
-import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.compose.common.DataState
-import io.music_assistant.client.ui.compose.common.items.AlbumWithMenu
-import io.music_assistant.client.ui.compose.common.items.ArtistWithMenu
-import io.music_assistant.client.ui.compose.common.items.AudiobookWithMenu
-import io.music_assistant.client.ui.compose.common.items.GenreWithMenu
-import io.music_assistant.client.ui.compose.common.items.LibraryActions
-import io.music_assistant.client.ui.compose.common.items.PlayHandler
-import io.music_assistant.client.ui.compose.common.items.PlaylistActions
-import io.music_assistant.client.ui.compose.common.items.PlaylistWithMenu
-import io.music_assistant.client.ui.compose.common.items.PodcastEpisodeWithMenu
-import io.music_assistant.client.ui.compose.common.items.PodcastWithMenu
-import io.music_assistant.client.ui.compose.common.items.ProgressActions
+import io.music_assistant.client.ui.compose.common.items.CategoryRow
+import io.music_assistant.client.ui.compose.common.items.ItemCategory
 import io.music_assistant.client.ui.compose.common.items.ProvideClickActions
-import io.music_assistant.client.ui.compose.common.items.RadioWithMenu
-import io.music_assistant.client.ui.compose.common.items.TrackWithMenu
 import io.music_assistant.client.ui.compose.common.items.lazyListKey
 import io.music_assistant.client.ui.compose.common.moveToEnabledBoundary
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
@@ -87,14 +71,6 @@ import io.music_assistant.client.ui.compose.nav.TopBarLayout
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import musicassistantclient.composeapp.generated.resources.Res
-import musicassistantclient.composeapp.generated.resources.all_albums
-import musicassistantclient.composeapp.generated.resources.all_artists
-import musicassistantclient.composeapp.generated.resources.all_audiobooks
-import musicassistantclient.composeapp.generated.resources.all_genres
-import musicassistantclient.composeapp.generated.resources.all_playlists
-import musicassistantclient.composeapp.generated.resources.all_podcasts
-import musicassistantclient.composeapp.generated.resources.all_radio
-import musicassistantclient.composeapp.generated.resources.all_tracks
 import musicassistantclient.composeapp.generated.resources.home_edit_rows
 import musicassistantclient.composeapp.generated.resources.home_save_rows
 import musicassistantclient.composeapp.generated.resources.nav_home
@@ -121,9 +97,9 @@ fun HomeScreen(
     val shortcutsState = homeScreenState.shortcuts
     var editMode by remember { mutableStateOf(false) }
 
-    val baseList = remember(recommendationsState) {
+    val baseList = remember(recommendationsState, shortcutsState) {
         if (recommendationsState is DataState.Data) {
-            recommendationsState.data
+            val recommendations = recommendationsState.data
                 .filter {
                     it.items?.any { item ->
                         item is Track ||
@@ -138,10 +114,34 @@ fun HomeScreen(
                     } == true
                 }
                 .distinctBy { it.lazyListKey() }
+                .map {
+                    ItemCategory(
+                        id = it.itemId,
+                        title = it.displayName,
+                        items = it.items.orEmpty(),
+                        lazyListKey = it.lazyListKey(),
+                        itemType = it.rowItemType,
+                    )
+                }
+
+            if (shortcutsState is DataState.Data) {
+                val shortcuts = shortcutsState.data
+                val shortcutsCategory = ItemCategory(
+                    id = "shortcuts",
+                    title = "Shortcuts",
+                    items = shortcuts.map { it.item },
+                    lazyListKey = "shortcuts",
+                    tag = HomeScreenSemantics.SHORTCUTS_ROW_TAG,
+                )
+                recommendations + shortcutsCategory
+            } else {
+                recommendations
+            }
         } else {
             emptyList()
         }
     }
+
     // Reconciled, enabled-first ordering. Authoritative for normal-mode display.
     val working = remember(baseList, homeRowsConfig) { reconcileHomeRows(baseList, homeRowsConfig) }
 
@@ -149,7 +149,7 @@ fun HomeScreen(
     // snapshotted fresh on entering edit mode.
     var items by remember { mutableStateOf(working) }
     val enabledCount = items.count { it.second }
-    val enabledByKey = remember(items) { items.associate { it.first.lazyListKey() to it.second } }
+    val enabledByKey = remember(items) { items.associate { it.first.lazyListKey to it.second } }
 
     val displayedData =
         if (editMode) items.map { it.first } else working.filter { it.second }.map { it.first }
@@ -172,7 +172,7 @@ fun HomeScreen(
                         homeScreenViewModel.saveHomeRows(
                             items.map {
                                 SettingsRepository.HomeRowPref(
-                                    it.first.itemId,
+                                    it.first.id,
                                     it.second,
                                 )
                             },
@@ -187,24 +187,24 @@ fun HomeScreen(
         },
         topAppBarState = state.topAppBarState,
     ) {
-        val rowContent: @Composable (RecommendationFolder) -> Unit = { row ->
+        val rowContent: @Composable (ItemCategory) -> Unit = {
             CategoryRow(
-                title = row.displayName,
-                rowItemType = row.rowItemType,
+                itemCategory = it,
                 onNavigateClick = onNavigateClick,
                 onPlayClick = { item, option, radio, _ ->
                     homeScreenViewModel.onPlayClick(item, option, radio)
                 },
-                onAllClick = { row.rowItemType?.let { onLibraryItemClick(it) } },
-                mediaItems = row.items.orEmpty(),
+                onAllClick = { it.itemType?.let { onLibraryItemClick(it) } },
                 playlistActions = actionsViewModel,
                 libraryActions = actionsViewModel,
                 progressActions = actionsViewModel,
                 providerIconFetcher = providerIconFetcher,
             )
         }
+
         ProvideClickActions(ClickContext.HOME) {
             LazyColumn(
+                modifier = Modifier.testTag(HomeScreenSemantics.LIST_TAG),
                 state = state.lazyListState,
                 contentPadding = contentPadding,
             ) {
@@ -218,33 +218,15 @@ fun HomeScreen(
                         }
                     }
                 } else {
-                    if (shortcutsState is DataState.Data) {
-                        item {
-                            CategoryRow(
-                                title = "Shortcuts",
-                                onNavigateClick = onNavigateClick,
-                                onPlayClick = { item, option, radio, _ ->
-                                    homeScreenViewModel.onPlayClick(item, option, radio)
-                                },
-                                mediaItems = shortcutsState.data.map { it.item },
-                                playlistActions = actionsViewModel,
-                                libraryActions = actionsViewModel,
-                                progressActions = actionsViewModel,
-                                providerIconFetcher = providerIconFetcher,
-                                rowTag = HomeScreenSemantics.SHORTCUTS_ROW_TAG,
-                            )
-                        }
-                    }
-
                     items(
                         items = displayedData,
-                        key = { it.lazyListKey() },
-                    ) { row ->
+                        key = { it.lazyListKey },
+                    ) { itemCategory ->
                         if (editMode) {
-                            val enabled = enabledByKey[row.lazyListKey()] ?: true
-                            ReorderableItem(reorderableState, key = row.lazyListKey()) {
+                            val enabled = enabledByKey[itemCategory.lazyListKey] ?: true
+                            ReorderableItem(reorderableState, key = itemCategory.lazyListKey) {
                                 Box(modifier = Modifier.fillMaxWidth()) {
-                                    rowContent(row)
+                                    rowContent(itemCategory)
                                     Box(
                                         modifier = Modifier
                                             .matchParentSize()
@@ -272,7 +254,11 @@ fun HomeScreen(
                                             enabled = !enabled || enabledCount > 1,
                                             onCheckedChange = { newEnabled ->
                                                 items =
-                                                    moveToEnabledBoundary(items, row, newEnabled)
+                                                    moveToEnabledBoundary(
+                                                        items,
+                                                        itemCategory,
+                                                        newEnabled,
+                                                    )
                                             },
                                         )
                                         Icon(
@@ -291,7 +277,7 @@ fun HomeScreen(
                                 }
                             }
                         } else {
-                            rowContent(row)
+                            rowContent(itemCategory)
                         }
                     }
                 }
@@ -330,190 +316,6 @@ private fun LandingPageTopBar(
     )
 }
 
-// --- Common UI Components ---
-
-@Composable
-fun CategoryRow(
-    title: String,
-    rowItemType: MediaType? = null,
-    onNavigateClick: (AppMediaItem) -> Unit,
-    onPlayClick: PlayHandler<AppMediaItem>,
-    onAllClick: () -> Unit = { },
-    mediaItems: List<AppMediaItem>,
-    playlistActions: PlaylistActions,
-    libraryActions: LibraryActions,
-    progressActions: ProgressActions? = null,
-    providerIconFetcher: (@Composable (Modifier, String) -> Unit),
-    rowTag: String? = null,
-) {
-    val rowListState = rememberLazyListState()
-
-    Column {
-        RowTitle(
-            title = title,
-            link = {
-                rowItemType?.let { type ->
-                    val allTitle = allItemsTitle(type)
-                    allTitle?.let {
-                        TextButton(
-                            onClick = onAllClick,
-                            contentPadding = PaddingValues(start = 4.dp, end = 4.dp),
-                        ) {
-                            Text(allTitle, style = MaterialTheme.typography.labelLarge)
-                        }
-                    }
-                }
-            },
-        )
-
-        val modifier = if (rowTag != null) {
-            Modifier.testTag(rowTag)
-        } else {
-            Modifier
-        }
-
-        LazyRow(
-            modifier = modifier,
-            state = rowListState,
-            contentPadding = PaddingValues(horizontal = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-            items(
-                items = mediaItems,
-                key = { it.lazyListKey() },
-                contentType = { item ->
-                    when (item) {
-                        is Track -> "Track"
-                        is Artist -> "Artist"
-                        is Album -> "Album"
-                        is Playlist -> "Playlist"
-                        is Audiobook -> "Audiobook"
-                        is Podcast -> "Podcast"
-                        is PodcastEpisode -> "Episode"
-                        is RadioStation -> "RadioStation"
-                        is Genre -> "Genre"
-                        else -> "Unknown"
-                    }
-                },
-            ) { item ->
-                when (item) {
-                    is Artist -> ArtistWithMenu(
-                        item = item,
-                        onNavigateClick = onNavigateClick,
-                        onPlayOption = onPlayClick,
-                        libraryActions = libraryActions,
-                        providerIconFetcher = providerIconFetcher,
-                    )
-
-                    is Album -> AlbumWithMenu(
-                        item = item,
-                        onNavigateClick = onNavigateClick,
-                        onPlayOption = onPlayClick,
-                        playlistActions = playlistActions,
-                        libraryActions = libraryActions,
-                        providerIconFetcher = providerIconFetcher,
-                    )
-
-                    is Playlist -> PlaylistWithMenu(
-                        item = item,
-                        onNavigateClick = onNavigateClick,
-                        onPlayOption = onPlayClick,
-                        libraryActions = libraryActions,
-                        providerIconFetcher = providerIconFetcher,
-                    )
-
-                    is Podcast -> PodcastWithMenu(
-                        item = item,
-                        onNavigateClick = onNavigateClick,
-                        onPlayOption = onPlayClick,
-                        libraryActions = libraryActions,
-                        providerIconFetcher = providerIconFetcher,
-                    )
-
-                    is Track -> TrackWithMenu(
-                        item = item,
-                        onPlayOption = onPlayClick,
-                        playlistActions = playlistActions,
-                        libraryActions = libraryActions,
-                        providerIconFetcher = providerIconFetcher,
-                    )
-
-                    is PodcastEpisode -> PodcastEpisodeWithMenu(
-                        item = item,
-                        onPlayOption = onPlayClick,
-                        playlistActions = playlistActions,
-                        libraryActions = libraryActions,
-                        progressActions = progressActions,
-                        providerIconFetcher = providerIconFetcher,
-                    )
-
-                    is Audiobook -> AudiobookWithMenu(
-                        item = item,
-                        onNavigateClick = onNavigateClick,
-                        onPlayOption = onPlayClick,
-                        playlistActions = playlistActions,
-                        libraryActions = libraryActions,
-                        progressActions = progressActions,
-                        providerIconFetcher = providerIconFetcher,
-                    )
-
-                    is RadioStation -> RadioWithMenu(
-                        item = item,
-                        onPlayOption = onPlayClick,
-                        playlistActions = playlistActions,
-                        libraryActions = libraryActions,
-                        providerIconFetcher = providerIconFetcher,
-                    )
-
-                    is Genre -> GenreWithMenu(
-                        item = item,
-                        onNavigateClick = onNavigateClick,
-                        onPlayOption = onPlayClick,
-                        libraryActions = libraryActions,
-                        providerIconFetcher = providerIconFetcher,
-                    )
-
-                    else -> {}
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun RowTitle(
-    title: String,
-    link: @Composable () -> Unit = {},
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween,
-    ) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.titleLarge,
-        )
-
-        link()
-    }
-}
-
-@Composable
-fun allItemsTitle(type: MediaType) = when (type) {
-    MediaType.TRACK -> stringResource(Res.string.all_tracks)
-    MediaType.ALBUM -> stringResource(Res.string.all_albums)
-    MediaType.ARTIST -> stringResource(Res.string.all_artists)
-    MediaType.PLAYLIST -> stringResource(Res.string.all_playlists)
-    MediaType.AUDIOBOOK -> stringResource(Res.string.all_audiobooks)
-    MediaType.PODCAST -> stringResource(Res.string.all_podcasts)
-    MediaType.RADIO -> stringResource(Res.string.all_radio)
-    MediaType.GENRE -> stringResource(Res.string.all_genres)
-    else -> null
-}
-
 class HomeScreenState(
     val topAppBarState: TopAppBarState,
     val lazyListState: LazyListState,
@@ -540,4 +342,5 @@ class HomeScreenState(
 
 object HomeScreenSemantics {
     const val SHORTCUTS_ROW_TAG = "ShortcutsRow"
+    const val LIST_TAG = "List"
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -493,3 +493,7 @@ class HomeScreenState(
         }
     }
 }
+
+object HomeScreenSemantics {
+    const val SHORTCUTS_ROW_TAG = "ShortcutsRow"
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -143,7 +143,9 @@ fun HomeScreen(
     }
 
     // Reconciled, enabled-first ordering. Authoritative for normal-mode display.
-    val working = remember(baseList, homeRowsConfig) { reconcileHomeRows(baseList, homeRowsConfig) }
+    val working = remember(baseList, homeRowsConfig) {
+        reconcileHomeRows(baseList, homeRowsConfig, onTop = "shortcuts")
+    }
 
     // Edit-mode working copy — isolated from external (real-time) updates while editing;
     // snapshotted fresh on entering edit mode.

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -166,7 +166,7 @@ fun HomeScreen(
         topBar = {
             LandingPageTopBar(
                 editMode = editMode,
-                onRefresh = { homeScreenViewModel.loadRecommendations() },
+                onRefresh = { homeScreenViewModel.loadData() },
                 onToggleEditMode = {
                     if (editMode) {
                         homeScreenViewModel.saveHomeRows(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
@@ -210,8 +210,8 @@ class HomeScreenViewModel(
                     ?.jsonObject?.get("sidebar.shortcuts")
                     ?.jsonArray?.map { it.jsonPrimitive.content }
 
-            if (recommendations != null && shortcutUris != null) {
-                val shortcuts = shortcutUris.mapNotNull {
+            if (recommendations != null) {
+                val shortcuts = shortcutUris?.mapNotNull {
                     mediaItemRepository.fetchMediaItem(
                         Request(
                             command = APICommands.MUSIC_ITEM_BY_URI,
@@ -220,12 +220,12 @@ class HomeScreenViewModel(
                             },
                         ),
                     ).getOrNull()
-                }.map { Shortcut(it) }
+                }?.map { Shortcut(it) }
 
                 _state.update {
                     it.copy(
                         recommendations = DataState.Data(recommendations),
-                        shortcuts = DataState.Data(shortcuts),
+                        shortcuts = if (shortcuts != null) DataState.Data(shortcuts) else DataState.NoData(),
                     )
                 }
             } else {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
@@ -18,7 +18,6 @@ import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.data.repository.MediaItemRepository
 import io.music_assistant.client.player.sendspin.SendspinState
 import io.music_assistant.client.settings.SettingsRepository
-import io.music_assistant.client.ui.Timings
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.action.PlayerAction
 import io.music_assistant.client.ui.compose.common.action.QueueAction
@@ -27,7 +26,6 @@ import io.music_assistant.client.utils.DataConnectionState
 import io.music_assistant.client.utils.SessionState
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -97,8 +95,7 @@ class HomeScreenViewModel(
                         when (val connState = connection.dataConnectionState) {
                             DataConnectionState.Authenticated -> {
                                 if (_state.value.recommendations !is DataState.Data) {
-                                    loadDataJob?.cancel()
-                                    loadDataJob = loadData()
+                                    loadData()
                                 }
                                 // Only show loading if we don't have cached data (e.g. fresh connect).
                                 // During reconnection the existing player list stays visible.
@@ -114,7 +111,7 @@ class HomeScreenViewModel(
                                 when (connState.authProcessState) {
                                     AuthProcessState.NotStarted,
                                     AuthProcessState.InProgress,
-                                    -> {
+                                        -> {
                                         if (_playersState.value !is PlayersState.Data) {
                                             _playersState.update { PlayersState.Loading }
                                         }
@@ -123,7 +120,7 @@ class HomeScreenViewModel(
 
                                     AuthProcessState.LoggedOut,
                                     is AuthProcessState.Failed,
-                                    -> {
+                                        -> {
                                         _playersState.update { PlayersState.NoAuth }
                                         stopJobs()
                                     }
@@ -153,7 +150,7 @@ class HomeScreenViewModel(
                             is SessionState.Disconnected.Error,
                             SessionState.Disconnected.Initial,
                             SessionState.Disconnected.ByUser,
-                            -> {
+                                -> {
                                 _playersState.update { PlayersState.Disconnected }
                                 stopJobs()
                             }
@@ -187,13 +184,25 @@ class HomeScreenViewModel(
         }
     }
 
-    fun loadData(): Job = viewModelScope.launch {
-        _state.update { it.copy(recommendations = DataState.Loading(), shortcuts = DataState.Loading()) }
-        repeat(MAX_RECOMMENDATION_ATTEMPTS) { attempt ->
-            if (attempt > 0) delay(Timings.RETRY_DEBOUNCE)
-            val recommendationsResult =
-                getList<RecommendationFolder>(Request.Library.recommendations())
+    fun loadData() {
+        loadDataJob?.cancel()
 
+        _state.update {
+            it.copy(
+                recommendations = DataState.Loading(),
+                shortcuts = DataState.Loading(),
+            )
+        }
+
+        loadDataJob = viewModelScope.launch {
+            _state.update {
+                it.copy(
+                    recommendations = DataState.Loading(),
+                    shortcuts = DataState.Loading(),
+                )
+            }
+
+            val recommendations = getList<RecommendationFolder>(Request.Library.recommendations())
             val shortcutUris =
                 apiClient.sendRequest(Request(APICommands.AUTH_ME))
                     .getOrNull()?.result
@@ -201,29 +210,28 @@ class HomeScreenViewModel(
                     ?.jsonObject?.get("sidebar.shortcuts")
                     ?.jsonArray?.map { it.jsonPrimitive.content }
 
-            val shortcuts = shortcutUris?.mapNotNull {
-                mediaItemRepository.fetchMediaItem(
-                    Request(
-                        command = APICommands.MUSIC_ITEM_BY_URI,
-                        args = buildJsonObject {
-                            put("uri", JsonPrimitive(it))
-                        },
-                    ),
-                ).getOrNull()
-            }?.map { Shortcut(it) }
+            if (recommendations != null && shortcutUris != null) {
+                val shortcuts = shortcutUris.mapNotNull {
+                    mediaItemRepository.fetchMediaItem(
+                        Request(
+                            command = APICommands.MUSIC_ITEM_BY_URI,
+                            args = buildJsonObject {
+                                put("uri", JsonPrimitive(it))
+                            },
+                        ),
+                    ).getOrNull()
+                }.map { Shortcut(it) }
 
-            recommendationsResult?.let { items ->
                 _state.update {
                     it.copy(
-                        recommendations = DataState.Data(items),
-                        shortcuts = if (shortcuts != null) DataState.Data(shortcuts) else DataState.NoData(),
+                        recommendations = DataState.Data(recommendations),
+                        shortcuts = DataState.Data(shortcuts),
                     )
                 }
-                return@launch
+            } else {
+                _state.update { it.copy(recommendations = DataState.Error()) }
             }
         }
-
-        _state.update { it.copy(recommendations = DataState.Error()) }
     }
 
     fun onPlayClick(
@@ -346,8 +354,10 @@ class HomeScreenViewModel(
                     state.connectionInfo.isTls,
                 ),
             )
+
         is SessionState.Connected.WebRTC ->
             settings.getTokenForServer(settings.getWebRTCServerIdentifier(state.remoteId.rawId))
+
         else -> null
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
@@ -50,7 +50,7 @@ class HomeScreenViewModel(
     private val mediaItemRepository: MediaItemRepository,
 ) : ViewModel() {
     private val jobs = mutableListOf<Job>()
-    private var recommendationsJob: Job? = null
+    private var loadDataJob: Job? = null
 
     private val _links = MutableSharedFlow<String>()
     val links = _links.asSharedFlow()
@@ -70,14 +70,14 @@ class HomeScreenViewModel(
     private val _connectionState = MutableStateFlow<SessionState>(SessionState.Disconnected.Initial)
     val connectionState = _connectionState.asStateFlow()
 
-    private val _recommendationsState = MutableStateFlow(
-        RecommendationsState(
+    private val _state = MutableStateFlow(
+        State(
             shortcuts = DataState.Loading(),
             recommendations = DataState.Loading(),
             homeRowsConfig = settings.homeRowsConfig.value,
         ),
     )
-    val recommendationsState = _recommendationsState.asStateFlow()
+    val state = _state.asStateFlow()
 
     private val _playersState =
         MutableStateFlow<PlayersState>(PlayersState.Loading)
@@ -96,9 +96,9 @@ class HomeScreenViewModel(
                     is SessionState.Connected -> {
                         when (val connState = connection.dataConnectionState) {
                             DataConnectionState.Authenticated -> {
-                                if (_recommendationsState.value.recommendations !is DataState.Data) {
-                                    recommendationsJob?.cancel()
-                                    recommendationsJob = loadData()
+                                if (_state.value.recommendations !is DataState.Data) {
+                                    loadDataJob?.cancel()
+                                    loadDataJob = loadData()
                                 }
                                 // Only show loading if we don't have cached data (e.g. fresh connect).
                                 // During reconnection the existing player list stays visible.
@@ -143,12 +143,12 @@ class HomeScreenViewModel(
                         if (_playersState.value !is PlayersState.Data) {
                             _playersState.update { PlayersState.Loading }
                         }
-                        recommendationsJob?.cancel()
+                        loadDataJob?.cancel()
                         stopJobs()
                     }
 
                     is SessionState.Disconnected -> {
-                        recommendationsJob?.cancel()
+                        loadDataJob?.cancel()
                         when (connection) {
                             is SessionState.Disconnected.Error,
                             SessionState.Disconnected.Initial,
@@ -174,7 +174,7 @@ class HomeScreenViewModel(
 
         viewModelScope.launch {
             settings.homeRowsConfig.collect { config ->
-                _recommendationsState.update { it.copy(homeRowsConfig = config) }
+                _state.update { it.copy(homeRowsConfig = config) }
             }
         }
 
@@ -188,7 +188,7 @@ class HomeScreenViewModel(
     }
 
     fun loadData(): Job = viewModelScope.launch {
-        _recommendationsState.update { it.copy(recommendations = DataState.Loading()) }
+        _state.update { it.copy(recommendations = DataState.Loading(), shortcuts = DataState.Loading()) }
         repeat(MAX_RECOMMENDATION_ATTEMPTS) { attempt ->
             if (attempt > 0) delay(Timings.RETRY_DEBOUNCE)
             val recommendationsResult =
@@ -213,7 +213,7 @@ class HomeScreenViewModel(
             }?.map { Shortcut(it) }
 
             recommendationsResult?.let { items ->
-                _recommendationsState.update {
+                _state.update {
                     it.copy(
                         recommendations = DataState.Data(items),
                         shortcuts = if (shortcuts != null) DataState.Data(shortcuts) else DataState.NoData(),
@@ -223,7 +223,7 @@ class HomeScreenViewModel(
             }
         }
 
-        _recommendationsState.update { it.copy(recommendations = DataState.Error()) }
+        _state.update { it.copy(recommendations = DataState.Error()) }
     }
 
     fun onPlayClick(
@@ -249,7 +249,7 @@ class HomeScreenViewModel(
 
     private fun updateRecommendationsIfNeeded(changed: Track) {
         val recommendationsData =
-            (_recommendationsState.value.recommendations as? DataState.Data)?.data
+            (_state.value.recommendations as? DataState.Data)?.data
                 ?: return
         val updated = recommendationsData.map { row ->
             row.items?.let { itemsList ->
@@ -266,7 +266,7 @@ class HomeScreenViewModel(
                 )
             } ?: row
         }
-        _recommendationsState.update {
+        _state.update {
             it.copy(recommendations = DataState.Data(updated))
         }
     }
@@ -374,7 +374,7 @@ class HomeScreenViewModel(
         settings.setHomeRowsConfig(working + carriedOver)
     }
 
-    data class RecommendationsState(
+    data class State(
         val shortcuts: DataState<List<Shortcut>>,
         val recommendations: DataState<List<RecommendationFolder>>,
         val homeRowsConfig: List<SettingsRepository.HomeRowPref> = emptyList(),

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
@@ -98,7 +98,7 @@ class HomeScreenViewModel(
                             DataConnectionState.Authenticated -> {
                                 if (_recommendationsState.value.recommendations !is DataState.Data) {
                                     recommendationsJob?.cancel()
-                                    recommendationsJob = loadRecommendations()
+                                    recommendationsJob = loadData()
                                 }
                                 // Only show loading if we don't have cached data (e.g. fresh connect).
                                 // During reconnection the existing player list stays visible.
@@ -108,33 +108,6 @@ class HomeScreenViewModel(
                                 stopJobs()
                                 jobs.add(watchPlayersData())
                                 jobs.add(watchSelectedPlayerData())
-
-                                viewModelScope.launch {
-                                    val shortcutUris =
-                                        apiClient.sendRequest(Request(APICommands.AUTH_ME))
-                                            .getOrNull()?.result
-                                            ?.jsonObject?.get("preferences")
-                                            ?.jsonObject?.get("sidebar.shortcuts")
-                                            ?.jsonArray?.map { it.jsonPrimitive.content }
-
-                                    if (shortcutUris != null) {
-                                        val results = shortcutUris.mapNotNull {
-                                            mediaItemRepository.fetchMediaItem(
-                                                Request(
-                                                    command = APICommands.MUSIC_ITEM_BY_URI,
-                                                    args = buildJsonObject {
-                                                        put("uri", JsonPrimitive(it))
-                                                    },
-                                                ),
-                                            ).getOrNull()
-                                        }
-
-                                        val shortcuts = results.map { Shortcut(it) }
-                                        _recommendationsState.update {
-                                            it.copy(shortcuts = DataState.Data(shortcuts))
-                                        }
-                                    }
-                                }
                             }
 
                             is DataConnectionState.AwaitingAuth -> {
@@ -214,18 +187,42 @@ class HomeScreenViewModel(
         }
     }
 
-    fun loadRecommendations(): Job = viewModelScope.launch {
+    fun loadData(): Job = viewModelScope.launch {
         _recommendationsState.update { it.copy(recommendations = DataState.Loading()) }
         repeat(MAX_RECOMMENDATION_ATTEMPTS) { attempt ->
             if (attempt > 0) delay(Timings.RETRY_DEBOUNCE)
-            getList<io.music_assistant.client.data.model.client.items.RecommendationFolder>(
-                Request.Library.recommendations(),
-            )
-                ?.let { items ->
-                    _recommendationsState.update { it.copy(recommendations = DataState.Data(items)) }
-                    return@launch
+            val recommendationsResult =
+                getList<RecommendationFolder>(Request.Library.recommendations())
+
+            val shortcutUris =
+                apiClient.sendRequest(Request(APICommands.AUTH_ME))
+                    .getOrNull()?.result
+                    ?.jsonObject?.get("preferences")
+                    ?.jsonObject?.get("sidebar.shortcuts")
+                    ?.jsonArray?.map { it.jsonPrimitive.content }
+
+            val shortcuts = shortcutUris?.mapNotNull {
+                mediaItemRepository.fetchMediaItem(
+                    Request(
+                        command = APICommands.MUSIC_ITEM_BY_URI,
+                        args = buildJsonObject {
+                            put("uri", JsonPrimitive(it))
+                        },
+                    ),
+                ).getOrNull()
+            }?.map { Shortcut(it) }
+
+            recommendationsResult?.let { items ->
+                _recommendationsState.update {
+                    it.copy(
+                        recommendations = DataState.Data(items),
+                        shortcuts = if (shortcuts != null) DataState.Data(shortcuts) else DataState.NoData(),
+                    )
                 }
+                return@launch
+            }
         }
+
         _recommendationsState.update { it.copy(recommendations = DataState.Error()) }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
@@ -3,6 +3,7 @@ package io.music_assistant.client.ui.compose.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
+import io.music_assistant.client.api.APICommands
 import io.music_assistant.client.api.Request
 import io.music_assistant.client.api.ServiceClient
 import io.music_assistant.client.data.MainDataSource
@@ -35,6 +36,11 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 @OptIn(FlowPreview::class)
 class HomeScreenViewModel(
@@ -102,6 +108,33 @@ class HomeScreenViewModel(
                                 stopJobs()
                                 jobs.add(watchPlayersData())
                                 jobs.add(watchSelectedPlayerData())
+
+                                viewModelScope.launch {
+                                    val shortcutUris =
+                                        apiClient.sendRequest(Request(APICommands.AUTH_ME))
+                                            .getOrNull()?.result
+                                            ?.jsonObject?.get("preferences")
+                                            ?.jsonObject?.get("sidebar.shortcuts")
+                                            ?.jsonArray?.map { it.jsonPrimitive.content }
+
+                                    if (shortcutUris != null) {
+                                        val results = shortcutUris.mapNotNull {
+                                            mediaItemRepository.fetchMediaItem(
+                                                Request(
+                                                    command = APICommands.MUSIC_ITEM_BY_URI,
+                                                    args = buildJsonObject {
+                                                        put("uri", JsonPrimitive(it))
+                                                    },
+                                                ),
+                                            ).getOrNull()
+                                        }
+
+                                        val shortcuts = results.map { Shortcut(it) }
+                                        _recommendationsState.update {
+                                            it.copy(shortcuts = DataState.Data(shortcuts))
+                                        }
+                                    }
+                                }
                             }
 
                             is DataConnectionState.AwaitingAuth -> {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
@@ -9,6 +9,7 @@ import io.music_assistant.client.data.MainDataSource
 import io.music_assistant.client.data.model.client.Player
 import io.music_assistant.client.data.model.client.PlayerData
 import io.music_assistant.client.data.model.client.QueueOption
+import io.music_assistant.client.data.model.client.Shortcut
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Genre
 import io.music_assistant.client.data.model.client.items.RecommendationFolder
@@ -65,6 +66,7 @@ class HomeScreenViewModel(
 
     private val _recommendationsState = MutableStateFlow(
         RecommendationsState(
+            shortcuts = DataState.Loading(),
             recommendations = DataState.Loading(),
             homeRowsConfig = settings.homeRowsConfig.value,
         ),
@@ -343,6 +345,7 @@ class HomeScreenViewModel(
     }
 
     data class RecommendationsState(
+        val shortcuts: DataState<List<Shortcut>>,
         val recommendations: DataState<List<RecommendationFolder>>,
         val homeRowsConfig: List<SettingsRepository.HomeRowPref> = emptyList(),
     )

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
@@ -60,9 +60,11 @@ class HomeScreenViewModel(
     /** Live elapsed-time flow for the slider. Ticks at 500 ms only while playing + subscribed. */
     fun observePosition(queueId: String) = dataSource.positionTracker.observe(queueId)
 
+    private val _connectionState = MutableStateFlow<SessionState>(SessionState.Disconnected.Initial)
+    val connectionState = _connectionState.asStateFlow()
+
     private val _recommendationsState = MutableStateFlow(
         RecommendationsState(
-            connectionState = SessionState.Disconnected.Initial,
             recommendations = DataState.Loading(),
             homeRowsConfig = settings.homeRowsConfig.value,
         ),
@@ -76,7 +78,7 @@ class HomeScreenViewModel(
     init {
         viewModelScope.launch {
             apiClient.sessionState.collect { connection ->
-                _recommendationsState.update { state -> state.copy(connectionState = connection) }
+                _connectionState.value = connection
                 when (connection) {
                     is SessionState.Reconnecting -> {
                         // Preserve UI state during reconnection - don't stop jobs or reload data
@@ -341,7 +343,6 @@ class HomeScreenViewModel(
     }
 
     data class RecommendationsState(
-        val connectionState: SessionState,
         val recommendations: DataState<List<RecommendationFolder>>,
         val homeRowsConfig: List<SettingsRepository.HomeRowPref> = emptyList(),
     )

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
@@ -15,6 +15,7 @@ import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Genre
 import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.data.model.client.items.Track
+import io.music_assistant.client.data.model.server.ServerUser
 import io.music_assistant.client.data.repository.MediaItemRepository
 import io.music_assistant.client.player.sendspin.SendspinState
 import io.music_assistant.client.settings.SettingsRepository
@@ -24,6 +25,7 @@ import io.music_assistant.client.ui.compose.common.action.QueueAction
 import io.music_assistant.client.utils.AuthProcessState
 import io.music_assistant.client.utils.DataConnectionState
 import io.music_assistant.client.utils.SessionState
+import io.music_assistant.client.utils.resultAs
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -36,9 +38,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 
 @OptIn(FlowPreview::class)
 class HomeScreenViewModel(
@@ -203,12 +202,8 @@ class HomeScreenViewModel(
             }
 
             val recommendations = getList<RecommendationFolder>(Request.Library.recommendations())
-            val shortcutUris =
-                apiClient.sendRequest(Request(APICommands.AUTH_ME))
-                    .getOrNull()?.result
-                    ?.jsonObject?.get("preferences")
-                    ?.jsonObject?.get("sidebar.shortcuts")
-                    ?.jsonArray?.map { it.jsonPrimitive.content }
+            val shortcutUris = apiClient.sendRequest(Request(APICommands.AUTH_ME))
+                .resultAs<ServerUser>()?.preferences?.shortcuts
 
             if (recommendations != null) {
                 val shortcuts = shortcutUris?.mapNotNull {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -48,8 +48,6 @@ import io.music_assistant.client.data.model.client.items.Genre
 import io.music_assistant.client.data.model.client.items.Playlist
 import io.music_assistant.client.data.model.client.items.Podcast
 import io.music_assistant.client.data.model.client.items.RecommendationFolder
-import io.music_assistant.client.settings.SettingsRepository
-import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.ToastDuration
 import io.music_assistant.client.ui.compose.common.ToastHost
 import io.music_assistant.client.ui.compose.common.providers.ProviderIcon
@@ -121,8 +119,6 @@ fun MainNavigationRoot(
         }
     }
 
-    val recommendationsState =
-        homeScreenViewModel.recommendationsState.collectAsStateWithLifecycle()
     val playersState by homeScreenViewModel.playersState.collectAsStateWithLifecycle()
     // Single pager state used across all views
     val data = playersState as? HomeScreenViewModel.PlayersState.Data
@@ -148,10 +144,6 @@ fun MainNavigationRoot(
         }
     }
 
-    val connectionState = recommendationsState.value.connectionState
-    val dataState = recommendationsState.value.recommendations
-    val homeRowsConfig = recommendationsState.value.homeRowsConfig
-
     var playerExpanded by remember { mutableStateOf(false) }
 
     val onExpandPlayer = remember { { expanded: Boolean -> playerExpanded = expanded } }
@@ -163,6 +155,7 @@ fun MainNavigationRoot(
     )
     val multiBackStack = remember { MultiBackStack(backStacks) }
 
+    val connectionState = homeScreenViewModel.recommendationsState.collectAsStateWithLifecycle().value.connectionState
     // Apply a pending navigation deep link (musicassistant://app/<page> or the
     // https App/Universal Link). The destination is retained upstream, and we
     // gate on Authenticated + re-key on connectionState so that the transient
@@ -289,8 +282,6 @@ fun MainNavigationRoot(
                                 mainNavEntryProvider(
                                     floatingBarContentPadding,
                                     connectionState,
-                                    dataState,
-                                    homeRowsConfig,
                                     multiBackStack,
                                     homeScreenViewModel,
                                     actionsViewModel,
@@ -323,8 +314,6 @@ fun MainNavigationRoot(
 private fun mainNavEntryProvider(
     contentPadding: PaddingValues,
     connectionState: SessionState,
-    dataState: DataState<List<RecommendationFolder>>,
-    homeRowsConfig: List<SettingsRepository.HomeRowPref>,
     multiBackStack: MultiBackStack<NavKey>,
     homeScreenViewModel: HomeScreenViewModel,
     actionsViewModel: ActionsViewModel,
@@ -341,7 +330,6 @@ private fun mainNavEntryProvider(
                 homeScreenViewModel,
                 contentPadding = contentPadding,
                 connectionState = connectionState,
-                dataState = dataState,
                 onNavigateClick = { item ->
                     when (item) {
                         is Artist,
@@ -370,7 +358,6 @@ private fun mainNavEntryProvider(
                     actionsViewModel.getProviderIcon(provider)
                         ?.let { ProviderIcon(modifier, it) }
                 },
-                homeRowsConfig = homeRowsConfig,
                 actionsViewModel = actionsViewModel,
                 state = homeScreenState,
             )

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -155,13 +155,13 @@ fun MainNavigationRoot(
     )
     val multiBackStack = remember { MultiBackStack(backStacks) }
 
-    val connectionState = homeScreenViewModel.recommendationsState.collectAsStateWithLifecycle().value.connectionState
     // Apply a pending navigation deep link (musicassistant://app/<page> or the
     // https App/Universal Link). The destination is retained upstream, and we
     // gate on Authenticated + re-key on connectionState so that the transient
     // pre-auth MainNavigationRoot instance — torn down during the cold-launch
     // Main→Settings→Main churn — never consumes it; only the authenticated
     // instance that stays on screen applies and clears it.
+    val connectionState by homeScreenViewModel.connectionState.collectAsStateWithLifecycle()
     val pendingDeepLink by deepLinkBus.pending.collectAsStateWithLifecycle()
     LaunchedEffect(pendingDeepLink, connectionState) {
         val dest = pendingDeepLink ?: return@LaunchedEffect
@@ -281,7 +281,7 @@ fun MainNavigationRoot(
                             entries = multiBackStack.toEntries(
                                 mainNavEntryProvider(
                                     floatingBarContentPadding,
-                                    connectionState,
+                                    connectionState is SessionState.Connected,
                                     multiBackStack,
                                     homeScreenViewModel,
                                     actionsViewModel,
@@ -313,7 +313,7 @@ fun MainNavigationRoot(
 @Composable
 private fun mainNavEntryProvider(
     contentPadding: PaddingValues,
-    connectionState: SessionState,
+    isConnected: Boolean,
     multiBackStack: MultiBackStack<NavKey>,
     homeScreenViewModel: HomeScreenViewModel,
     actionsViewModel: ActionsViewModel,
@@ -329,7 +329,7 @@ private fun mainNavEntryProvider(
             HomeScreen(
                 homeScreenViewModel,
                 contentPadding = contentPadding,
-                connectionState = connectionState,
+                isConnected = isConnected,
                 onNavigateClick = { item ->
                     when (item) {
                         is Artist,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -69,6 +69,8 @@ import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.data.model.client.stringResource
 import io.music_assistant.client.data.model.client.toClickContext
 import io.music_assistant.client.settings.ViewMode
+import io.music_assistant.client.ui.compose.common.CenteredProgress
+import io.music_assistant.client.ui.compose.common.CenteredText
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.ExtractedColorsFetcher
 import io.music_assistant.client.ui.compose.common.SortChip
@@ -882,32 +884,12 @@ private fun ChaptersTabContent(
 }
 
 @Composable
-private fun CenteredProgress() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-    ) {
-        CircularProgressIndicator()
-    }
-}
-
-@Composable
 private fun InlineProgress() {
     Box(
         modifier = Modifier.fillMaxWidth().padding(16.dp),
         contentAlignment = Alignment.Center,
     ) {
         CircularProgressIndicator()
-    }
-}
-
-@Composable
-private fun CenteredText(text: String, color: Color = Color.Unspecified) {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text(text = text, color = color)
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryScreen.kt
@@ -1,27 +1,20 @@
 package io.music_assistant.client.ui.compose.library
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarState
@@ -32,13 +25,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.music_assistant.client.ui.compose.common.GridButton
 import io.music_assistant.client.ui.compose.nav.ScreenState
 import io.music_assistant.client.ui.compose.nav.TopBarLayout
 import io.music_assistant.client.utils.libraryItemMinWidth
@@ -114,35 +106,12 @@ private fun LibraryGrid(
         contentPadding = paddingValues,
     ) {
         items(libraryCategories) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable(onClick = { onCategoryClick(it) })
-                    .clip(RoundedCornerShape(8.dp))
-                    .background(MaterialTheme.colorScheme.primaryContainer)
-                    .padding(16.dp),
-            ) {
-                Row(
-                    modifier = Modifier.height(width / ITEM_HEIGHT_RATIO),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
-                ) {
-                    Icon(
-                        modifier = Modifier.size(30.dp),
-                        imageVector = it.icon(),
-                        contentDescription = it.name,
-                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                    )
-
-                    Text(
-                        text = stringResource(it.stringResource()),
-                        style = MaterialTheme.typography.titleMedium,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer,
-                    )
-                }
-            }
+            GridButton(
+                modifier = Modifier.fillMaxWidth().height(width / ITEM_HEIGHT_RATIO),
+                text = stringResource(it.stringResource()),
+                icon = it.icon(),
+                onClick = { onCategoryClick(it) },
+            )
         }
     }
 }
@@ -171,7 +140,7 @@ class LibraryScreenState(
     }
 }
 
-private const val ITEM_HEIGHT_RATIO = 4
+private const val ITEM_HEIGHT_RATIO = 3
 
 @Preview
 @Composable

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
@@ -57,6 +57,7 @@ import io.music_assistant.client.ui.compose.common.clearFocusOnScroll
 import io.music_assistant.client.ui.compose.common.items.AlbumWithMenu
 import io.music_assistant.client.ui.compose.common.items.ArtistWithMenu
 import io.music_assistant.client.ui.compose.common.items.AudiobookWithMenu
+import io.music_assistant.client.ui.compose.common.items.CategoryRow
 import io.music_assistant.client.ui.compose.common.items.GenreWithMenu
 import io.music_assistant.client.ui.compose.common.items.LibraryActions
 import io.music_assistant.client.ui.compose.common.items.PlayHandler
@@ -71,7 +72,6 @@ import io.music_assistant.client.ui.compose.common.items.lazyListKey
 import io.music_assistant.client.ui.compose.common.providers.ProviderIcon
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
-import io.music_assistant.client.ui.compose.home.CategoryRow
 import io.music_assistant.client.ui.compose.nav.ScreenState
 import io.music_assistant.client.ui.compose.nav.TopBarLayout
 import kotlinx.coroutines.CoroutineScope

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/HomeRowsConfigTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/HomeRowsConfigTest.kt
@@ -13,9 +13,14 @@ class HomeRowsConfigTest {
         lazyListKey = id,
     )
 
-    private fun reconcile(serverIds: List<String>, config: List<HomeRowPref>) =
-        reconcileHomeRows(serverIds.map { itemCategory(it) }, config)
+    private fun reconcile(
+        serverIds: List<String>,
+        config: List<HomeRowPref>,
+        onTop: String? = null,
+    ): List<Pair<String, Boolean>> {
+        return reconcileHomeRows(serverIds.map { itemCategory(it) }, config, onTop)
             .map { it.first.id to it.second }
+    }
 
     @Test
     fun `empty config keeps server order with all rows visible`() {
@@ -77,15 +82,29 @@ class HomeRowsConfigTest {
     }
 
     @Test
-    fun `shortcuts is sorted to the top if it's not in config`() {
+    fun `onTop is sorted to the top if it's not in config`() {
         val config = listOf(
             HomeRowPref("c", true),
             HomeRowPref("a", true),
             HomeRowPref("b", true),
         )
         assertEquals(
-            listOf("shortcuts" to true, "c" to true, "a" to true, "b" to true),
-            reconcile(listOf("a", "b", "c", "shortcuts"), config),
+            listOf("blah" to true, "c" to true, "a" to true, "b" to true),
+            reconcile(listOf("a", "b", "c", "blah"), config, onTop = "blah"),
+        )
+    }
+
+    @Test
+    fun `onTop is not sorted to the top if it is in config`() {
+        val config = listOf(
+            HomeRowPref("c", true),
+            HomeRowPref("a", true),
+            HomeRowPref("blah", true),
+            HomeRowPref("b", true),
+        )
+        assertEquals(
+            listOf("c" to true, "a" to true, "blah" to true, "b" to true),
+            reconcile(listOf("a", "b", "c", "blah"), config, onTop = "blah"),
         )
     }
 }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/HomeRowsConfigTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/HomeRowsConfigTest.kt
@@ -1,22 +1,21 @@
 package io.music_assistant.client.ui.compose.home
 
-import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.settings.SettingsRepository.HomeRowPref
+import io.music_assistant.client.ui.compose.common.items.ItemCategory
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class HomeRowsConfigTest {
-    private fun folder(id: String) = RecommendationFolder(
-        itemId = id,
-        provider = "test",
-        name = id,
-        uri = null,
-        images = emptyMap(),
+    private fun itemCategory(id: String) = ItemCategory(
+        id = id,
+        title = id,
+        items = emptyList(),
+        lazyListKey = id,
     )
 
     private fun reconcile(serverIds: List<String>, config: List<HomeRowPref>) =
-        reconcileHomeRows(serverIds.map { folder(it) }, config)
-            .map { it.first.itemId to it.second }
+        reconcileHomeRows(serverIds.map { itemCategory(it) }, config)
+            .map { it.first.id to it.second }
 
     @Test
     fun `empty config keeps server order with all rows visible`() {
@@ -74,6 +73,19 @@ class HomeRowsConfigTest {
         assertEquals(
             listOf("a" to true, "b" to true),
             reconcile(listOf("a", "b"), config),
+        )
+    }
+
+    @Test
+    fun `shortcuts is sorted to the top if it's not in config`() {
+        val config = listOf(
+            HomeRowPref("c", true),
+            HomeRowPref("a", true),
+            HomeRowPref("b", true),
+        )
+        assertEquals(
+            listOf("shortcuts" to true, "c" to true, "a" to true, "b" to true),
+            reconcile(listOf("a", "b", "c", "shortcuts"), config),
         )
     }
 }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/HomeRowsConfigTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/HomeRowsConfigTest.kt
@@ -2,13 +2,14 @@ package io.music_assistant.client.ui.compose.home
 
 import io.music_assistant.client.settings.SettingsRepository.HomeRowPref
 import io.music_assistant.client.ui.compose.common.items.ItemCategory
+import io.music_assistant.client.ui.compose.common.toDisplayString
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class HomeRowsConfigTest {
     private fun itemCategory(id: String) = ItemCategory(
         id = id,
-        title = id,
+        title = id.toDisplayString(),
         items = emptyList(),
         lazyListKey = id,
     )


### PR DESCRIPTION
Work towards #589

<img width="270" height="600" alt="Screenshot_20260620_141414" src="https://github.com/user-attachments/assets/9860a4c1-7dce-4a81-a529-652fc2c29115" />

This adds shortcuts as a reorderable row (defaulting to the top) on the Home screen. Adding/removing shortcuts can be a follow-up - this lays enough foundation for a review and is useful on its own.

TODO:
- [x] Tidy up shortcut `ItemCategory` hardcoded values
- [x] Work out if we can decode `sidebar.shortcuts` key with `@Serializable` classes (if not, we can feedback about this to server team)
- [x] Work out if there's a better way to grab multiple items via URIs than with multiple `item_by_uri` commands