### PR TITLE
Remove album/playlist sort menu

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/SortOption.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/SortOption.kt
@@ -73,13 +73,8 @@ object SortConfig {
     fun fieldsFor(context: SubItemContext): List<SortField> = when (context) {
         SubItemContext.ARTIST_ALBUMS -> listOf(SortField.NAME, SortField.YEAR)
         SubItemContext.ARTIST_TRACKS -> listOf(SortField.NAME, SortField.DURATION)
-        SubItemContext.ALBUM_TRACKS -> listOf(SortField.ORIGINAL, SortField.NAME, SortField.DURATION)
-        SubItemContext.PLAYLIST_ITEMS -> listOf(
-            SortField.ORIGINAL,
-            SortField.NAME,
-            SortField.ARTIST_NAME,
-            SortField.DURATION,
-        )
+        SubItemContext.ALBUM_TRACKS -> listOf(SortField.ORIGINAL)
+        SubItemContext.PLAYLIST_ITEMS -> listOf(SortField.ORIGINAL)
         SubItemContext.PODCAST_EPISODES -> listOf(SortField.NAME, SortField.RELEASE_DATE, SortField.DURATION)
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -566,7 +566,7 @@ private fun TabsBar(
                 )
             }
         }
-        if (sortCtx != null && currentSort != null) {
+        if (sortCtx != null && currentSort != null && sortCtx !in listOf(SubItemContext.ALBUM_TRACKS, SubItemContext.PLAYLIST_ITEMS)) {
             SortChip(
                 currentSort = currentSort,
                 availableFields = SortConfig.fieldsFor(sortCtx),

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -566,18 +566,22 @@ private fun TabsBar(
                 )
             }
         }
-        if (sortCtx != null && currentSort != null && sortCtx !in listOf(SubItemContext.ALBUM_TRACKS, SubItemContext.PLAYLIST_ITEMS)) {
-            SortChip(
-                currentSort = currentSort,
-                availableFields = SortConfig.fieldsFor(sortCtx),
-                onSortChanged = { opt ->
-                    if (sortCtx == SubItemContext.ARTIST_ALBUMS) {
-                        onAlbumsSortChanged(sortCtx, opt)
-                    } else {
-                        onPlayableItemsSortChanged(sortCtx, opt)
-                    }
-                },
-            )
+        if (sortCtx != null && currentSort != null) {
+            val availableFields = SortConfig.fieldsFor(sortCtx)
+
+            if (availableFields.size > 1) {
+                SortChip(
+                    currentSort = currentSort,
+                    availableFields = availableFields,
+                    onSortChanged = { opt ->
+                        if (sortCtx == SubItemContext.ARTIST_ALBUMS) {
+                            onAlbumsSortChanged(sortCtx, opt)
+                        } else {
+                            onPlayableItemsSortChanged(sortCtx, opt)
+                        }
+                    },
+                )
+            }
         }
 
         currentTab.viewMediaType?.let { viewMediaType ->


### PR DESCRIPTION
Based on discussion on Discord.

## Is there anything about the code changes here that should be highlighted?

It seems like the simplest thing to do while keeping options open for later was just to remove all the sort orders except for "Original" and then not show sort chips when there's only one option. 

## Before submitting this PR, make sure you have:
- [x] Given this PR a readable name that can be used in the app's changelog
- [x] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

