### PR TITLE
Backfill login/logout tests and extract server settings from `ServiceClient`

### DIFF
--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/LoginTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/LoginTest.kt
@@ -6,6 +6,8 @@ import io.music_assistant.client.api.ServiceClient
 import io.music_assistant.client.support.FakeServiceClient
 import io.music_assistant.client.support.Qualifiers
 import io.music_assistant.client.support.launchApp
+import io.music_assistant.client.support.launchLoggedInApp
+import io.music_assistant.client.support.pages.clickSettings
 import io.music_assistant.client.support.rules.createTestRuleChain
 import org.junit.Rule
 import org.junit.Test
@@ -30,5 +32,12 @@ class LoginTest {
             .connect()
             .loginWithError("wrong", serviceClient.password, "Invalid username or password")
             .loginWithError(serviceClient.username, "wrong", "Invalid username or password")
+    }
+
+    @Test
+    fun canLogout() {
+        launchLoggedInApp(composeTestRule, serviceClient)
+            .clickSettings()
+            .logout()
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/LoginTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/LoginTest.kt
@@ -35,7 +35,7 @@ class LoginTest {
     }
 
     @Test
-    fun canLogout() {
+    fun `can logout`() {
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickSettings()
             .logout()

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/LoginTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/LoginTest.kt
@@ -1,0 +1,34 @@
+package io.music_assistant.client.feature
+
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.music_assistant.client.api.ServiceClient
+import io.music_assistant.client.support.FakeServiceClient
+import io.music_assistant.client.support.Qualifiers
+import io.music_assistant.client.support.launchApp
+import io.music_assistant.client.support.rules.createTestRuleChain
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.java.KoinJavaComponent.inject
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(qualifiers = Qualifiers.MEDIUM_PHONE)
+class LoginTest {
+    @get:Rule
+    val testRuleChain = createTestRuleChain()
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    val serviceClient: FakeServiceClient by inject(ServiceClient::class.java)
+
+    @Test
+    fun `entering incorrect username or password shows server error`() {
+        launchApp(composeTestRule)
+            .connect()
+            .loginWithError("wrong", serviceClient.password, "Invalid username or password")
+            .loginWithError(serviceClient.username, "wrong", "Invalid username or password")
+    }
+}

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -31,6 +31,7 @@ import io.music_assistant.client.utils.SessionState
 import io.music_assistant.client.utils.UniqueIdGenerator
 import io.music_assistant.client.utils.getServerIdentifier
 import io.music_assistant.client.utils.myJson
+import io.music_assistant.client.utils.update
 import io.music_assistant.client.webrtc.DataChannelWrapper
 import io.music_assistant.client.webrtc.model.RemoteId
 import kotlinx.coroutines.flow.Flow
@@ -515,8 +516,16 @@ class FakeServiceClient(private val settingsRepository: SettingsRepository) : Se
     }
 
     override suspend fun login(username: String, password: String) {
-        authorize("token", true)
-        _isReadyForCommands.value = true
+        if (username == this.username && password == this.password) {
+            authorize("token", true)
+            _isReadyForCommands.value = true
+        } else {
+            _sessionState.update { state ->
+                (state as SessionState.Connected).update(
+                    authProcessState = AuthProcessState.Failed("Invalid username or password"),
+                )
+            }
+        }
     }
 
     override suspend fun authorize(token: String, isAutoLogin: Boolean) {

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -29,7 +29,6 @@ import io.music_assistant.client.utils.AuthProcessState
 import io.music_assistant.client.utils.ConnectionData
 import io.music_assistant.client.utils.SessionState
 import io.music_assistant.client.utils.UniqueIdGenerator
-import io.music_assistant.client.utils.getServerIdentifier
 import io.music_assistant.client.utils.myJson
 import io.music_assistant.client.utils.update
 import io.music_assistant.client.webrtc.DataChannelWrapper
@@ -529,11 +528,6 @@ class FakeServiceClient(private val settingsRepository: SettingsRepository) : Se
     }
 
     override suspend fun authorize(token: String, isAutoLogin: Boolean) {
-        val serverIdentifier = settingsRepository.getServerIdentifier(_sessionState.value)
-        if (serverIdentifier != null) {
-            settingsRepository.setTokenForServer(serverIdentifier, token)
-        }
-
         _sessionState.update {
             when (it) {
                 is SessionState.Connected.Direct -> {
@@ -543,6 +537,7 @@ class FakeServiceClient(private val settingsRepository: SettingsRepository) : Se
                             authProcessState = AuthProcessState.NotStarted,
                             user = User("-1", username, username, "user"),
                             wasAutoLogin = true,
+                            token = token,
                         ),
                     )
                 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -626,6 +626,10 @@ class FakeServiceClient : ServiceClient {
         }
     }
 
+    override fun noServer() {
+        _sessionState.update { SessionState.Disconnected.NoServerData }
+    }
+
     fun addToLibrary(vararg items: ServerMediaItem) {
         this.items.addAll(items)
         items.forEach { item ->

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -547,7 +547,12 @@ class FakeServiceClient : ServiceClient {
     }
 
     override fun logout() {
-        TODO("Not yet implemented")
+        _sessionState.update {
+            (it as? SessionState.Connected)?.update(
+                authProcessState = AuthProcessState.LoggedOut,
+                user = null,
+            ) ?: it
+        }
     }
 
     override fun resolveImageUrl(

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -24,7 +24,6 @@ import io.music_assistant.client.data.model.server.events.Event
 import io.music_assistant.client.data.model.server.events.PlayerUpdatedEvent
 import io.music_assistant.client.data.model.server.events.QueueItemsUpdatedEvent
 import io.music_assistant.client.data.model.server.events.QueueUpdatedEvent
-import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.utils.AuthProcessState
 import io.music_assistant.client.utils.ConnectionData
 import io.music_assistant.client.utils.SessionState
@@ -45,7 +44,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.encodeToJsonElement
 
-class FakeServiceClient(private val settingsRepository: SettingsRepository) : ServiceClient {
+class FakeServiceClient : ServiceClient {
     private var legacyVersion: LegacyVersion? = null
     private var requestErrors: Boolean = false
     private var connectionError: Exception? = null
@@ -601,7 +600,6 @@ class FakeServiceClient(private val settingsRepository: SettingsRepository) : Se
                 )
                 _sessionState.value = SessionState.Connected.Direct(connection, connectionData)
                 _serverBaseUrl.value = connectionData.serverInfo?.baseUrl
-                settingsRepository.updateConnectionInfo(connection)
             } else {
                 _sessionState.value = SessionState.Disconnected.Error(it)
                 _serverBaseUrl.value = null

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -550,9 +550,6 @@ class FakeServiceClient : ServiceClient {
         TODO("Not yet implemented")
     }
 
-    private val _serverBaseUrl = MutableStateFlow<String?>(null)
-    override val serverBaseUrl: StateFlow<String?> = _serverBaseUrl
-
     override fun resolveImageUrl(
         path: String,
         provider: String,
@@ -599,10 +596,8 @@ class FakeServiceClient : ServiceClient {
                     ),
                 )
                 _sessionState.value = SessionState.Connected.Direct(connection, connectionData)
-                _serverBaseUrl.value = connectionData.serverInfo?.baseUrl
             } else {
                 _sessionState.value = SessionState.Disconnected.Error(it)
-                _serverBaseUrl.value = null
             }
         }
     }
@@ -747,7 +742,6 @@ class FakeServiceClient : ServiceClient {
 
         if (error != null) {
             _sessionState.value = SessionState.Disconnected.Error(error)
-            _serverBaseUrl.value = null
         }
     }
 

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/AuthenticatePage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/AuthenticatePage.kt
@@ -14,9 +14,20 @@ class AuthenticatePage(private val composeTestRule: ComposeTestRule) : Page {
     }
 
     fun login(username: String, password: String): HomePage {
+        fillLogin(username, password)
+        return HomePage(composeTestRule).assertOnPage()
+    }
+
+    fun loginWithError(username: String, password: String, error: String): AuthenticatePage {
+        fillLogin(username, password)
+
+        composeTestRule.onNodeWithText(error).assertIsDisplayed()
+        return this.assertOnPage()
+    }
+
+    private fun fillLogin(username: String, password: String) {
         composeTestRule.onNodeWithText("Username").assertIsDisplayed().performTextInput(username)
         composeTestRule.onNodeWithText("Password").assertIsDisplayed().performTextInput(password)
         composeTestRule.onNodeWithText("Login").assertIsDisplayed().performClick()
-        return HomePage(composeTestRule).assertOnPage()
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SettingsPage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SettingsPage.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import io.music_assistant.client.support.get
 import musicassistantclient.composeapp.generated.resources.Res
+import musicassistantclient.composeapp.generated.resources.auth_logout
 import musicassistantclient.composeapp.generated.resources.nav_settings
 import musicassistantclient.composeapp.generated.resources.settings_disconnect
 
@@ -18,5 +19,10 @@ class SettingsPage(composeTestRule: ComposeTestRule) : ComposePage(composeTestRu
     fun disconnect(): ConnectPage {
         composeTestRule.onNodeWithText(Res.string.settings_disconnect.get()).performClick()
         return ConnectPage(composeTestRule, savedCredentials = true).assertOnPage()
+    }
+
+    fun logout(): AuthenticatePage {
+        composeTestRule.onNodeWithText(Res.string.auth_logout.get()).performClick()
+        return AuthenticatePage(composeTestRule).assertOnPage()
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/rules/KoinTestRule.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/rules/KoinTestRule.kt
@@ -24,8 +24,8 @@ fun createKoinTestRule(): KoinTestRule {
 }
 
 private fun createFakeServiceClient(
-    settingsRepository: SettingsRepository,
+    @Suppress("UNUSED_PARAMETER")settingsRepository: SettingsRepository,
     @Suppress("UNUSED_PARAMETER") errorBus: ErrorMessageBus,
 ): FakeServiceClient {
-    return FakeServiceClient(settingsRepository)
+    return FakeServiceClient()
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -28,7 +28,6 @@ import io.music_assistant.client.utils.SessionState
 import io.music_assistant.client.utils.connectionInfo
 import io.music_assistant.client.utils.createPlatformHttpClient
 import io.music_assistant.client.utils.currentTimeMillis
-import io.music_assistant.client.utils.getServerIdentifier
 import io.music_assistant.client.utils.myJson
 import io.music_assistant.client.utils.update
 import io.music_assistant.client.webrtc.model.RemoteId
@@ -845,7 +844,6 @@ class KtorServiceClient(
                 AuthResolution.Aborted -> return
                 is AuthResolution.Surface -> setAuthFailed(resolution.message)
                 is AuthResolution.Reject -> {
-                    clearCurrentServerToken()
                     setAuthFailed(resolution.message)
                 }
 
@@ -856,7 +854,6 @@ class KtorServiceClient(
         } catch (e: Exception) {
             if (_sessionState.value !is SessionState.Connected) return
             setAuthFailed(e.message ?: "Exception happened: $e")
-            clearCurrentServerToken()
         }
     }
 
@@ -874,13 +871,6 @@ class KtorServiceClient(
     }
 
     override fun logout() {
-        val currentState = _sessionState.value
-        if (currentState is SessionState.Connected) {
-            val serverIdentifier = settings.getServerIdentifier(currentState)
-            settings.setTokenForServer(serverIdentifier, null)
-            logger.d { "Cleared token for server" }
-        }
-
         if (_sessionState.value !is SessionState.Connected) return
         _sessionState.update {
             (it as? SessionState.Connected)?.update(
@@ -915,7 +905,6 @@ class KtorServiceClient(
                 AuthResolution.Aborted -> return
                 is AuthResolution.Surface -> setAuthFailed(resolution.message)
                 is AuthResolution.Reject -> {
-                    clearCurrentServerToken()
                     setAuthFailed(resolution.message)
                 }
                 is AuthResolution.Authenticated ->
@@ -926,7 +915,6 @@ class KtorServiceClient(
         } catch (e: Exception) {
             if (_sessionState.value !is SessionState.Connected) return
             setAuthFailed(e.message ?: "Exception happened: $e")
-            clearCurrentServerToken()
         }
     }
 
@@ -934,12 +922,6 @@ class KtorServiceClient(
         val user = answer.resultAs<AuthorizationResponse>()?.user ?: run {
             setAuthFailed("Failed to parse user data")
             return
-        }
-        val currentState = _sessionState.value
-        if (currentState is SessionState.Connected) {
-            val serverIdentifier = settings.getServerIdentifier(currentState)
-            settings.setTokenForServer(serverIdentifier, token)
-            logger.d { "Saved token for server" }
         }
 
         silentReauth.reset()
@@ -949,16 +931,8 @@ class KtorServiceClient(
                 user = user,
                 wasAutoLogin = isAutoLogin,
                 needsServerReauth = false,
+                token = token,
             ) ?: it
-        }
-    }
-
-    private fun clearCurrentServerToken() {
-        val currentState = _sessionState.value
-        if (currentState is SessionState.Connected) {
-            val serverIdentifier = settings.getServerIdentifier(currentState)
-            settings.setTokenForServer(serverIdentifier, null)
-            logger.i { "Cleared token for server due to auth failure" }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -25,7 +25,6 @@ import io.music_assistant.client.utils.DataConnectionState
 import io.music_assistant.client.utils.HasConnectionData
 import io.music_assistant.client.utils.NetworkMonitor
 import io.music_assistant.client.utils.SessionState
-import io.music_assistant.client.utils.connectionInfo
 import io.music_assistant.client.utils.createPlatformHttpClient
 import io.music_assistant.client.utils.currentTimeMillis
 import io.music_assistant.client.utils.myJson
@@ -128,16 +127,6 @@ class KtorServiceClient(
     private val _sessionState: MutableStateFlow<SessionState> =
         MutableStateFlow(SessionState.Disconnected.Initial)
     override val sessionState = _sessionState.asStateFlow()
-
-    override val serverBaseUrl: StateFlow<String?> = _sessionState
-        .map { state ->
-            when (state) {
-                is SessionState.Connected.Direct -> state.connectionInfo.webUrl
-                is SessionState.Reconnecting.Direct -> state.connectionInfo.webUrl
-                else -> null
-            }
-        }
-        .stateIn(this, SharingStarted.Eagerly, null)
 
     override val isReadyForCommands: StateFlow<Boolean> = _sessionState
         .map { it is SessionState.Connected && it.dataConnectionState is DataConnectionState.Authenticated }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -364,6 +364,10 @@ class KtorServiceClient(
         disconnect(SessionState.Disconnected.Error(reason))
     }
 
+    override fun noServer() {
+        _sessionState.update { SessionState.Disconnected.NoServerData }
+    }
+
     /**
      * Called when the app returns to the foreground.
      */
@@ -429,56 +433,6 @@ class KtorServiceClient(
         launch {
             isReadyForCommands.collect { ready ->
                 logger.i { "isReadyForCommands=$ready" }
-            }
-        }
-
-        launch {
-            _sessionState.collect { state ->
-                when (state) {
-                    is SessionState.Connected -> Unit
-                    is SessionState.Reconnecting -> Unit
-
-                    is SessionState.Disconnected -> {
-                        when (state) {
-                            SessionState.Disconnected.ByUser,
-                            SessionState.Disconnected.NoServerData,
-                            SessionState.Disconnected.Backgrounded,
-                            is SessionState.Disconnected.Error,
-                            -> Unit
-
-                            SessionState.Disconnected.Initial -> {
-                                val mostRecent = settings.connectionHistory.value.firstOrNull()
-                                when (mostRecent?.type) {
-                                    ConnectionType.DIRECT -> {
-                                        val connInfo = mostRecent.connectionInfo
-                                        if (connInfo != null) {
-                                            connect(connInfo)
-                                        } else {
-                                            _sessionState.update { SessionState.Disconnected.NoServerData }
-                                        }
-                                    }
-
-                                    ConnectionType.WEBRTC -> {
-                                        val remoteId =
-                                            mostRecent.remoteId?.let { RemoteId.parse(it) }
-                                        if (remoteId != null) {
-                                            connectWebRTC(remoteId)
-                                        } else {
-                                            _sessionState.update { SessionState.Disconnected.NoServerData }
-                                        }
-                                    }
-
-                                    else -> {
-                                        settings.connectionInfo.value?.let { connect(it) }
-                                            ?: _sessionState.update { SessionState.Disconnected.NoServerData }
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    SessionState.Connecting -> Unit
-                }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -442,20 +442,12 @@ class KtorServiceClient(
                 logger.i { "isReadyForCommands=$ready" }
             }
         }
+
         launch {
             _sessionState.collect { state ->
                 when (state) {
-                    is SessionState.Connected -> {
-                        state.connectionInfo?.let { connInfo ->
-                            settings.updateConnectionInfo(connInfo)
-                        }
-                    }
-
-                    is SessionState.Reconnecting -> {
-                        state.connectionInfo?.let { connInfo ->
-                            settings.updateConnectionInfo(connInfo)
-                        }
-                    }
+                    is SessionState.Connected -> Unit
+                    is SessionState.Reconnecting -> Unit
 
                     is SessionState.Disconnected -> {
                         when (state) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/ServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/ServiceClient.kt
@@ -16,7 +16,6 @@ interface ServiceClient {
     suspend fun authorize(token: String, isAutoLogin: Boolean = false)
     fun logout()
     val isReadyForCommands: StateFlow<Boolean>
-    val serverBaseUrl: StateFlow<String?>
     fun resolveImageUrl(
         path: String,
         provider: String,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/ServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/ServiceClient.kt
@@ -39,6 +39,7 @@ interface ServiceClient {
     fun onExternalConsumerInactive()
     fun onPlaybackInactive()
     fun forceDisconnect(reason: Exception)
+    fun noServer()
 
     /** True while an external consumer (Android Auto / CarPlay) is bound. Cross-platform car edge. */
     val externalConsumerActive: StateFlow<Boolean>

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/auth/AuthenticationManager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/auth/AuthenticationManager.kt
@@ -114,6 +114,10 @@ class AuthenticationManager(
                                 }
 
                                 is AuthProcessState.Failed -> {
+                                    val serverIdentifier = settings.getServerIdentifier(state)
+                                    settings.setTokenForServer(serverIdentifier, null)
+                                    log.i { "Cleared token for server due to auth failure" }
+
                                     log.i {
                                         "AwaitingAuth(Failed): " +
                                             dataConnectionState.authProcessState.reason
@@ -123,6 +127,10 @@ class AuthenticationManager(
                                 }
 
                                 AuthProcessState.LoggedOut -> {
+                                    val serverIdentifier = settings.getServerIdentifier(state)
+                                    settings.setTokenForServer(serverIdentifier, null)
+                                    log.d { "Cleared token for server" }
+
                                     log.i { "AwaitingAuth(LoggedOut)" }
                                     _authState.value = AuthState.Idle
                                 }
@@ -136,9 +144,10 @@ class AuthenticationManager(
 
                                 val serverIdentifier = settings.getServerIdentifier(state)
                                 val serverId = dataConnectionState.serverInfo.serverId
-                                settings.setIdForServer(
+                                settings.setIdForServer(serverIdentifier, serverId)
+                                settings.setTokenForServer(
                                     serverIdentifier,
-                                    serverId,
+                                    dataConnectionState.token,
                                 )
                             }
                         }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/auth/AuthenticationManager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/auth/AuthenticationManager.kt
@@ -11,7 +11,6 @@ import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.utils.AuthProcessState
 import io.music_assistant.client.utils.DataConnectionState
 import io.music_assistant.client.utils.SessionState
-import io.music_assistant.client.utils.getServerIdentifier
 import io.music_assistant.client.utils.mainDispatcher
 import io.music_assistant.client.utils.resultAs
 import kotlinx.coroutines.CancellationException
@@ -343,3 +342,22 @@ class AuthenticationManager(
 }
 
 class ServerIdMismatchException : Exception()
+
+private fun SettingsRepository.getServerIdentifier(sessionState: SessionState): String? {
+    return when (sessionState) {
+        is SessionState.Connected -> getServerIdentifier(sessionState)
+        else -> null
+    }
+}
+
+private fun SettingsRepository.getServerIdentifier(sessionState: SessionState.Connected): String {
+    return when (sessionState) {
+        is SessionState.Connected.Direct -> this.getDirectServerIdentifier(
+            sessionState.connectionInfo.host,
+            sessionState.connectionInfo.port,
+            sessionState.connectionInfo.isTls,
+        )
+
+        is SessionState.Connected.WebRTC -> this.getWebRTCServerIdentifier(sessionState.remoteId.rawId)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/connection/ConnectionManager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/connection/ConnectionManager.kt
@@ -1,0 +1,39 @@
+package io.music_assistant.client.connection
+
+import io.music_assistant.client.api.ServiceClient
+import io.music_assistant.client.settings.SettingsRepository
+import io.music_assistant.client.utils.SessionState
+import io.music_assistant.client.utils.connectionInfo
+import io.music_assistant.client.utils.mainDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+class ConnectionManager(
+    private val serviceClient: ServiceClient,
+    private val settings: SettingsRepository,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + mainDispatcher)
+
+    init {
+        scope.launch {
+            serviceClient.sessionState.collect { state ->
+                when (state) {
+                    is SessionState.Connected -> {
+                        state.connectionInfo?.let { connInfo ->
+                            settings.updateConnectionInfo(connInfo)
+                        }
+                    }
+
+                    is SessionState.Reconnecting -> {
+                        state.connectionInfo?.let { connInfo ->
+                            settings.updateConnectionInfo(connInfo)
+                        }
+                    }
+
+                    else -> {}
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/connection/ConnectionManager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/connection/ConnectionManager.kt
@@ -1,10 +1,12 @@
 package io.music_assistant.client.connection
 
 import io.music_assistant.client.api.ServiceClient
+import io.music_assistant.client.settings.ConnectionType
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.utils.SessionState
 import io.music_assistant.client.utils.connectionInfo
 import io.music_assistant.client.utils.mainDispatcher
+import io.music_assistant.client.webrtc.model.RemoteId
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.SharingStarted
@@ -45,7 +47,47 @@ class ConnectionManager(
                         }
                     }
 
-                    else -> {}
+                    is SessionState.Disconnected -> {
+                        when (state) {
+                            SessionState.Disconnected.ByUser,
+                            SessionState.Disconnected.NoServerData,
+                            SessionState.Disconnected.Backgrounded,
+                            is SessionState.Disconnected.Error,
+                                -> Unit
+
+                            SessionState.Disconnected.Initial -> {
+                                val mostRecent = settings.connectionHistory.value.firstOrNull()
+                                when (mostRecent?.type) {
+                                    ConnectionType.DIRECT -> {
+                                        val connInfo = mostRecent.connectionInfo
+                                        if (connInfo != null) {
+                                            serviceClient.connect(connInfo)
+                                        } else {
+                                            serviceClient.noServer()
+                                        }
+                                    }
+
+                                    ConnectionType.WEBRTC -> {
+                                        val remoteId =
+                                            mostRecent.remoteId?.let { RemoteId.parse(it) }
+                                        if (remoteId != null) {
+                                            serviceClient.connectWebRTC(remoteId)
+                                        } else {
+                                            serviceClient.noServer()
+                                        }
+                                    }
+
+                                    else -> {
+                                        settings.connectionInfo.value?.let {
+                                            serviceClient.connect(it)
+                                        } ?: serviceClient.noServer()
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    else -> Unit
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/connection/ConnectionManager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/connection/ConnectionManager.kt
@@ -7,6 +7,10 @@ import io.music_assistant.client.utils.connectionInfo
 import io.music_assistant.client.utils.mainDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 class ConnectionManager(
@@ -14,6 +18,16 @@ class ConnectionManager(
     private val settings: SettingsRepository,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + mainDispatcher)
+
+    val serverBaseUrl: StateFlow<String?> = serviceClient.sessionState
+        .map { state ->
+            when (state) {
+                is SessionState.Connected.Direct -> state.connectionInfo.webUrl
+                is SessionState.Reconnecting.Direct -> state.connectionInfo.webUrl
+                else -> null
+            }
+        }
+        .stateIn(scope, SharingStarted.Eagerly, null)
 
     init {
         scope.launch {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/di/SharedModule.kt
@@ -6,6 +6,7 @@ import io.music_assistant.client.api.KtorServiceClient
 import io.music_assistant.client.api.ServiceClient
 import io.music_assistant.client.auth.AuthCoordinator
 import io.music_assistant.client.auth.AuthenticationManager
+import io.music_assistant.client.connection.ConnectionManager
 import io.music_assistant.client.data.CarDspApplier
 import io.music_assistant.client.data.LocalPlayerController
 import io.music_assistant.client.data.MainDataSource
@@ -57,6 +58,12 @@ fun sharedModule(
         singleOf(::ImageCacheInvalidator)
         singleOf(serviceClientConstructor) { bind<ServiceClient>() }
         singleOf(::LogSharer)
+        single(createdAtStart = true) {
+            ConnectionManager(
+                get(),
+                get(),
+            )
+        }
         single(createdAtStart = true) {
             AuthenticationManager(
                 get(),

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/ConnectionData.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/ConnectionData.kt
@@ -12,6 +12,7 @@ data class ConnectionData(
     val user: User? = null,
     val authProcessState: AuthProcessState = AuthProcessState.NotStarted,
     val wasAutoLogin: Boolean = false,
+    val token: String? = null,
     /**
      * True when the transport reconnected and the underlying server-side session
      * does NOT survive that reconnect (e.g. WebRTC: every new peer connection is a
@@ -26,7 +27,7 @@ data class ConnectionData(
         get() = when {
             serverInfo == null -> DataConnectionState.AwaitingServerInfo
             user == null || needsServerReauth -> DataConnectionState.AwaitingAuth(authProcessState, serverInfo)
-            else -> DataConnectionState.Authenticated(serverInfo)
+            else -> DataConnectionState.Authenticated(serverInfo, token!!)
         }
 }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/ConnectionData.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/ConnectionData.kt
@@ -26,8 +26,14 @@ data class ConnectionData(
     val dataConnectionState: DataConnectionState
         get() = when {
             serverInfo == null -> DataConnectionState.AwaitingServerInfo
-            user == null || needsServerReauth -> DataConnectionState.AwaitingAuth(authProcessState, serverInfo)
-            else -> DataConnectionState.Authenticated(serverInfo, token!!)
+            user == null || needsServerReauth || token == null -> {
+                DataConnectionState.AwaitingAuth(
+                    authProcessState,
+                    serverInfo,
+                )
+            }
+
+            else -> DataConnectionState.Authenticated(serverInfo, token)
         }
 }
 
@@ -37,13 +43,14 @@ data class ConnectionData(
  */
 sealed interface HasConnectionData {
     val connectionData: ConnectionData
-    val serverInfo: ServerInfo? get() = dataConnectionState.let {
-        when (it) {
-            is DataConnectionState.Authenticated -> it.serverInfo
-            is DataConnectionState.AwaitingAuth -> it.serverInfo
-            DataConnectionState.AwaitingServerInfo -> null
+    val serverInfo: ServerInfo?
+        get() = dataConnectionState.let {
+            when (it) {
+                is DataConnectionState.Authenticated -> it.serverInfo
+                is DataConnectionState.AwaitingAuth -> it.serverInfo
+                DataConnectionState.AwaitingServerInfo -> null
+            }
         }
-    }
 
     val user: User? get() = connectionData.user
     val authProcessState: AuthProcessState get() = connectionData.authProcessState

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/DataConnectionState.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/DataConnectionState.kt
@@ -7,5 +7,5 @@ sealed interface DataConnectionState {
     data class AwaitingAuth(val authProcessState: AuthProcessState, val serverInfo: ServerInfo) :
         DataConnectionState
 
-    data class Authenticated(val serverInfo: ServerInfo) : DataConnectionState
+    data class Authenticated(val serverInfo: ServerInfo, val token: String) : DataConnectionState
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/SessionState.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/SessionState.kt
@@ -88,6 +88,7 @@ fun SessionState.Connected.update(
     user: User? = this.user,
     authProcessState: AuthProcessState = this.authProcessState,
     wasAutoLogin: Boolean = this.wasAutoLogin,
+    token: String? = this.connectionData.token,
     needsServerReauth: Boolean = this.connectionData.needsServerReauth,
 ): SessionState.Connected = update(
     connectionData = ConnectionData(
@@ -95,6 +96,7 @@ fun SessionState.Connected.update(
         user,
         authProcessState,
         wasAutoLogin,
+        token,
         needsServerReauth,
     ),
 )
@@ -127,6 +129,7 @@ fun SessionState.Reconnecting.update(
     user: User? = this.user,
     authProcessState: AuthProcessState = this.authProcessState,
     wasAutoLogin: Boolean = this.wasAutoLogin,
+    token: String? = this.connectionData.token,
     needsServerReauth: Boolean = this.connectionData.needsServerReauth,
 ): SessionState.Reconnecting = update(
     connectionData = ConnectionData(
@@ -134,6 +137,7 @@ fun SessionState.Reconnecting.update(
         user,
         authProcessState,
         wasAutoLogin,
+        token,
         needsServerReauth,
     ),
 )

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/SessionState.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/SessionState.kt
@@ -3,7 +3,6 @@ package io.music_assistant.client.utils
 import io.music_assistant.client.api.ConnectionInfo
 import io.music_assistant.client.data.model.server.ServerInfo
 import io.music_assistant.client.data.model.server.User
-import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.webrtc.model.RemoteId
 
 sealed class SessionState {
@@ -150,22 +149,3 @@ val SessionState.Reconnecting.connectionInfo: ConnectionInfo?
         is SessionState.Reconnecting.Direct -> connectionInfo
         is SessionState.Reconnecting.WebRTC -> null
     }
-
-fun SettingsRepository.getServerIdentifier(sessionState: SessionState): String? {
-    return when (sessionState) {
-        is SessionState.Connected -> getServerIdentifier(sessionState)
-        else -> null
-    }
-}
-
-fun SettingsRepository.getServerIdentifier(sessionState: SessionState.Connected): String {
-    return when (sessionState) {
-        is SessionState.Connected.Direct -> this.getDirectServerIdentifier(
-            sessionState.connectionInfo.host,
-            sessionState.connectionInfo.port,
-            sessionState.connectionInfo.isTls,
-        )
-
-        is SessionState.Connected.WebRTC -> this.getWebRTCServerIdentifier(sessionState.remoteId.rawId)
-    }
-}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/auth/AuthenticationManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/auth/AuthenticationManagerTest.kt
@@ -137,7 +137,6 @@ private class StubServiceClient : ServiceClient {
     override val sessionState = MutableStateFlow<SessionState>(SessionState.Disconnected.Initial)
     override val isReadyForCommands = MutableStateFlow(false)
     override val externalConsumerActive = MutableStateFlow(false)
-    override val serverBaseUrl = MutableStateFlow<String?>(null)
     override val webRTCHttpProxy: WebRTCHttpProxy? = null
     override val events: Flow<Event<out Any>> = emptyFlow()
     override val webrtcSendspinChannel: DataChannelWrapper? = null
@@ -165,4 +164,5 @@ private class StubServiceClient : ServiceClient {
     override fun onExternalConsumerInactive() = Unit
     override fun onPlaybackInactive() = Unit
     override fun forceDisconnect(reason: Exception) = Unit
+    override fun noServer() = Unit
 }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/LocalPlayerDispatchTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/LocalPlayerDispatchTest.kt
@@ -388,8 +388,6 @@ private class RecordingClient(
         get() = error("not used")
     override val externalConsumerActive: StateFlow<Boolean>
         get() = error("not used")
-    override val serverBaseUrl: StateFlow<String?>
-        get() = error("not used")
     override val events: Flow<Event<out Any>>
         get() = error("not used")
     override val webrtcSendspinChannel: DataChannelWrapper? = null
@@ -418,4 +416,5 @@ private class RecordingClient(
     override fun onExternalConsumerInactive() = Unit
     override fun onPlaybackInactive() = Unit
     override fun forceDisconnect(reason: Exception) = Unit
+    override fun noServer() = Unit
 }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/StubServiceClient.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/StubServiceClient.kt
@@ -32,8 +32,6 @@ class StubServiceClient : ServiceClient {
         get() = TODO("Not yet implemented")
     override val externalConsumerActive: StateFlow<Boolean>
         get() = TODO("Not yet implemented")
-    override val serverBaseUrl: StateFlow<String?>
-        get() = TODO("Not yet implemented")
 
     override fun resolveImageUrl(path: String, provider: String, isRemotelyAccessible: Boolean, proxyId: String?): String? = null
 
@@ -79,5 +77,8 @@ class StubServiceClient : ServiceClient {
     }
 
     override fun forceDisconnect(reason: Exception) {
+    }
+
+    override fun noServer() {
     }
 }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/auth/AuthenticationViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/auth/AuthenticationViewModelTest.kt
@@ -159,7 +159,7 @@ class AuthenticationViewModelTest {
 
             // serverInfo + user populated → dataConnectionState resolves to Authenticated.
             sessionState.value = connectedDirectWith(
-                ConnectionData(serverInfo = SERVER_INFO, user = USER_FIXTURE),
+                ConnectionData(serverInfo = SERVER_INFO, user = USER_FIXTURE, token = "blah"),
             )
             expectNoEvents()
 

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
@@ -12,6 +12,7 @@ import io.music_assistant.client.api.Request
 import io.music_assistant.client.api.ServiceClient
 import io.music_assistant.client.auth.AuthenticationManager
 import io.music_assistant.client.carplay.CarPlayStrings
+import io.music_assistant.client.connection.ConnectionManager
 import io.music_assistant.client.data.MainDataSource
 import io.music_assistant.client.data.executeLocalPlayerDispatch
 import io.music_assistant.client.data.model.client.MediaType
@@ -74,6 +75,7 @@ object KmpHelper : KoinComponent {
     val mainDataSource: MainDataSource by inject()
     val serviceClient: ServiceClient by inject()
     val authManager: AuthenticationManager by inject()
+    val connectionManager: ConnectionManager by inject()
     private val deepLinkBus: DeepLinkBus by inject()
     private val mediaItemRepository: MediaItemRepository by inject()
     private val settingsRepository: SettingsRepository by inject()
@@ -84,7 +86,7 @@ object KmpHelper : KoinComponent {
     val mainScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     fun getServerUrl(): String? {
-        return serviceClient.serverBaseUrl.value
+        return connectionManager.serverBaseUrl.value
     }
 
     /**


### PR DESCRIPTION
Follow up to #749

## Is there anything about the code changes here that should be highlighted?

The main idea here was to extract as much as possible of the `SettingsRepository` interactions from `KtorServiceClient` around connection/authentication to "thin out" those parts of the implementation. That simplifies that class itself, but more importantly moves more code within the boundary for tests that use `FakeServiceClient` (making those tests more "realistic").

## Are there any additional changes not related to the issue above?

## Before submitting this PR, make sure you have:
- [x] Given this PR a readable name that can be used in the app's changelog
- [x] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

