### PR TITLE
Add DirectTransport reconnect diagnostics

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/DirectTransport.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/DirectTransport.kt
@@ -38,7 +38,7 @@ class DirectTransport(
     private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
         logger.e(throwable) { "Uncaught exception in DirectTransport scope" }
         when (_state.value) {
-            TransportState.Connected -> verifyConnection()
+            TransportState.Connected -> verifyConnection(probeReason = "direct_transport_scope_exception")
             TransportState.Connecting, is TransportState.Reconnecting ->
                 _state.value = TransportState.Failed(
                     Exception("Recovery machinery died: ${throwable.message}", throwable),
@@ -67,6 +67,9 @@ class DirectTransport(
 
     @Volatile
     private var messageCounter = 0L
+
+    private fun Job?.lifecycleLabel(): String =
+        this?.let { "active=${it.isActive},cancelled=${it.isCancelled},completed=${it.isCompleted}" } ?: "none"
 
     override fun connect() {
         connectionJob?.cancel()
@@ -148,7 +151,7 @@ class DirectTransport(
         }
     }
 
-    override fun verifyConnection(timeoutMs: Long) {
+    override fun verifyConnection(timeoutMs: Long, probeReason: String) {
         val s = session ?: return
         val countBefore = messageCounter
         scope.launch {
@@ -156,21 +159,30 @@ class DirectTransport(
                 s.send(Frame.Ping(byteArrayOf()))
                 true
             } catch (e: Exception) {
-                logger.i { "Connection probe failed immediately: ${e.message}" }
+                logger.i {
+                    "Direct connection probe failed immediately: probeReason=$probeReason " +
+                        "state=${_state.value} messageCounterBefore=$countBefore " +
+                        "error=${e.message ?: "no-message"}"
+                }
                 false
             }
 
             if (!sendOk) {
-                initiateReconnect()
+                initiateReconnect("probe_ping_failed:$probeReason")
                 return@launch
             }
 
             delay(timeoutMs)
 
             // If no messages arrived and session unchanged — connection is dead
-            if (messageCounter == countBefore && session === s && _state.value == TransportState.Connected) {
-                logger.i { "No activity within ${timeoutMs}ms after probe — reconnecting" }
-                initiateReconnect()
+            val countAfter = messageCounter
+            if (countAfter == countBefore && session === s && _state.value == TransportState.Connected) {
+                logger.i {
+                    "Direct connection probe timed out: probeReason=$probeReason timeoutMs=$timeoutMs " +
+                        "messageCounterBefore=$countBefore messageCounterAfter=$countAfter " +
+                        "state=${_state.value}"
+                }
+                initiateReconnect("probe_timeout:$probeReason")
             }
         }
     }
@@ -199,7 +211,12 @@ class DirectTransport(
      * Transition to Reconnecting BEFORE nulling the session, so any concurrent
      * sendRequest sees a non-Connected transport state and skips disconnect(Error).
      */
-    private fun initiateReconnect() {
+    private fun initiateReconnect(reason: String) {
+        logger.i {
+            "Direct reconnect initiated: reason=$reason state=${_state.value} " +
+                "connectionJob=${connectionJob.lifecycleLabel()} sessionPresent=${session != null} " +
+                "messageCounter=$messageCounter"
+        }
         _state.value = TransportState.Reconnecting(0)
         connectionJob?.cancel()
         val s = session

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -310,7 +310,7 @@ class KtorServiceClient(
         val elapsed = currentTimeMillis() - backgroundedAt
         if (elapsed > STALE_CONNECTION_THRESHOLD_MS && state is SessionState.Connected) {
             logger.i { "External consumer active: probing connection after ${elapsed}ms in background" }
-            transport?.verifyConnection()
+            transport?.verifyConnection(probeReason = "external_consumer_active")
         }
     }
 
@@ -388,7 +388,7 @@ class KtorServiceClient(
         val elapsed = currentTimeMillis() - backgroundedAt
         if (elapsed > STALE_CONNECTION_THRESHOLD_MS && state is SessionState.Connected) {
             logger.i { "App foregrounded: probing connection after ${elapsed}ms in background" }
-            transport?.verifyConnection()
+            transport?.verifyConnection(probeReason = "app_foreground")
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/TransportState.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/TransportState.kt
@@ -24,7 +24,7 @@ interface Transport {
      * [timeoutMs], transitions to [TransportState.Reconnecting] and reconnects.
      * Default no-op for transports with built-in keepalive (e.g. WebRTC ICE).
      */
-    fun verifyConnection(timeoutMs: Long = 1000) {}
+    fun verifyConnection(timeoutMs: Long = 1000, probeReason: String = "unknown_caller") {}
 
     /** Release the transport's coroutine scope. Call [disconnect] first; unusable after. */
     fun close() {}


### PR DESCRIPTION
I was trying to fix a crash I experienced locally but I couldn't see exactly what was happening when we died somewhere in kotlin/native. That is, I could see _what_ exception was being thrown just not _why_. This PR just adds logging around the verifyConnection() function to hopefully help with that (and any other (re-)connection-related bugs in the future).