### PR TITLE
Add monotonic sleep-inclusive clock monotonicMs() for KMP

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/music_assistant/client/utils/PlatformTime.kt
+++ b/composeApp/src/androidMain/kotlin/io/music_assistant/client/utils/PlatformTime.kt
@@ -1,10 +1,25 @@
 package io.music_assistant.client.utils
 
+import android.os.SystemClock
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 
 actual fun currentTimeMillis(): Long = System.currentTimeMillis()
+
+/** False in local JVM unit tests, where the android.jar [SystemClock] stub throws. */
+private val hasRealSystemClock: Boolean = try {
+    SystemClock.elapsedRealtime()
+    true
+} catch (_: RuntimeException) {
+    false
+}
+
+private const val NANOS_PER_MILLI = 1_000_000L
+
+/** [SystemClock.elapsedRealtime] ticks through deep sleep; [SystemClock.uptimeMillis] doesn't. */
+actual fun monotonicMs(): Long =
+    if (hasRealSystemClock) SystemClock.elapsedRealtime() else System.nanoTime() / NANOS_PER_MILLI
 
 actual fun formatIsoDate(isoDate: String): String = try {
     LocalDate.parse(isoDate.substringBefore("T"))

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/PlatformTime.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/PlatformTime.kt
@@ -2,4 +2,11 @@ package io.music_assistant.client.utils
 
 expect fun currentTimeMillis(): Long
 
+/**
+ * Monotonic sleep-inclusive milliseconds with an arbitrary origin: only comparable to
+ * other readings of this clock in this process — never to wall time, never across the
+ * language bridge.
+ */
+expect fun monotonicMs(): Long
+
 expect fun formatIsoDate(isoDate: String): String

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/utils/MonotonicClockTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/utils/MonotonicClockTest.kt
@@ -1,0 +1,30 @@
+package io.music_assistant.client.utils
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class MonotonicClockTest {
+    @Test
+    fun repeatedReadingsNeverDecrease() {
+        var previous = monotonicMs()
+        repeat(1000) {
+            val next = monotonicMs()
+            assertTrue(next >= previous, "clock went backwards: $previous -> $next")
+            previous = next
+        }
+    }
+
+    @Test
+    fun advancesWithRealElapsedTime() = runTest {
+        val before = monotonicMs()
+        // Real (non-virtual) delay: runTest skips delays on its own scheduler,
+        // so hop to a real dispatcher for the wait.
+        withContext(Dispatchers.Default) { delay(60) }
+        val after = monotonicMs()
+        assertTrue(after - before >= 40, "expected >=40ms advance, got ${after - before}ms")
+    }
+}

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/utils/PlatformTime.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/utils/PlatformTime.kt
@@ -1,15 +1,26 @@
 package io.music_assistant.client.utils
 
+import kotlinx.cinterop.ExperimentalForeignApi
 import platform.Foundation.NSDate
 import platform.Foundation.NSDateFormatter
 import platform.Foundation.NSDateFormatterMediumStyle
 import platform.Foundation.NSDateFormatterNoStyle
 import platform.Foundation.NSISO8601DateFormatter
 import platform.Foundation.timeIntervalSince1970
+import platform.posix.CLOCK_MONOTONIC
+import platform.posix.clock_gettime_nsec_np
 
 actual fun currentTimeMillis(): Long {
     return (NSDate().timeIntervalSince1970 * 1000).toLong()
 }
+
+/**
+ * Darwin's `CLOCK_MONOTONIC` (same domain as `mach_continuous_time`, which K/N doesn't
+ * expose) ticks through device sleep; `CLOCK_MONOTONIC_RAW`/`CLOCK_UPTIME_RAW` don't.
+ */
+@OptIn(ExperimentalForeignApi::class)
+actual fun monotonicMs(): Long =
+    (clock_gettime_nsec_np(CLOCK_MONOTONIC.toUInt()) / 1_000_000u).toLong()
 
 actual fun formatIsoDate(isoDate: String): String {
     val parser = NSISO8601DateFormatter().apply {


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

Adds an expect/actual monotonicMs() next to currentTimeMillis():
- Android: SystemClock.elapsedRealtime() (ticks through deep sleep), with a System.nanoTime() fallback for local JVM unit tests where the android.jar SystemClock stub throws.
- iOS: clock_gettime_nsec_np(CLOCK_MONOTONIC) — Darwin's CLOCK_MONOTONIC shares mach_continuous_time's domain and keeps ticking during sleep, unlike CLOCK_MONOTONIC_RAW/CLOCK_UPTIME_RAW; mach_continuous_time itself is not exposed by the Kotlin/Native 2.4.0 platform libs.

Values are only comparable to readings of the same clock in the same process and never cross the language bridge; the KDoc states the rule.

Position anchor math in the now-playing pipeline needs a clock that neither jumps with wall-time adjustments nor pauses while the device sleeps, since lock-screen position spans exactly those intervals.

## Are there any additional changes not related to the issue above?

This is the first of a series of PRs that will be overhauling the Kotlin->iOS bridge. As such, it's not actually doing anything (yet). That's expected.

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

