### PR TITLE
Improve playback recovery after background connection drops

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -1184,15 +1184,14 @@ class KtorServiceClient(
                     if (request.command != APICommands.AUTH_LOGOUT &&
                         sessionState !is SessionState.Connecting &&
                         sessionState !is SessionState.Reconnecting &&
-                        transportState !is TransportState.Reconnecting
+                        transportState !is TransportState.Reconnecting &&
+                        !reconnectFromCurrent("send failed: ${e.message}")
                     ) {
-                        if (!reconnectFromCurrent("send failed: ${e.message}")) {
-                            disconnect(
-                                SessionState.Disconnected.Error(
-                                    Exception("Error sending command: ${e.message}"),
-                                ),
-                            )
-                        }
+                        disconnect(
+                            SessionState.Disconnected.Error(
+                                Exception("Error sending command: ${e.message}"),
+                            ),
+                        )
                     }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -1175,11 +1175,24 @@ class KtorServiceClient(
                     logger.e(e) { "sendRequest[$msgId] cmd=$cmd send FAILED" }
                     rpcEngine.removeCallback(msgId)
                     continuation.resume(Result.failure(e))
-                    // Don't trigger full disconnect if transport is already reconnecting —
-                    // its own loop will surface the error via TransportState.Failed.
+                    // A send failure is definitive liveness evidence: the high-level
+                    // Connected/Authenticated state can lag behind a closed WebRTC data channel.
+                    // Kick a fresh reconnect so callers that queue on failure are replayed when
+                    // the transport returns. Logout is user-intent teardown; never resurrect it.
+                    val sessionState = _sessionState.value
                     val transportState = transport?.state?.value
-                    if (transportState !is TransportState.Reconnecting) {
-                        disconnect(SessionState.Disconnected.Error(Exception("Error sending command: ${e.message}")))
+                    if (request.command != APICommands.AUTH_LOGOUT &&
+                        sessionState !is SessionState.Connecting &&
+                        sessionState !is SessionState.Reconnecting &&
+                        transportState !is TransportState.Reconnecting
+                    ) {
+                        if (!reconnectFromCurrent("send failed: ${e.message}")) {
+                            disconnect(
+                                SessionState.Disconnected.Error(
+                                    Exception("Error sending command: ${e.message}"),
+                                ),
+                            )
+                        }
                     }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -1181,12 +1181,12 @@ class KtorServiceClient(
                     // the transport returns. Logout is user-intent teardown; never resurrect it.
                     val sessionState = _sessionState.value
                     val transportState = transport?.state?.value
-                    if (request.command != APICommands.AUTH_LOGOUT &&
+                    val canStartReconnect = request.command != APICommands.AUTH_LOGOUT &&
                         sessionState !is SessionState.Connecting &&
                         sessionState !is SessionState.Reconnecting &&
-                        transportState !is TransportState.Reconnecting &&
-                        !reconnectFromCurrent("send failed: ${e.message}")
-                    ) {
+                        transportState !is TransportState.Reconnecting
+                    val reconnectStarted = canStartReconnect && reconnectFromCurrent("send failed: ${e.message}")
+                    if (canStartReconnect && !reconnectStarted) {
                         disconnect(
                             SessionState.Disconnected.Error(
                                 Exception("Error sending command: ${e.message}"),


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

The combination of WebRTC and having my audio paused (vs. ducked) now has exposed some gaps in how we handle recovery when losing our connection while we're backgrounded. Broadening the things that allow the reconnect path helps tremendously (based on my "walking the dog while getting a multitude of texts read aloud by Siri" tests).

## Are there any additional changes not related to the issue above?

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

