### PR TITLE
Fix 'error loading data' against latest Music Assistant dev server

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerMediaItem.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerMediaItem.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.intOrNull
@@ -51,8 +52,10 @@ data class ServerMediaItem(
     // podcast episode only
     @SerialName("podcast") val podcast: ServerMediaItem? = null,
     // Audiobook only
-    @SerialName("authors") val authors: List<String>? = null,
-    @SerialName("narrators") val narrators: List<String>? = null,
+    // Server sends plain strings (legacy) or Artist/ItemMapping objects
+    // either shape decodes to the display name.
+    @SerialName("authors") val authors: List<@Serializable(NameOrStringSerializer::class) String>? = null,
+    @SerialName("narrators") val narrators: List<@Serializable(NameOrStringSerializer::class) String>? = null,
     @SerialName("publisher") val publisher: String? = null,
     // Progress tracking (audiobooks, podcast episodes)
     // Server sends Boolean for audiobooks and Int 0/1 for podcast episodes
@@ -117,6 +120,24 @@ data class ServerMediaItemChapter(
     @SerialName("start") val start: Double,
     @SerialName("end") val end: Double? = null,
 )
+
+// Audiobook authors/narrators changed server-side from `list[str]` to
+// `list[Artist | ItemMapping | str]`. Accept a JSON string as-is, or take the
+// `name` field of an object; the app only needs the display name.
+private object NameOrStringSerializer : KSerializer<String> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("NameOrString", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): String =
+        (decoder as? JsonDecoder)?.decodeJsonElement()?.let { element ->
+            when (element) {
+                is JsonPrimitive -> element.content
+                is JsonObject -> (element["name"] as? JsonPrimitive)?.content ?: ""
+                else -> ""
+            }
+        } ?: decoder.decodeString()
+
+    override fun serialize(encoder: Encoder, value: String) = encoder.encodeString(value)
+}
 
 // Server inconsistency: audiobooks send Boolean, podcast episodes send Int 0/1
 private object FlexibleBooleanSerializer : KSerializer<Boolean> {

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/ServerMediaItemSerializationTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/ServerMediaItemSerializationTest.kt
@@ -48,4 +48,29 @@ class ServerMediaItemSerializationTest {
 
         assertEquals(validAlbumPosition.toInt(), track.position)
     }
+
+    // Audiobook authors/narrators arrive as plain strings (legacy) or as
+    // Artist/ItemMapping objects (current server dev); both must decode.
+    private val audiobookJson = """
+        {"item_id":"1560","provider":"library","name":"10 Blind Dates",
+         "media_type":"audiobook","is_playable":true,
+         "authors":[
+           {"item_id":"a1","provider":"library","name":"Ashley Elston",
+            "media_type":"artist","available":true,"is_playable":true,
+            "image":null,"year":null},
+           "Plain String Author"
+         ],
+         "narrators":[
+           {"item_id":"n1","provider":"library","name":"Nora Narrator",
+            "media_type":"artist","available":true}
+         ]}
+    """.trimIndent()
+
+    @Test
+    fun decodesAuthorsAndNarratorsFromObjectsOrStrings() {
+        val item = myJson.decodeFromString<ServerMediaItem>(audiobookJson)
+
+        assertEquals(listOf("Ashley Elston", "Plain String Author"), item.authors)
+        assertEquals(listOf("Nora Narrator"), item.narrators)
+    }
 }


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

The server (music-assistant/models dev) changed audiobook authors and narrators from list[str] to list[Artist | ItemMapping | str], so lists containing audiobooks (music/recommendations, audiobook library) failed to decode with 'Expected JsonPrimitive, but had JsonObject'.

Accept both shapes: plain strings pass through, objects contribute their 'name' field.

## Are there any additional changes not related to the issue above?

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

