### PR TITLE
Fix reconnecting progress state for Home

### DIFF
--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/HomeTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/HomeTest.kt
@@ -70,4 +70,17 @@ class HomeTest {
         homePage.refresh()
             .assertMediaDisplayed(album.name)
     }
+
+    @Test
+    fun `shows progress while reconnecting`() {
+        val album = ServerMediaItemFixtures.album()
+        serviceClient.addToLibrary(album)
+        val homePage = launchLoggedInApp(composeTestRule, serviceClient)
+
+        serviceClient.setConnected(false)
+        homePage.assertProgress()
+
+        serviceClient.setConnected(true)
+        homePage.assertMediaDisplayed(album.name)
+    }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -683,6 +683,37 @@ class FakeServiceClient(private val settingsRepository: SettingsRepository) : Se
         this.legacyVersion = version
     }
 
+    fun setConnected(connected: Boolean) {
+        if (connected) {
+            _sessionState.update {
+                when (it) {
+                    is SessionState.Reconnecting.Direct -> {
+                        SessionState.Connected.Direct(
+                            connectionInfo = it.connectionInfo,
+                            connectionData = it.connectionData,
+                        )
+                    }
+
+                    else -> error("Unhandled SessionState: $it")
+                }
+            }
+        } else {
+            _sessionState.update {
+                when (it) {
+                    is SessionState.Connected.Direct -> {
+                        SessionState.Reconnecting.Direct(
+                            attempt = 1,
+                            connectionInfo = it.connectionInfo,
+                            connectionData = it.connectionData,
+                        )
+                    }
+
+                    else -> error("Unhandled SessionState: $it")
+                }
+            }
+        }
+    }
+
     enum class LegacyVersion {
         V2_8,
     }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/HomePage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/HomePage.kt
@@ -1,6 +1,8 @@
 package io.music_assistant.client.support.pages
 
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasProgressBarRangeInfo
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -58,6 +60,13 @@ class HomePage(composeTestRule: ComposeTestRule) : ComposePage(composeTestRule) 
 
     fun assertErrorLoadingData(): HomePage {
         composeTestRule.onNodeWithText(Res.string.library_error.get()).assertIsDisplayed()
+        return this
+    }
+
+    fun assertProgress(): HomePage {
+        composeTestRule.onNode(hasProgressBarRangeInfo(ProgressBarRangeInfo.Indeterminate))
+            .assertIsDisplayed()
+
         return this
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/CenteredProgress.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/CenteredProgress.kt
@@ -2,6 +2,7 @@ package io.music_assistant.client.ui.compose.common
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.progressSemantics
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -13,6 +14,6 @@ fun CenteredProgress() {
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
     ) {
-        CircularProgressIndicator()
+        CircularProgressIndicator(Modifier.progressSemantics())
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -148,15 +148,13 @@ fun HomeScreen(
         },
         topAppBarState = state.topAppBarState,
     ) {
-        if (!isConnected || recommendationsState !is DataState.Data) {
-            if (recommendationsState is DataState.Loading) {
-                CenteredProgress()
-            } else {
-                CenteredText(
-                    text = stringResource(Res.string.library_error),
-                    color = MaterialTheme.colorScheme.error,
-                )
-            }
+        if (!isConnected || recommendationsState is DataState.Loading) {
+            CenteredProgress()
+        } else if (recommendationsState !is DataState.Data) {
+            CenteredText(
+                text = stringResource(Res.string.library_error),
+                color = MaterialTheme.colorScheme.error,
+            )
         } else {
             val rowContent: @Composable (ItemCategory) -> Unit = {
                 CategoryRow(


### PR DESCRIPTION
This fixes the app showing "Error loading data" when reconnecting while on the Home screen.

We could potentially just show any existing data in this state, but this just restores the previous behaviour (showing the progress indicator) and adds a test so it'll be easy to make an explicit change like that in the future.