### PR TITLE
Fix LazyGrid/List duplicate-key crashes as a class

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/AppMediaItem.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/AppMediaItem.kt
@@ -13,6 +13,7 @@ import io.music_assistant.client.data.model.server.ServerMediaItem
 interface PlayableItem {
     val defaultIcon: ImageVector
     val parentName: String?
+    val mediaType: MediaType
     val itemId: String
     val displayName: String
     val version: String?

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/AddToPlaylistDialog.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/AddToPlaylistDialog.kt
@@ -113,10 +113,9 @@ fun AddToPlaylistDialog(
                     } else {
                         items(
                             items = playlists,
-                            key = { p -> p.lazyListKey() },
+                            key = { it.lazyListKey() },
                         ) { playlist ->
-                            val isHighlighted =
-                                playlist.lazyListKey() == highlighted?.lazyListKey()
+                            val isHighlighted = playlist.lazyListKey() == highlighted?.lazyListKey()
                             TextButton(
                                 onClick = {
                                     playlistActions.addToPlaylist(item.uri, playlist)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
@@ -7,12 +7,13 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -115,16 +116,20 @@ fun CategoryRow(
             Modifier
         }
 
+        // Recommendation rows are server-curated and can repeat canonical item
+        // Key by occurrence to avoid Compose's duplicate-key crash
+        val itemKeys = remember(mediaItems) { mediaItems.lazyListOccurrenceKeys() }
+
         LazyRow(
             modifier = modifier,
             state = rowListState,
             contentPadding = PaddingValues(horizontal = 16.dp),
             horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-            items(
+            itemsIndexed(
                 items = mediaItems,
-                key = { it.lazyListKey() },
-                contentType = { item ->
+                key = { index, _ -> itemKeys[index] },
+                contentType = { _, item ->
                     when (item) {
                         is Track -> "Track"
                         is Artist -> "Artist"
@@ -138,7 +143,7 @@ fun CategoryRow(
                         else -> "Unknown"
                     }
                 },
-            ) { item ->
+            ) { _, item ->
                 when (item) {
                     is Artist -> ArtistWithMenu(
                         item = item,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
@@ -45,7 +45,7 @@ data class ItemCategory(
     val id: String,
     val title: DisplayString,
     val items: List<AppMediaItem>,
-    val lazyListKey: Any,
+    val lazyListKey: String,
     val itemType: MediaType? = null,
     val tag: String? = null,
 )

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/LazyListKeys.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/LazyListKeys.kt
@@ -1,57 +1,47 @@
 package io.music_assistant.client.ui.compose.common.items
 
-import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.PlayableItem
-import kotlin.jvm.JvmName
 
 /**
- * Stable canonical identity for an [AppMediaItem] inside a Compose `LazyColumn`,
- * `LazyRow`, or `LazyVerticalGrid`'s `key = { ... }` lambda when the rendered
- * collection cannot contain the same canonical item twice.
+ * Stable canonical identity for an [AppMediaItem] as a single collision-safe
+ * [String], combining `mediaType`, `provider`, and `itemId`.
  *
- * Combines `mediaType`, `provider`, and `itemId` so the same canonical
- * `itemId` carried by two different providers (e.g. a track with the same
- * server-side `itemId` from Spotify and Apple Music) produces distinct
- * keys. Without this, Compose's `SubcomposeLayout.subcompose` precondition
- * (`SubcomposeLayout.kt:614` — "Key X was already used") fires during
- * fling/prefetch on iOS and the app crashes.
+ * Use this as a Compose lazy-layout `key` ONLY when the rendered collection
+ * cannot contain the same canonical item twice. For collections that may
+ * legitimately repeat an item (folders, playlists, queues, search results),
+ * use [lazyListOccurrenceKeys] instead.
  *
- * Returns a structured [Triple] rather than a delimited string so the
- * encoding cannot accidentally collide on field contents — e.g. without
- * this, `(provider="apple_music", itemId="xyz")` would generate the same
- * underscore-joined string as `(provider="apple", itemId="music_xyz")`.
- * Compose's slot identity uses `equals`/`hashCode`, both of which Triple
- * implements structurally.
- *
- * Contract pinned by `LazyListKeysTest`.
+ * The encoding is length-prefixed so field contents can never collide across
+ * field boundaries — e.g. (provider="apple_music", itemId="xyz") is distinct
+ * from (provider="apple", itemId="music_xyz").
  */
-fun AppMediaItem.lazyListKey(): Triple<MediaType, String, String> =
-    Triple(mediaType, provider, itemId)
+fun AppMediaItem.lazyListKey(): String =
+    mediaItemKey(mediaType.name, provider, itemId)
 
 /**
  * Keys a lazy-layout list of media items that may legitimately contain the same
- * canonical [lazyListKey] more than once, such as folders, playlists, queues, or
+ * canonical media item more than once, such as folders, playlists, queues, or
  * other occurrence-based server data.
  */
-fun List<AppMediaItem>.lazyListOccurrenceKeys(): List<Pair<Triple<MediaType, String, String>, Int>> =
+fun List<AppMediaItem>.lazyListOccurrenceKeys(): List<String> =
     occurrenceKeys { it.lazyListKey() }
 
 /**
- * [PlayableItem] does not expose [AppMediaItem.mediaType], but every concrete
- * [PlayableItem] in this codebase is also an [AppMediaItem], so each item is
- * narrowed here to reuse the canonical [lazyListKey].
+ * Keys playable lists with the same canonical identity as [AppMediaItem].
  */
-@JvmName("lazyListOccurrenceKeysPlayable")
-fun List<PlayableItem>.lazyListOccurrenceKeys(): List<Pair<Triple<MediaType, String, String>, Int>> =
-    occurrenceKeys { (it as AppMediaItem).lazyListKey() }
+fun List<PlayableItem>.playableLazyListOccurrenceKeys(): List<String> =
+    occurrenceKeys { item -> mediaItemKey(item.mediaType.name, item.provider, item.itemId) }
 
-private fun <T, K> List<T>.occurrenceKeys(keyOf: (T) -> K): List<Pair<K, Int>> {
-    val occurrences = mutableMapOf<K, Int>()
+private fun <T> List<T>.occurrenceKeys(keyOf: (T) -> String): List<String> {
+    val occurrences = mutableMapOf<String, Int>()
     return map { item ->
         val key = keyOf(item)
         val occurrence = occurrences.getOrElse(key) { 0 }
         occurrences[key] = occurrence + 1
-        key to occurrence
+        if (occurrence == 0) key else mediaItemKey("occurrence", key, occurrence.toString())
     }
 }
+
+private fun mediaItemKey(vararg fields: String): String =
+    fields.joinToString(separator = "") { field -> "${field.length}:$field" }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/LazyListKeys.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/LazyListKeys.kt
@@ -2,10 +2,13 @@ package io.music_assistant.client.ui.compose.common.items
 
 import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.items.AppMediaItem
+import io.music_assistant.client.data.model.client.items.PlayableItem
+import kotlin.jvm.JvmName
 
 /**
- * Stable, unique key for an [AppMediaItem] inside a Compose `LazyColumn`,
- * `LazyRow`, or `LazyVerticalGrid`'s `key = { ... }` lambda.
+ * Stable canonical identity for an [AppMediaItem] inside a Compose `LazyColumn`,
+ * `LazyRow`, or `LazyVerticalGrid`'s `key = { ... }` lambda when the rendered
+ * collection cannot contain the same canonical item twice.
  *
  * Combines `mediaType`, `provider`, and `itemId` so the same canonical
  * `itemId` carried by two different providers (e.g. a track with the same
@@ -25,3 +28,30 @@ import io.music_assistant.client.data.model.client.items.AppMediaItem
  */
 fun AppMediaItem.lazyListKey(): Triple<MediaType, String, String> =
     Triple(mediaType, provider, itemId)
+
+/**
+ * Keys a lazy-layout list of media items that may legitimately contain the same
+ * canonical [lazyListKey] more than once, such as folders, playlists, queues, or
+ * other occurrence-based server data.
+ */
+fun List<AppMediaItem>.lazyListOccurrenceKeys(): List<Pair<Triple<MediaType, String, String>, Int>> =
+    occurrenceKeys { it.lazyListKey() }
+
+/**
+ * [PlayableItem] does not expose [AppMediaItem.mediaType], but every concrete
+ * [PlayableItem] in this codebase is also an [AppMediaItem], so each item is
+ * narrowed here to reuse the canonical [lazyListKey].
+ */
+@JvmName("lazyListOccurrenceKeysPlayable")
+fun List<PlayableItem>.lazyListOccurrenceKeys(): List<Pair<Triple<MediaType, String, String>, Int>> =
+    occurrenceKeys { (it as AppMediaItem).lazyListKey() }
+
+private fun <T, K> List<T>.occurrenceKeys(keyOf: (T) -> K): List<Pair<K, Int>> {
+    val occurrences = mutableMapOf<K, Int>()
+    return map { item ->
+        val key = keyOf(item)
+        val occurrence = occurrences.getOrElse(key) { 0 }
+        occurrences[key] = occurrence + 1
+        key to occurrence
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -87,6 +87,7 @@ import io.music_assistant.client.ui.compose.common.items.ProgressActions
 import io.music_assistant.client.ui.compose.common.items.ProvideClickActions
 import io.music_assistant.client.ui.compose.common.items.TrackWithMenu
 import io.music_assistant.client.ui.compose.common.items.lazyListOccurrenceKeys
+import io.music_assistant.client.ui.compose.common.items.playableLazyListOccurrenceKeys
 import io.music_assistant.client.ui.compose.common.items.supportsAddToPlaylist
 import io.music_assistant.client.ui.compose.common.providers.ProviderIcon
 import io.music_assistant.client.ui.compose.common.rememberAnimatedPlayerColors
@@ -651,17 +652,11 @@ private fun LazyGridScope.detailHeaderItems(
     heroSlot: @Composable () -> Unit,
     tabsSlot: (@Composable () -> Unit)?,
 ) {
-    item(
-        key = DETAIL_HERO_KEY,
-        span = { GridItemSpan(maxLineSpan) },
-    ) {
+    fullSpanItem(DETAIL_HERO_KEY) {
         Box(modifier = Modifier.fullBleed(gridPadding)) { heroSlot() }
     }
     tabsSlot?.let { slot ->
-        item(
-            key = DETAIL_TABS_KEY,
-            span = { GridItemSpan(maxLineSpan) },
-        ) { slot() }
+        fullSpanItem(DETAIL_TABS_KEY) { slot() }
     }
 }
 
@@ -703,13 +698,6 @@ private fun LazyGridScope.fullSpanItem(
     key = key,
     span = { GridItemSpan(maxLineSpan) },
 ) { content() }
-
-private const val DETAIL_HERO_KEY = "detail:hero"
-private const val DETAIL_TABS_KEY = "detail:tabs"
-private const val DETAIL_ERROR_KEY = "detail:error"
-private const val DETAIL_EMPTY_KEY = "detail:empty"
-private const val DETAIL_LOADING_KEY = "detail:loading"
-private const val DETAIL_CHAPTER_KEY_PREFIX = "detail:chapter:"
 
 /**
  * Resolves a list tab's [state] to grid rows: Error → error message, empty (or NoData) → empty
@@ -765,10 +753,7 @@ private fun AlbumsTabContent(
                 items = albums,
                 key = { index, _ -> albumKeys[index] },
                 span = when (viewMode) {
-                    ViewMode.LIST -> {
-                        { _, _ -> GridItemSpan(maxLineSpan) }
-                    }
-
+                    ViewMode.LIST -> { _, _ -> GridItemSpan(maxLineSpan) }
                     ViewMode.GRID -> null
                 },
             ) { _, album ->
@@ -807,10 +792,7 @@ private fun ArtistsTabContent(
                 items = artists,
                 key = { index, _ -> artistKeys[index] },
                 span = when (viewMode) {
-                    ViewMode.LIST -> {
-                        { _, _ -> GridItemSpan(maxLineSpan) }
-                    }
-
+                    ViewMode.LIST -> { _, _ -> GridItemSpan(maxLineSpan) }
                     ViewMode.GRID -> null
                 },
             ) { _, artist ->
@@ -846,15 +828,12 @@ private fun PlayablesTabContent(
     val viewMode = viewModeProvider(MediaType.TRACK)
     DetailGrid(contentPadding, heroSlot, tabsSlot, gridState) {
         tabListBody(playableItemsState) { tracks ->
-            val trackKeys = tracks.lazyListOccurrenceKeys()
+            val trackKeys = tracks.playableLazyListOccurrenceKeys()
             itemsIndexed(
                 items = tracks,
                 key = { index, _ -> trackKeys[index] },
                 span = when (viewMode) {
-                    ViewMode.LIST -> {
-                        { _, _ -> GridItemSpan(maxLineSpan) }
-                    }
-
+                    ViewMode.LIST -> { _, _ -> GridItemSpan(maxLineSpan) }
                     ViewMode.GRID -> null
                 },
             ) { index, track ->
@@ -1148,3 +1127,10 @@ private fun PreviewAudiobook(isRowMode: Boolean = true) {
 private fun PreviewAudiobookGrid() {
     PreviewAudiobook(isRowMode = false)
 }
+
+private const val DETAIL_HERO_KEY = "detail:hero"
+private const val DETAIL_TABS_KEY = "detail:tabs"
+private const val DETAIL_ERROR_KEY = "detail:error"
+private const val DETAIL_EMPTY_KEY = "detail:empty"
+private const val DETAIL_LOADING_KEY = "detail:loading"
+private const val DETAIL_CHAPTER_KEY_PREFIX = "detail:chapter:"

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridScope
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ViewList
@@ -86,6 +86,7 @@ import io.music_assistant.client.ui.compose.common.items.PodcastEpisodeWithMenu
 import io.music_assistant.client.ui.compose.common.items.ProgressActions
 import io.music_assistant.client.ui.compose.common.items.ProvideClickActions
 import io.music_assistant.client.ui.compose.common.items.TrackWithMenu
+import io.music_assistant.client.ui.compose.common.items.lazyListOccurrenceKeys
 import io.music_assistant.client.ui.compose.common.items.supportsAddToPlaylist
 import io.music_assistant.client.ui.compose.common.providers.ProviderIcon
 import io.music_assistant.client.ui.compose.common.rememberAnimatedPlayerColors
@@ -420,7 +421,7 @@ private fun ItemContent(
                             tabsSlot = null,
                             gridState = gridState,
                         ) {
-                            fullSpanItem { InlineProgress() }
+                            fullSpanItem(DETAIL_LOADING_KEY) { InlineProgress() }
                         }
                     }
                 } else {
@@ -650,11 +651,17 @@ private fun LazyGridScope.detailHeaderItems(
     heroSlot: @Composable () -> Unit,
     tabsSlot: (@Composable () -> Unit)?,
 ) {
-    item(span = { GridItemSpan(maxLineSpan) }) {
+    item(
+        key = DETAIL_HERO_KEY,
+        span = { GridItemSpan(maxLineSpan) },
+    ) {
         Box(modifier = Modifier.fullBleed(gridPadding)) { heroSlot() }
     }
     tabsSlot?.let { slot ->
-        item(span = { GridItemSpan(maxLineSpan) }) { slot() }
+        item(
+            key = DETAIL_TABS_KEY,
+            span = { GridItemSpan(maxLineSpan) },
+        ) { slot() }
     }
 }
 
@@ -689,8 +696,20 @@ private fun DetailGrid(
     }
 }
 
-private fun LazyGridScope.fullSpanItem(content: @Composable () -> Unit) =
-    item(span = { GridItemSpan(maxLineSpan) }) { content() }
+private fun LazyGridScope.fullSpanItem(
+    key: String,
+    content: @Composable () -> Unit,
+) = item(
+    key = key,
+    span = { GridItemSpan(maxLineSpan) },
+) { content() }
+
+private const val DETAIL_HERO_KEY = "detail:hero"
+private const val DETAIL_TABS_KEY = "detail:tabs"
+private const val DETAIL_ERROR_KEY = "detail:error"
+private const val DETAIL_EMPTY_KEY = "detail:empty"
+private const val DETAIL_LOADING_KEY = "detail:loading"
+private const val DETAIL_CHAPTER_KEY_PREFIX = "detail:chapter:"
 
 /**
  * Resolves a list tab's [state] to grid rows: Error → error message, empty (or NoData) → empty
@@ -705,7 +724,7 @@ private inline fun <T> LazyGridScope.tabListBody(
         is DataState.Data -> state.data
         is DataState.Stale -> state.data
         is DataState.Error -> {
-            fullSpanItem {
+            fullSpanItem(DETAIL_ERROR_KEY) {
                 CenteredText(
                     text = stringResource(Res.string.library_error),
                     color = MaterialTheme.colorScheme.error,
@@ -717,7 +736,7 @@ private inline fun <T> LazyGridScope.tabListBody(
         else -> emptyList()
     }
     if (data.isEmpty()) {
-        fullSpanItem { CenteredText(stringResource(Res.string.library_empty)) }
+        fullSpanItem(DETAIL_EMPTY_KEY) { CenteredText(stringResource(Res.string.library_empty)) }
     } else {
         items(data)
     }
@@ -740,16 +759,19 @@ private fun AlbumsTabContent(
     val viewMode = viewModeProvider(MediaType.ALBUM)
     DetailGrid(contentPadding, heroSlot, tabsSlot, gridState) {
         tabListBody(albumsState) { albums ->
-            items(
+            // not a @Composable scope, so remember() is unavailable here
+            val albumKeys = albums.lazyListOccurrenceKeys()
+            itemsIndexed(
                 items = albums,
+                key = { index, _ -> albumKeys[index] },
                 span = when (viewMode) {
                     ViewMode.LIST -> {
-                        { GridItemSpan(maxLineSpan) }
+                        { _, _ -> GridItemSpan(maxLineSpan) }
                     }
 
                     ViewMode.GRID -> null
                 },
-            ) { album ->
+            ) { _, album ->
                 AlbumWithMenu(
                     item = album,
                     viewMode = viewMode,
@@ -780,16 +802,18 @@ private fun ArtistsTabContent(
     val viewMode = viewModeProvider(MediaType.ARTIST)
     DetailGrid(contentPadding, heroSlot, tabsSlot, gridState) {
         tabListBody(artistsState) { artists ->
-            items(
+            val artistKeys = artists.lazyListOccurrenceKeys()
+            itemsIndexed(
                 items = artists,
+                key = { index, _ -> artistKeys[index] },
                 span = when (viewMode) {
                     ViewMode.LIST -> {
-                        { GridItemSpan(maxLineSpan) }
+                        { _, _ -> GridItemSpan(maxLineSpan) }
                     }
 
                     ViewMode.GRID -> null
                 },
-            ) { artist ->
+            ) { _, artist ->
                 ArtistWithMenu(
                     item = artist,
                     viewMode = viewMode,
@@ -822,42 +846,43 @@ private fun PlayablesTabContent(
     val viewMode = viewModeProvider(MediaType.TRACK)
     DetailGrid(contentPadding, heroSlot, tabsSlot, gridState) {
         tabListBody(playableItemsState) { tracks ->
-            tracks.forEachIndexed { index, track ->
-                item(
-                    span = when (viewMode) {
-                        ViewMode.LIST -> {
-                            { GridItemSpan(maxLineSpan) }
-                        }
-
-                        ViewMode.GRID -> null
-                    },
-                ) {
-                    when (track) {
-                        is Track -> TrackWithMenu(
-                            item = track,
-                            viewMode = viewMode,
-                            showTrackNumber = parentItem is Album,
-                            onPlayOption = onPlayChildClick,
-                            playlistActions = playlistActions,
-                            onRemoveFromPlaylist = if (parentItem is Playlist && parentItem.isEditable) {
-                                { onRemoveFromPlaylist(parentItem.itemId, index) }
-                            } else {
-                                null
-                            },
-                            libraryActions = libraryActions,
-                            providerIconFetcher = providerIconFetcher,
-                        )
-
-                        is PodcastEpisode -> PodcastEpisodeWithMenu(
-                            item = track,
-                            viewMode = viewMode,
-                            onPlayOption = onPlayChildClick,
-                            playlistActions = null,
-                            libraryActions = libraryActions,
-                            progressActions = progressActions,
-                            providerIconFetcher = providerIconFetcher,
-                        )
+            val trackKeys = tracks.lazyListOccurrenceKeys()
+            itemsIndexed(
+                items = tracks,
+                key = { index, _ -> trackKeys[index] },
+                span = when (viewMode) {
+                    ViewMode.LIST -> {
+                        { _, _ -> GridItemSpan(maxLineSpan) }
                     }
+
+                    ViewMode.GRID -> null
+                },
+            ) { index, track ->
+                when (track) {
+                    is Track -> TrackWithMenu(
+                        item = track,
+                        viewMode = viewMode,
+                        showTrackNumber = parentItem is Album,
+                        onPlayOption = onPlayChildClick,
+                        playlistActions = playlistActions,
+                        onRemoveFromPlaylist = if (parentItem is Playlist && parentItem.isEditable) {
+                            { onRemoveFromPlaylist(parentItem.itemId, index) }
+                        } else {
+                            null
+                        },
+                        libraryActions = libraryActions,
+                        providerIconFetcher = providerIconFetcher,
+                    )
+
+                    is PodcastEpisode -> PodcastEpisodeWithMenu(
+                        item = track,
+                        viewMode = viewMode,
+                        onPlayOption = onPlayChildClick,
+                        playlistActions = null,
+                        libraryActions = libraryActions,
+                        progressActions = progressActions,
+                        providerIconFetcher = providerIconFetcher,
+                    )
                 }
             }
         }
@@ -875,10 +900,10 @@ private fun ChaptersTabContent(
 ) {
     DetailGrid(contentPadding, heroSlot, tabsSlot, gridState) {
         if (chapters.isEmpty()) {
-            fullSpanItem { CenteredText(stringResource(Res.string.library_empty)) }
+            fullSpanItem(DETAIL_EMPTY_KEY) { CenteredText(stringResource(Res.string.library_empty)) }
         } else {
             chapters.forEach { chapter ->
-                fullSpanItem {
+                fullSpanItem(DETAIL_CHAPTER_KEY_PREFIX + chapter.position) {
                     ChapterRow(
                         chapter = chapter,
                         onClick = { onChapterClick(chapter.position) },

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/AdaptiveMediaGrid.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/AdaptiveMediaGrid.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
@@ -47,7 +47,7 @@ import io.music_assistant.client.ui.compose.common.items.PodcastWithMenu
 import io.music_assistant.client.ui.compose.common.items.ProgressActions
 import io.music_assistant.client.ui.compose.common.items.RadioWithMenu
 import io.music_assistant.client.ui.compose.common.items.TrackWithMenu
-import io.music_assistant.client.ui.compose.common.items.lazyListKey
+import io.music_assistant.client.ui.compose.common.items.lazyListOccurrenceKeys
 import io.music_assistant.client.utils.gridItemMinSize
 
 @Composable
@@ -67,6 +67,8 @@ fun AdaptiveMediaGrid(
     contentPadding: PaddingValues,
 ) {
     val isRow = viewMode == ViewMode.LIST
+    val itemKeys = remember(items) { items.lazyListOccurrenceKeys() }
+
     // Detect when we're near the end and trigger load more
     val shouldLoadMore by remember {
         derivedStateOf {
@@ -93,15 +95,15 @@ fun AdaptiveMediaGrid(
         horizontalArrangement = Arrangement.spacedBy(4.dp),
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
-        items(
+        itemsIndexed(
             items = items,
-            key = { it.lazyListKey() },
+            key = { index, _ -> itemKeys[index] },
             span = if (isRow) {
-                { GridItemSpan(maxLineSpan) }
+                { _, _ -> GridItemSpan(maxLineSpan) }
             } else {
                 null
             },
-        ) { item ->
+        ) { _, item ->
             when (item) {
                 is Artist -> ArtistWithMenu(
                     item = item,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryScreen.kt
@@ -105,7 +105,10 @@ private fun LibraryGrid(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         contentPadding = paddingValues,
     ) {
-        items(libraryCategories) {
+        items(
+            items = libraryCategories,
+            key = { it.name },
+        ) {
             GridButton(
                 modifier = Modifier.fillMaxWidth().height(width / ITEM_HEIGHT_RATIO),
                 text = stringResource(it.stringResource()),

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
@@ -16,7 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -68,7 +68,7 @@ import io.music_assistant.client.ui.compose.common.items.ProgressActions
 import io.music_assistant.client.ui.compose.common.items.ProvideClickActions
 import io.music_assistant.client.ui.compose.common.items.RadioWithMenu
 import io.music_assistant.client.ui.compose.common.items.TrackWithMenu
-import io.music_assistant.client.ui.compose.common.items.lazyListKey
+import io.music_assistant.client.ui.compose.common.items.lazyListOccurrenceKeys
 import io.music_assistant.client.ui.compose.common.providers.ProviderIcon
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
@@ -269,10 +269,11 @@ private fun SearchContent(
                             item {
                                 Spacer(modifier = Modifier.height(16.dp))
                             }
-                            items(
+                            val itemKeys = items.lazyListOccurrenceKeys()
+                            itemsIndexed(
                                 items = items,
-                                key = { it.lazyListKey() },
-                            ) { item ->
+                                key = { index, _ -> itemKeys[index] },
+                            ) { _, item ->
                                 when (item) {
                                     is Track -> TrackWithMenu(
                                         viewMode = ViewMode.LIST,

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/common/items/LazyListKeysTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/common/items/LazyListKeysTest.kt
@@ -3,6 +3,7 @@ package io.music_assistant.client.ui.compose.common.items
 import io.music_assistant.client.data.model.client.items.Album
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Artist
+import io.music_assistant.client.data.model.client.items.PlayableItem
 import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.data.model.client.items.Track
 import kotlin.test.Test
@@ -88,6 +89,50 @@ class LazyListKeysTest {
         val a = track(provider = "apple_music", itemId = "xyz")
         val b = track(provider = "apple", itemId = "music_xyz")
         assertNotEquals(a.lazyListKey(), b.lazyListKey())
+    }
+
+    @Test
+    fun `occurrence keys distinguish duplicate canonical items`() {
+        val duplicate = track(provider = "library", itemId = "same")
+        val keys = listOf<AppMediaItem>(duplicate, duplicate).lazyListOccurrenceKeys()
+
+        assertEquals(2, keys.distinct().size)
+        assertEquals(duplicate.lazyListKey() to 0, keys[0])
+        assertEquals(duplicate.lazyListKey() to 1, keys[1])
+    }
+
+    @Test
+    fun `occurrence keys do not shift unrelated items after insertion`() {
+        val a = track(provider = "library", itemId = "a")
+        val b = track(provider = "library", itemId = "b")
+        val c = track(provider = "library", itemId = "c")
+        val inserted = track(provider = "library", itemId = "inserted")
+
+        val originalKeysById = listOf<AppMediaItem>(a, b, c)
+            .zip(listOf<AppMediaItem>(a, b, c).lazyListOccurrenceKeys())
+            .associate { (item, key) -> item.itemId to key }
+        val insertedKeysById = listOf<AppMediaItem>(inserted, a, b, c)
+            .zip(listOf<AppMediaItem>(inserted, a, b, c).lazyListOccurrenceKeys())
+            .associate { (item, key) -> item.itemId to key }
+
+        assertEquals(originalKeysById["a"], insertedKeysById["a"])
+        assertEquals(originalKeysById["b"], insertedKeysById["b"])
+        assertEquals(originalKeysById["c"], insertedKeysById["c"])
+    }
+
+    @Test
+    fun `playable occurrence keys distinguish duplicate items`() {
+        // Exercises the PlayableItem-typed overload used by PlayablesTabContent.
+        // Duplicate playable items must still get distinct keys (same canonical
+        // key, different occurrence ordinal) without an unexplained cast at the
+        // call site.
+        val duplicate: PlayableItem = track(provider = "library", itemId = "same")
+        val keys = listOf(duplicate, duplicate).lazyListOccurrenceKeys()
+
+        assertEquals(2, keys.distinct().size)
+        assertEquals(keys[0].first, keys[1].first)
+        assertEquals(0, keys[0].second)
+        assertEquals(1, keys[1].second)
     }
 
     private fun track(provider: String, itemId: String): Track = Track(

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/common/items/LazyListKeysTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/common/items/LazyListKeysTest.kt
@@ -1,30 +1,27 @@
 package io.music_assistant.client.ui.compose.common.items
 
+import io.music_assistant.client.data.model.client.ImageInfo
+import io.music_assistant.client.data.model.client.ImageType
+import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.items.Album
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Artist
 import io.music_assistant.client.data.model.client.items.PlayableItem
 import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.data.model.client.items.Track
+import io.music_assistant.client.ui.compose.common.icons.TrackIcon
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 
 /**
- * Pins the [AppMediaItem.lazyListKey] contract.
+ * Pins the lazy-list media key contract.
  *
- * The crash that motivated this test (TestFlight build-29 LayoutNode
- * regression) fired Compose's "Key X was already used" precondition
- * (SubcomposeLayout.kt:614) during fling/prefetch on a LazyRow whose items
- * were keyed by `"${item::class.simpleName}_${item.itemId}"` — missing the
- * provider, so a cross-provider duplicate-itemId collision crashed the app
- * on scroll. CM 1.10.3 got away with it; CM 1.11.0's tightened prefetch
- * actually subcomposes the colliding sibling.
- *
- * Contract:
- *   - Any two AppMediaItems that differ in (mediaType, provider, itemId)
- *     MUST produce different keys.
- *   - Identical AppMediaItems MUST produce the same key (stable).
+ * The crash that motivated this test fired Compose's "Key X was already used"
+ * precondition during fling/prefetch on a LazyRow whose items were keyed by
+ * `"${item::class.simpleName}_${item.itemId}"` — missing the provider, so a
+ * cross-provider duplicate-itemId collision crashed the app on scroll.
  */
 class LazyListKeysTest {
     @Test
@@ -82,9 +79,8 @@ class LazyListKeysTest {
 
     @Test
     fun `underscore-bearing provider does not collide with other field arrangements`() {
-        // Compose accepts Any? as a slot key, so the key MUST be a structurally
-        // typed value (Triple) rather than an underscore-delimited string —
-        // otherwise (provider="apple_music", itemId="xyz") collides with
+        // The canonical key must not reduce to a naive delimiter join, or
+        // (provider="apple_music", itemId="xyz") would equal
         // (provider="apple", itemId="music_xyz").
         val a = track(provider = "apple_music", itemId = "xyz")
         val b = track(provider = "apple", itemId = "music_xyz")
@@ -96,9 +92,18 @@ class LazyListKeysTest {
         val duplicate = track(provider = "library", itemId = "same")
         val keys = listOf<AppMediaItem>(duplicate, duplicate).lazyListOccurrenceKeys()
 
+        assertEquals(2, keys.size)
         assertEquals(2, keys.distinct().size)
-        assertEquals(duplicate.lazyListKey() to 0, keys[0])
-        assertEquals(duplicate.lazyListKey() to 1, keys[1])
+        assertNotEquals(keys[0], keys[1])
+    }
+
+    @Test
+    fun `first occurrence key is stable whether the item is alone or in a list`() {
+        val duplicate = track(provider = "library", itemId = "same")
+        val alone = listOf<AppMediaItem>(duplicate).lazyListOccurrenceKeys().single()
+        val inList = listOf<AppMediaItem>(duplicate, duplicate).lazyListOccurrenceKeys()[0]
+
+        assertEquals(alone, inList)
     }
 
     @Test
@@ -122,17 +127,32 @@ class LazyListKeysTest {
 
     @Test
     fun `playable occurrence keys distinguish duplicate items`() {
-        // Exercises the PlayableItem-typed overload used by PlayablesTabContent.
+        // Exercises the PlayableItem-specific helper used by PlayablesTabContent.
         // Duplicate playable items must still get distinct keys (same canonical
         // key, different occurrence ordinal) without an unexplained cast at the
         // call site.
         val duplicate: PlayableItem = track(provider = "library", itemId = "same")
-        val keys = listOf(duplicate, duplicate).lazyListOccurrenceKeys()
+        val keys = listOf<PlayableItem>(duplicate, duplicate).playableLazyListOccurrenceKeys()
+
+        assertEquals(2, keys.size)
+        assertEquals(2, keys.distinct().size)
+        assertNotEquals(keys[0], keys[1])
+    }
+
+    @Test
+    fun `playable occurrence keys handle non AppMediaItem implementations`() {
+        // The PlayableItem helper must not assume every PlayableItem is an
+        // AppMediaItem: a standalone implementation is still disambiguated by
+        // media type and occurrence ordinal.
+        val playable = testPlayable(provider = "library", itemId = "same")
+        val keys = listOf<PlayableItem>(playable, playable).playableLazyListOccurrenceKeys()
 
         assertEquals(2, keys.distinct().size)
-        assertEquals(keys[0].first, keys[1].first)
-        assertEquals(0, keys[0].second)
-        assertEquals(1, keys[1].second)
+        assertNotEquals(keys[0], keys[1])
+
+        val other = testPlayable(provider = "library", itemId = "same", mediaType = MediaType.PODCAST_EPISODE)
+        val otherKeys = listOf<PlayableItem>(other, other).playableLazyListOccurrenceKeys()
+        assertFalse(otherKeys.any { it in keys })
     }
 
     private fun track(provider: String, itemId: String): Track = Track(
@@ -188,4 +208,27 @@ class LazyListKeysTest {
             images = emptyMap(),
             items = null,
         )
+
+    private fun testPlayable(
+        provider: String,
+        itemId: String,
+        mediaType: MediaType = MediaType.TRACK,
+    ): PlayableItem = object : PlayableItem {
+        override val defaultIcon = TrackIcon
+        override val parentName: String? = null
+        override val mediaType: MediaType = mediaType
+        override val itemId: String = itemId
+        override val displayName: String = "name"
+        override val version: String? = null
+        override val duration: Double? = null
+        override val uri: String? = null
+        override val subtitle: String? = null
+        override val images = emptyMap<ImageType, ImageInfo>()
+        override val provider: String = provider
+        override val isInLibrary: Boolean = provider == "library"
+        override val favorite: Boolean? = null
+        override val canStartRadio: Boolean = false
+        override val isPlayable: Boolean = true
+        override fun withFavorite(favorite: Boolean?): PlayableItem = this
+    }
 }


### PR DESCRIPTION
I was going through the Test Flight submitted crash reports and found that there were still some coming in after our last round of LazyList duplicate-key crash fixes in c9447a7. Apparently having duplicate items served to us from the server is more common than I thought, in more areas. This is an attempt to prevent those crashes everywhere we use `Lazy*` layouts without causing a bunch of re-ordering or performance issues. 🤞

Commit message:

Compose aborts (requirePrecondition / "Key was already used" in SubcomposeLayout) when a lazy layout is handed duplicate keys, which is the dominant TestFlight crash signature on fling/prefetch. Keying media lists by canonical identity alone collides whenever a collection legitimately repeats an item (recommendations, search results, playlists, folders, queues).

- Add lazyListOccurrenceKeys(): pairs each canonical key with a per-key occurrence ordinal so duplicates stay unique without churning unrelated items' keys on insert/remove.
- Convert the at-risk lazy layouts to itemsIndexed + occurrence keys: LibraryScreen, AdaptiveMediaGrid, ItemDetailsScreen, CategoryRow (recommendations), and SearchScreen.
- Give ItemDetailsScreen's static grid sections explicit stable keys.
- Pin the key contract with LazyListKeysTest.

Verified: testAndroidHostTest, iosSimulatorArm64Test, and compileTestKotlinIosArm64 all pass.