### PR TITLE
sidebar.shortcuts are not guaranteed to exist

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerUser.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerUser.kt
@@ -10,5 +10,5 @@ data class ServerUser(
 
 @Serializable
 data class ServerUserPreferences(
-    @SerialName("sidebar.shortcuts") val shortcuts: List<String>,
+    @SerialName("sidebar.shortcuts") val shortcuts: List<String> = emptyList(),
 )

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerUser.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerUser.kt
@@ -10,5 +10,5 @@ data class ServerUser(
 
 @Serializable
 data class ServerUserPreferences(
-    @SerialName("sidebar.shortcuts") val shortcuts: List<String> = emptyList(),
+    @SerialName("sidebar.shortcuts") val shortcuts: List<String>? = null,
 )


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

Not really, just noticed that we were expecting them to always exist and I don't have them, so it logged an ugly RPC decoding failure.

```
kotlinx.serialization.MissingFieldException: Field 'sidebar.shortcuts' is required for type with serial name 'io.music_assistant.client.data.model.server.ServerUserPreferences', but it was missing
```
(and 52 other lines).

## Are there any additional changes not related to the issue above?

Not an 'additional change' per se, but I'm not sure this sort of commit needs to go into the change-log?

## Before submitting this PR, make sure you have:
- [x] Given this PR a readable name that can be used in the app's changelog
- [x] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

