### PR TITLE
feat: iOS lock-screen and media widget skip back/forward for long-form content

### DIFF
--- a/androidApp/src/main/kotlin/io/music_assistant/client/services/SharedMediaSessionManager.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/services/SharedMediaSessionManager.kt
@@ -25,6 +25,7 @@ import io.music_assistant.client.data.MainDataSource
 import io.music_assistant.client.data.model.client.PlayerData
 import io.music_assistant.client.data.model.client.RepeatMode
 import io.music_assistant.client.data.model.client.items.AppMediaItem
+import io.music_assistant.client.data.model.client.items.LongFormSeekDefaults
 import io.music_assistant.client.ui.compose.common.action.PlayerAction
 import io.music_assistant.client.ui.compose.common.action.QueueAction
 import kotlinx.coroutines.CoroutineScope
@@ -292,8 +293,8 @@ class SharedMediaSessionManager(
 
             override fun onCustomAction(action: String, extras: Bundle?) {
                 when (action) {
-                    "ACTION_SEEK_BACK" -> act(PlayerAction.SeekBy(-10))
-                    "ACTION_SEEK_FORWARD" -> act(PlayerAction.SeekBy(30))
+                    "ACTION_SEEK_BACK" -> act(PlayerAction.SeekBy(-LongFormSeekDefaults.BACK_SECONDS))
+                    "ACTION_SEEK_FORWARD" -> act(PlayerAction.SeekBy(LongFormSeekDefaults.FORWARD_SECONDS))
                     "ACTION_SWITCH_PLAYER" -> dataSource.switchSessionPlayer()
                     "ACTION_TOGGLE_SHUFFLE" -> currentPlayer()?.let { pd ->
                         pd.queueInfo?.let {

--- a/composeApp/src/androidMain/kotlin/io/music_assistant/client/player/MediaPlayerController.android.kt
+++ b/composeApp/src/androidMain/kotlin/io/music_assistant/client/player/MediaPlayerController.android.kt
@@ -556,12 +556,17 @@ actual class MediaPlayerController actual constructor(platformContext: PlatformC
         duration: Double?,
         elapsedTime: Double?,
         playbackRate: Double,
+        isLongFormContent: Boolean,
     ) {
         // Android handles Now Playing via MediaSession, not implemented here
     }
 
     actual fun clearNowPlaying() {
         // Android handles Now Playing via MediaSession, not implemented here
+    }
+
+    actual fun setLongFormSeekIntervals(backSeconds: Long, forwardSeconds: Long) {
+        // Android handles seek intervals via MediaSession custom actions, not here
     }
 
     actual fun release() {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerController.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerController.kt
@@ -502,6 +502,10 @@ class LocalPlayerController(
                             command.removePrefix("seek:").toDoubleOrNull()?.let { position ->
                                 handleLocalCommand(playerData, PlayerAction.SeekTo(position.toLong()))
                             }
+                        } else if (command.startsWith("seek_by:")) {
+                            command.removePrefix("seek_by:").toLongOrNull()?.let { offset ->
+                                handleLocalCommand(playerData, PlayerAction.SeekBy(offset))
+                            }
                         } else {
                             log.w { "Unknown remote command: $command" }
                         }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -19,6 +19,7 @@ import io.music_assistant.client.data.model.client.Queue
 import io.music_assistant.client.data.model.client.QueueInfo
 import io.music_assistant.client.data.model.client.isBefore
 import io.music_assistant.client.data.model.client.items.AppMediaItem
+import io.music_assistant.client.data.model.client.items.LongFormSeekDefaults
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.data.model.client.items.image
 import io.music_assistant.client.data.model.client.items.isLongFormSpokenContent
@@ -45,7 +46,6 @@ import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.Timings
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.StaleReason
-import io.music_assistant.client.data.model.client.items.LongFormSeekDefaults
 import io.music_assistant.client.ui.compose.common.action.PlayerAction
 import io.music_assistant.client.ui.compose.common.action.QueueAction
 import io.music_assistant.client.ui.compose.common.icons.BookshelfIcon

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -21,6 +21,7 @@ import io.music_assistant.client.data.model.client.isBefore
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.data.model.client.items.image
+import io.music_assistant.client.data.model.client.items.isLongFormSpokenContent
 import io.music_assistant.client.data.model.server.DspConfig
 import io.music_assistant.client.data.model.server.DspConfigPreset
 import io.music_assistant.client.data.model.server.ProviderManifest
@@ -44,6 +45,7 @@ import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.Timings
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.StaleReason
+import io.music_assistant.client.data.model.client.items.LongFormSeekDefaults
 import io.music_assistant.client.ui.compose.common.action.PlayerAction
 import io.music_assistant.client.ui.compose.common.action.QueueAction
 import io.music_assistant.client.ui.compose.common.icons.BookshelfIcon
@@ -274,6 +276,11 @@ class MainDataSource(
     private var updateJob: Job? = null
 
     init {
+        mediaPlayerController.setLongFormSeekIntervals(
+            LongFormSeekDefaults.BACK_SECONDS,
+            LongFormSeekDefaults.FORWARD_SECONDS,
+        )
+
         // Re-fetch server players/queues after Sendspin registers (state → Ready).
         launch {
             localPlayerController.needsServerRefresh.collect { updatePlayersAndQueues() }
@@ -689,6 +696,7 @@ class MainDataSource(
                             } ?: pd.queueInfo.elapsedTime,
                             isPlaying = pd.player.isPlaying,
                             isPositionFrozen = positionTracker.isFrozenUntilConfirmed(pd.queueInfo.id),
+                            isLongFormContent = track.isLongFormSpokenContent,
                         )
                     }
                 }
@@ -704,6 +712,7 @@ class MainDataSource(
                             duration = snapshot.duration,
                             elapsedTime = snapshot.elapsedTime,
                             playbackRate = if (snapshot.isPlaying && !snapshot.isPositionFrozen) 1.0 else 0.0,
+                            isLongFormContent = snapshot.isLongFormContent,
                         )
                     }
                 }
@@ -738,6 +747,7 @@ class MainDataSource(
             val elapsedTime: Double?,
             val isPlaying: Boolean,
             val isPositionFrozen: Boolean = false,
+            val isLongFormContent: Boolean,
         ) : NowPlayingSnapshot
 
         companion object {
@@ -773,6 +783,7 @@ class MainDataSource(
                 if (a.duration != b.duration) return false
                 if (a.isPlaying != b.isPlaying) return false
                 if (a.isPositionFrozen != b.isPositionFrozen) return false
+                if (a.isLongFormContent != b.isLongFormContent) return false
                 val ae = a.elapsedTime
                 val be = b.elapsedTime
                 return when {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/AppMediaItem.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/AppMediaItem.kt
@@ -36,6 +36,11 @@ interface PlayableItem {
 val PlayableItem?.isLongFormSpokenContent: Boolean
     get() = this is Audiobook || this is PodcastEpisode
 
+object LongFormSeekDefaults {
+    const val BACK_SECONDS = 10L
+    const val FORWARD_SECONDS = 30L
+}
+
 /**
  * Items whose played/unplayed state can be marked on the server. Retains the original
  * [source] DTO so it can be echoed back verbatim — the server's `music/mark_played`

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/MediaPlayerController.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/MediaPlayerController.kt
@@ -61,9 +61,12 @@ expect class MediaPlayerController(platformContext: PlatformContext) {
         duration: Double?,
         elapsedTime: Double?,
         playbackRate: Double,
+        isLongFormContent: Boolean,
     )
 
     fun clearNowPlaying()
+
+    fun setLongFormSeekIntervals(backSeconds: Long, forwardSeconds: Long)
 }
 
 expect class PlatformContext

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerControls.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerControls.kt
@@ -28,6 +28,7 @@ import io.music_assistant.client.data.model.client.RepeatMode
 import io.music_assistant.client.data.model.client.items.Audiobook
 import io.music_assistant.client.data.model.client.items.isLongFormSpokenContent
 import io.music_assistant.client.ui.alphaOn
+import io.music_assistant.client.data.model.client.items.LongFormSeekDefaults
 import io.music_assistant.client.ui.compose.common.action.PlayerAction
 import io.music_assistant.client.ui.compose.common.icons.PauseIcon
 import io.music_assistant.client.ui.compose.common.icons.PlayIcon
@@ -81,7 +82,7 @@ fun PlayerControls(
                         tint = tint,
                         size = smallButtonSize,
                         enabled = playerEnabled && buttonsEnabled,
-                    ) { playerAction(playerData, PlayerAction.SeekBy(-10)) }
+                    ) { playerAction(playerData, PlayerAction.SeekBy(-LongFormSeekDefaults.BACK_SECONDS)) }
                 } else {
                     ActionButton(
                         icon = if (it.shuffleEnabled) {
@@ -157,7 +158,7 @@ fun PlayerControls(
                         tint = tint,
                         size = smallButtonSize,
                         enabled = playerEnabled && buttonsEnabled,
-                    ) { playerAction(playerData, PlayerAction.SeekBy(30)) }
+                    ) { playerAction(playerData, PlayerAction.SeekBy(LongFormSeekDefaults.FORWARD_SECONDS)) }
                 } else {
                     val repeatMode = it.repeatMode
                     ActionButton(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerControls.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerControls.kt
@@ -26,9 +26,9 @@ import io.music_assistant.client.data.model.client.PlayerData
 import io.music_assistant.client.data.model.client.PlayerDataFixtures
 import io.music_assistant.client.data.model.client.RepeatMode
 import io.music_assistant.client.data.model.client.items.Audiobook
+import io.music_assistant.client.data.model.client.items.LongFormSeekDefaults
 import io.music_assistant.client.data.model.client.items.isLongFormSpokenContent
 import io.music_assistant.client.ui.alphaOn
-import io.music_assistant.client.data.model.client.items.LongFormSeekDefaults
 import io.music_assistant.client.ui.compose.common.action.PlayerAction
 import io.music_assistant.client.ui.compose.common.icons.PauseIcon
 import io.music_assistant.client.ui.compose.common.icons.PlayIcon

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/NowPlayingSnapshotDedupTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/NowPlayingSnapshotDedupTest.kt
@@ -27,6 +27,7 @@ class NowPlayingSnapshotDedupTest {
         duration = 240.0,
         elapsedTime = 30.0,
         isPlaying = true,
+        isLongFormContent = false,
     )
 
     @Test

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/player/MediaPlayerController.ios.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/player/MediaPlayerController.ios.kt
@@ -90,6 +90,7 @@ actual class MediaPlayerController actual constructor(platformContext: PlatformC
         duration: Double?,
         elapsedTime: Double?,
         playbackRate: Double,
+        isLongFormContent: Boolean,
     ) {
         PlatformPlayerProvider.player?.updateNowPlaying(
             title,
@@ -99,11 +100,16 @@ actual class MediaPlayerController actual constructor(platformContext: PlatformC
             duration,
             elapsedTime,
             playbackRate,
+            isLongFormContent,
         )
     }
 
     actual fun clearNowPlaying() {
         PlatformPlayerProvider.player?.clearNowPlaying()
+    }
+
+    actual fun setLongFormSeekIntervals(backSeconds: Long, forwardSeconds: Long) {
+        PlatformPlayerProvider.player?.setLongFormSeekIntervals(backSeconds, forwardSeconds)
     }
 
     fun setRemoteCommandHandler(handler: RemoteCommandHandler?) {

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/player/PlatformAudioPlayer.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/player/PlatformAudioPlayer.kt
@@ -50,8 +50,11 @@ interface PlatformAudioPlayer {
         duration: Double?,
         elapsedTime: Double?,
         playbackRate: Double,
+        isLongFormContent: Boolean,
     )
     fun clearNowPlaying()
+
+    fun setLongFormSeekIntervals(backSeconds: Long, forwardSeconds: Long)
 
     // Remote command handler (set by Kotlin to receive play/pause/next/prev events)
     fun setRemoteCommandHandler(handler: RemoteCommandHandler?)

--- a/iosApp/NativeAudioController.swift
+++ b/iosApp/NativeAudioController.swift
@@ -423,7 +423,8 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
         artworkUrl: String?,
         duration: KotlinDouble?,
         elapsedTime: KotlinDouble?,
-        playbackRate: Double
+        playbackRate: Double,
+        isLongFormContent: Bool
     ) {
         NowPlayingManager.shared.updateNowPlayingInfo(
             title: title,
@@ -432,7 +433,15 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
             artworkUrl: artworkUrl,
             duration: duration?.doubleValue,
             elapsedTime: elapsedTime?.doubleValue,
-            playbackRate: playbackRate
+            playbackRate: playbackRate,
+            isLongFormContent: isLongFormContent
+        )
+    }
+
+    func setLongFormSeekIntervals(backSeconds: Int64, forwardSeconds: Int64) {
+        NowPlayingManager.shared.setLongFormSeekIntervals(
+            backSeconds: backSeconds,
+            forwardSeconds: forwardSeconds
         )
     }
 

--- a/iosApp/NowPlayingManager.swift
+++ b/iosApp/NowPlayingManager.swift
@@ -24,6 +24,9 @@ class NowPlayingManager {
     private var currentTitle: String?
     private var currentArtist: String?
     private var currentAlbum: String?
+    private var currentIsLongFormContent: Bool?
+    private var currentLongFormSeekBackSeconds: Int64?
+    private var currentLongFormSeekForwardSeconds: Int64?
 
     // MARK: - Logging
     private static let logTag = "NowPlayingManager"
@@ -111,8 +114,11 @@ class NowPlayingManager {
         artworkUrl: String?,
         duration: Double?,
         elapsedTime: Double?,
-        playbackRate: Double
+        playbackRate: Double,
+        isLongFormContent: Bool
     ) {
+        updateRemoteCommandMode(isLongFormContent: isLongFormContent)
+
         let newIdentifier = contentIdentifier(
             title: title, artist: artist, album: album, duration: duration
         )
@@ -288,6 +294,7 @@ class NowPlayingManager {
             MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
             self?.cachedArtwork = nil
             self?.updateCurrentState(title: nil, artist: nil, album: nil)
+            self?.updateRemoteCommandMode(isLongFormContent: false)
         }
     }
 
@@ -317,8 +324,10 @@ class NowPlayingManager {
         func addTarget(_ command: MPRemoteCommand, cmd: String) {
             command.isEnabled = true
             command.addTarget { [weak self] _ in
-                self?.logDebug("Remote command received: \(cmd)")
-                self?.commandHandler?(cmd)
+                guard let self = self else { return .commandFailed }
+                let resolvedCommand = self.resolveRemoteCommand(cmd)
+                self.logDebug("Remote command received: \(resolvedCommand)")
+                self.commandHandler?(resolvedCommand)
                 return .success
             }
         }
@@ -328,6 +337,10 @@ class NowPlayingManager {
         addTarget(commandCenter.togglePlayPauseCommand, cmd: "toggle_play_pause")
         addTarget(commandCenter.nextTrackCommand, cmd: "next")
         addTarget(commandCenter.previousTrackCommand, cmd: "previous")
+
+        addTarget(commandCenter.skipBackwardCommand, cmd: "seek_back")
+        addTarget(commandCenter.skipForwardCommand, cmd: "seek_forward")
+        updateRemoteCommandMode(isLongFormContent: false)
 
         commandCenter.changePlaybackPositionCommand.isEnabled = true
         commandCenter.changePlaybackPositionCommand.addTarget { [weak self] event in
@@ -340,9 +353,47 @@ class NowPlayingManager {
             self?.commandHandler?("seek:\(seekPosition)")
             return .success
         }
+    }
 
-        commandCenter.skipForwardCommand.isEnabled = false
-        commandCenter.skipBackwardCommand.isEnabled = false
+    private func resolveRemoteCommand(_ command: String) -> String {
+        switch command {
+        case "seek_back":
+            guard let seconds = currentLongFormSeekBackSeconds else { return command }
+            return "seek_by:-\(seconds)"
+        case "seek_forward":
+            guard let seconds = currentLongFormSeekForwardSeconds else { return command }
+            return "seek_by:\(seconds)"
+        default:
+            return command
+        }
+    }
+
+    private func updateRemoteCommandMode(isLongFormContent: Bool) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self,
+                  self.currentIsLongFormContent != isLongFormContent else { return }
+            self.currentIsLongFormContent = isLongFormContent
+
+            let commandCenter = MPRemoteCommandCenter.shared()
+            commandCenter.previousTrackCommand.isEnabled = !isLongFormContent
+            commandCenter.nextTrackCommand.isEnabled = !isLongFormContent
+            commandCenter.skipBackwardCommand.isEnabled = isLongFormContent
+            commandCenter.skipForwardCommand.isEnabled = isLongFormContent
+        }
+    }
+
+    func setLongFormSeekIntervals(backSeconds: Int64, forwardSeconds: Int64) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self,
+                  self.currentLongFormSeekBackSeconds != backSeconds ||
+                  self.currentLongFormSeekForwardSeconds != forwardSeconds else { return }
+            self.currentLongFormSeekBackSeconds = backSeconds
+            self.currentLongFormSeekForwardSeconds = forwardSeconds
+
+            let commandCenter = MPRemoteCommandCenter.shared()
+            commandCenter.skipBackwardCommand.preferredIntervals = [NSNumber(value: backSeconds)]
+            commandCenter.skipForwardCommand.preferredIntervals = [NSNumber(value: forwardSeconds)]
+        }
     }
 
     private func loadArtwork(urlString: String, completion: @escaping (MPMediaItemArtwork?) -> Void) -> Cancellable {


### PR DESCRIPTION
This updates the iOS lock screen and media widget to use the 10 second/30 second buttons when we're playing back audiobooks or podcasts, that we recently added in-app. I centralized the values to support (in the future) letting users override the values if they want to, but didn't want to bundle UI / new configs into the same PR. I also didn't touch the Android side any more than necessary to keep it compiling, but it should be easy enough to do the same there.

Commit message:

Adds audiobook/podcast-aware skip buttons to the iOS lock screen:
- LongFormSeekDefaults centralizes 10s back / 30s forward intervals
- seek_by: protocol added to LocalPlayerController for relative seeks
- iOS NowPlayingManager resolves skip_back/skip_forward to seek_by:±N and toggles prev/next vs skip back/forward based on content type
- Seek intervals flow through a dedicated setLongFormSeekIntervals channel rather than riding every updateNowPlaying call, so the per-second now-playing path no longer touches remote-command state
- Android and in-app controls use the same shared constants