### PR TITLE
feat(carplay): wire Car Tabs setting to the browse-grid category list

### DIFF
--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
@@ -31,6 +31,8 @@ import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.settings.carBulkActions
 import io.music_assistant.client.settings.carTapAction
 import io.music_assistant.client.settings.toCarDispatch
+import io.music_assistant.client.ui.compose.library.LibraryCategory
+import io.music_assistant.client.ui.compose.library.carTabCategories
 import io.music_assistant.client.utils.HasConnectionData
 import io.music_assistant.client.utils.currentTimeMillis
 import kotlinx.cinterop.BetaInteropApi
@@ -433,6 +435,25 @@ object KmpHelper : KoinComponent {
             ?: DefaultClickAction.PLAY_NOW
         val dispatch = action.toCarDispatch()
         return if (dispatchLocal(item, dispatch.option, dispatch.radioMode)) action.name else null
+    }
+
+    /**
+     * The ordered, enabled CarPlay browse-grid categories from the user's Car Tabs setting.
+     * Returns LibraryCategory.name strings (e.g. "ARTISTS", "ALBUMS") so Swift can map each
+     * to its fetcher and icon. Falls back to [carTabCategories] when no config is stored.
+     * Tracks and Genres are excluded because they are not in [carTabCategories].
+     */
+    fun carBrowseCategories(): List<String> {
+        val stored = settingsRepository.carTabsConfig.value
+            ?: return carTabCategories.map { it.name }
+        val parsed = stored.mapNotNull { pref ->
+            if (!pref.enabled) return@mapNotNull null
+            runCatching { LibraryCategory.valueOf(pref.name) }.getOrNull()
+                ?.takeIf { it in carTabCategories }
+        }
+        val present = parsed.toSet()
+        val missing = carTabCategories.filter { it !in present }
+        return (parsed + missing).map { it.name }
     }
 
     // MARK: - Library Actions (Siri)

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
@@ -447,13 +447,15 @@ object KmpHelper : KoinComponent {
         val stored = settingsRepository.carTabsConfig.value
             ?: return carTabCategories.map { it.name }
         val parsed = stored.mapNotNull { pref ->
-            if (!pref.enabled) return@mapNotNull null
             runCatching { LibraryCategory.valueOf(pref.name) }.getOrNull()
                 ?.takeIf { it in carTabCategories }
+                ?.let { it to pref.enabled }
         }
-        val present = parsed.toSet()
-        val missing = carTabCategories.filter { it !in present }
-        return (parsed + missing).map { it.name }
+        val present = parsed.map { it.first }.toSet()
+        val missing = carTabCategories.filter { it !in present }.map { it to true }
+        return (parsed + missing)
+            .filter { (_, enabled) -> enabled }
+            .map { (category, _) -> category.name }
     }
 
     // MARK: - Library Actions (Siri)

--- a/iosApp/iosApp/CarPlay/CarPlayContentManager.swift
+++ b/iosApp/iosApp/CarPlay/CarPlayContentManager.swift
@@ -149,6 +149,13 @@ class CarPlayContentManager {
 
     // MARK: - Configurable car actions (shared with Android Auto via SettingsRepository)
 
+    /// Ordered, enabled CarPlay browse-grid category names from the user's Car Tabs setting.
+    /// Returns LibraryCategory.name strings (e.g. "ARTISTS", "ALBUMS"). Falls back to the
+    /// default tab set when no config has been stored.
+    func carBrowseCategories() -> [String] {
+        KmpHelper.shared.carBrowseCategories()
+    }
+
     /// Ordered, CarPlay-supported bulk-action names configured for a browsable container's kind.
     func bulkActionNames(for item: AppMediaItem) -> [String] {
         KmpHelper.shared.carBulkActionNames(item: item)

--- a/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
+++ b/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
@@ -363,17 +363,25 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
         guard let strings = strings else { return }
         let imageSize = CGSize(width: 100, height: 100)
         let manager = CarPlayContentManager.shared
+
+        // Full catalog of CarPlay-supported browse categories, keyed by LibraryCategory.name.
         // Symbols match Material Design icons from HomeScreen.kt LibraryRow;
         // titles come from the shared catalog so they follow the app locale.
-        let categories: [(title: String, symbol: String, fetcher: (@escaping ([CPListItem]?) -> Void) -> Void)] = [
-            (strings.artists,    "mic.fill",                          manager.fetchArtists),       // Icons.Default.Mic
-            (strings.albums,     "opticaldisc.fill",                  manager.fetchAlbums),        // Icons.Default.Album
-            (strings.tracks,     "music.note",                        manager.fetchTracks),        // Icons.Default.MusicNote
-            (strings.playlists,  "list.bullet.rectangle.fill",        manager.fetchPlaylists),     // Icons.AutoMirrored.Filled.FeaturedPlayList
-            (strings.audiobooks, "book.fill",                         manager.fetchAudiobooks),    // Icons.AutoMirrored.Filled.MenuBook
-            (strings.podcasts,   "antenna.radiowaves.left.and.right", manager.fetchPodcasts),      // Icons.Default.Podcasts
-            (strings.radio,      "radio.fill",                        manager.fetchRadioStations), // Icons.Default.Radio
+        typealias CategoryEntry = (title: String, symbol: String, fetcher: (@escaping ([CPListItem]?) -> Void) -> Void)
+        let allCategories: [String: CategoryEntry] = [
+            "ARTISTS":    (strings.artists,    "mic.fill",                          manager.fetchArtists),
+            "ALBUMS":     (strings.albums,     "opticaldisc.fill",                  manager.fetchAlbums),
+            "PLAYLISTS":  (strings.playlists,  "list.bullet.rectangle.fill",        manager.fetchPlaylists),
+            "PODCASTS":   (strings.podcasts,   "antenna.radiowaves.left.and.right", manager.fetchPodcasts),
+            "RADIOS":     (strings.radio,      "radio.fill",                        manager.fetchRadioStations),
+            "AUDIOBOOKS": (strings.audiobooks, "book.fill",                         manager.fetchAudiobooks),
         ]
+
+        // Apply the user's Car Tabs ordering and visibility (Settings → Car → Tabs).
+        // Falls back to the full default set when no config is stored.
+        let configuredNames = manager.carBrowseCategories()
+        let categories: [CategoryEntry] = configuredNames.compactMap { allCategories[$0] }
+
         let buttons = categories.map { category -> CPGridButton in
             let image = Self.dynamicCategoryImage(symbol: category.symbol, size: imageSize)
             return CPGridButton(titleVariants: [category.title], image: image) { [weak self] _ in


### PR DESCRIPTION
A fixup of https://github.com/music-assistant/mobile-app/pull/610

Original description:


Summary

CarPlay now honors the Car Settings tab/action preferences configured in Settings → Car.

Browse grid tabs: The Browse grid now reads SettingsRepository.carTabsConfig (the same store Android Auto uses) via a new carBrowseCategories() bridge method in KmpHelper. Categories are shown in the user-configured order; disabled categories are hidden; unconfigured categories appear in the default order.
Item tap actions: Already wired in a prior PR via KmpHelper.playCarDefaultTap. No change needed.
Bulk actions: Already wired via KmpHelper.carBulkActionNames / playCarAction. No change needed.
Note: a full iOS/CarPlay build requires Xcode and the KMP toolchain; CI is the verification gate for compilation.

Why this matters

Issue https://github.com/music-assistant/mobile-app/issues/576 reported that changing the Car Settings tabs and item action preferences had no effect on the CarPlay UI. The settings were persisted but the CarPlay layer did not read them. Maintainer seadowg confirmed 2025-06-11 the issue is purely about the settings not affecting the CarPlay UI.

Fixes https://github.com/music-assistant/mobile-app/issues/576