### PR TITLE
Restore main nav gestures

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -2,9 +2,6 @@
 
 package io.music_assistant.client.ui.compose.home
 
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -295,13 +292,6 @@ fun MainNavigationRoot(
                             multiBackStack.removeLastOrNull()
                         },
                         backEnabled = !playerExpanded,
-                        // Workaround for CMP 1.10.3 iOS crash: LazyLayout measured inside
-                        // AnimatedContent + CupertinoOverscroll trips a SubcomposeLayout
-                        // precondition on first frame. Disabling transitions removes the
-                        // animating measure path.
-                        transitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
-                        popTransitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
-                        predictivePopTransitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
                     )
                 }
             }


### PR DESCRIPTION
Closes https://github.com/music-assistant/mobile-app/issues/675

It looks like we don't need the workaround that caused this issue any longer as we've upgraded to a new version of KMP that appears to fix https://github.com/music-assistant/mobile-app/issues/284 (I couldn't reproduce in the simulator with these changes).