### PR TITLE
Show podcast episode list in CarPlay instead of playing immediately

### DIFF
--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
@@ -16,10 +16,15 @@ import io.music_assistant.client.data.MainDataSource
 import io.music_assistant.client.data.executeLocalPlayerDispatch
 import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.QueueOption
+import io.music_assistant.client.data.model.client.SortConfig
+import io.music_assistant.client.data.model.client.SubItemContext
+import io.music_assistant.client.data.model.client.clientSorted
 import io.music_assistant.client.data.model.client.items.Album
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Artist
 import io.music_assistant.client.data.model.client.items.Playlist
+import io.music_assistant.client.data.model.client.items.Podcast
+import io.music_assistant.client.data.model.client.items.PodcastEpisode
 import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.data.model.client.toItemKind
@@ -363,6 +368,27 @@ object KmpHelper : KoinComponent {
                 ),
             ).getOrNull()
                 ?.filterIsInstance<Track>()
+                ?: emptyList()
+        }
+    }
+
+    fun fetchEpisodesByPodcast(
+        podcast: Podcast,
+        completion: (List<AppMediaItem>?) -> Unit,
+    ) {
+        launchFetch("episodesByPodcast:${podcast.itemId}", completion) {
+            mediaItemRepository.fetchMediaItems(
+                Request.Podcast.getEpisodes(
+                    itemId = podcast.itemId,
+                    providerInstanceIdOrDomain = podcast.provider,
+                    inLibraryOnly = false,
+                ),
+            ).getOrNull()
+                ?.filterIsInstance<PodcastEpisode>()
+                ?.clientSorted(
+                    SortConfig.defaultFor(SubItemContext.PODCAST_EPISODES),
+                    SubItemContext.PODCAST_EPISODES,
+                )
                 ?: emptyList()
         }
     }

--- a/iosApp/iosApp/CarPlay/CarPlayContentManager.swift
+++ b/iosApp/iosApp/CarPlay/CarPlayContentManager.swift
@@ -133,6 +133,15 @@ class CarPlayContentManager {
         }
     }
 
+    func fetchEpisodesForPodcast(
+        _ podcast: Podcast,
+        completion: @escaping ([CPListItem]?) -> Void
+    ) {
+        KmpHelper.shared.fetchEpisodesByPodcast(podcast: podcast) { items in
+            completion(self.mapItems(items))
+        }
+    }
+
     // MARK: - Action Handling
 
     func playItem(_ item: AppMediaItem) {
@@ -199,6 +208,8 @@ class CarPlayContentManager {
             iconName = "music.note.list"
         } else if item is Artist {
             iconName = "person.2.crop.square.stack"
+        } else if item is Podcast {
+            iconName = "antenna.radiowaves.left.and.right"
         } else {
             iconName = "music.note"
         }

--- a/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
+++ b/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
@@ -431,9 +431,9 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
         }
     }
 
-    /// Type-aware dispatch: container items (Artist, Album, Playlist) drill
-    /// in to their contained items; leaf items (Track, RadioStation, Podcast,
-    /// Audiobook, PodcastEpisode) play and push Now Playing.
+    /// Type-aware dispatch: container items (Artist, Album, Playlist, Podcast) drill
+    /// in to their contained items; leaf items (Track, RadioStation, Audiobook,
+    /// PodcastEpisode) play and push Now Playing.
     private func handleItemSelection(_ item: CPSelectableListItem) {
         // Drop offline taps with a visible alert.
         guard isReady else { showOfflineAlert(); return }
@@ -448,10 +448,12 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
             pushTracksForAlbum(album)
         } else if let playlist = mediaItem as? Playlist {
             pushTracksForPlaylist(playlist)
+        } else if let podcast = mediaItem as? Podcast {
+            pushEpisodesForPodcast(podcast)
         } else {
-            // Track / RadioStation / Podcast / Audiobook / PodcastEpisode — leaf items run the
-            // per-kind configured tap action. Only push Now Playing when it actually starts
-            // playback (a configured "add to queue" tap is non-disruptive).
+            // Track / RadioStation / Audiobook / PodcastEpisode — leaf items run the per-kind
+            // configured tap action. Only push Now Playing when it actually starts playback
+            // (a configured "add to queue" tap is non-disruptive).
             let dispatched = CarPlayContentManager.shared.playWithDefault(mediaItem)
             if let name = dispatched, Self.actionStartsPlayback(name) {
                 playAndShowNowPlaying()
@@ -503,6 +505,15 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
             bulkActionParent: playlist
         ) { completion in
             CarPlayContentManager.shared.fetchTracksForPlaylist(playlist, completion: completion)
+        }
+    }
+
+    private func pushEpisodesForPodcast(_ podcast: Podcast) {
+        pushDrilldown(
+            title: podcast.displayName,
+            bulkActionParent: podcast
+        ) { completion in
+            CarPlayContentManager.shared.fetchEpisodesForPodcast(podcast, completion: completion)
         }
     }
 


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

Podcasts were treated as leaf items (play on tap). They are now browsable containers that drill down to their episodes, matching the behavior of artists, albums, and playlists.

- KmpHelper.fetchEpisodesByPodcast: fetch + sort episodes (newest first)
- CarPlayContentManager.fetchEpisodesForPodcast: Swift wrapper
- CarPlaySceneDelegate: Podcast routes to pushEpisodesForPodcast drilldown

Closes #722

## Are there any additional changes not related to the issue above?

- Podcast list items use the podcast icon instead of generic music note

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`