### PR TITLE
iOS: route all nowPlayingInfo writes through NowPlayingInfoStore

### DIFF
--- a/iosApp/NowPlayingInfoStore.swift
+++ b/iosApp/NowPlayingInfoStore.swift
@@ -1,0 +1,126 @@
+import Foundation
+import MediaPlayer
+
+/// Sole writer of `MPNowPlayingInfoCenter.default().nowPlayingInfo`.
+///
+/// Two disjoint key groups: track metadata and transport (elapsed/rate). Position is
+/// held as an anchor and projected at flush; mutations coalesce into one dictionary
+/// assignment per main-loop pass. Main-thread-only (dispatchPrecondition-enforced).
+final class NowPlayingInfoStore {
+
+    /// `elapsedSec` nil = position unknown; rate is still published.
+    private struct TransportAnchor {
+        var elapsedSec: Double?
+        var anchorNs: UInt64
+        var rate: Double
+    }
+
+    /// Monotonic ns that keep ticking during device sleep (unlike CLOCK_UPTIME_RAW).
+    static func continuousNowNs() -> UInt64 {
+        clock_gettime_nsec_np(CLOCK_MONOTONIC)
+    }
+
+    private static let nsPerSecond = 1_000_000_000.0
+
+    private let now: () -> UInt64
+    private let scheduleFlush: (@escaping () -> Void) -> Void
+    private let sink: ([String: Any]?) -> Void
+
+    private var trackKeys: [String: Any] = [:]
+    private var transport: TransportAnchor?
+    private var flushScheduled = false
+    /// Bumped by `clear()` so an already-scheduled flush closure becomes a no-op.
+    private var generation: UInt64 = 0
+
+    /// Dependencies are injectable for tests; defaults target the real info center.
+    init(
+        now: @escaping () -> UInt64 = NowPlayingInfoStore.continuousNowNs,
+        scheduleFlush: @escaping (@escaping () -> Void) -> Void = { DispatchQueue.main.async(execute: $0) },
+        sink: @escaping ([String: Any]?) -> Void = { MPNowPlayingInfoCenter.default().nowPlayingInfo = $0 }
+    ) {
+        self.now = now
+        self.scheduleFlush = scheduleFlush
+        self.sink = sink
+    }
+
+    /// nil params keep the stored value; `replacingExisting` rebuilds the group and
+    /// resets the transport anchor.
+    func setTrackKeys(
+        title: String?,
+        artist: String?,
+        album: String?,
+        artwork: MPMediaItemArtwork?,
+        duration: Double?,
+        contentId: String?,
+        replacingExisting: Bool
+    ) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        if replacingExisting {
+            trackKeys.removeAll()
+            transport = nil
+        }
+        if let title { trackKeys[MPMediaItemPropertyTitle] = title }
+        if let artist { trackKeys[MPMediaItemPropertyArtist] = artist }
+        if let album { trackKeys[MPMediaItemPropertyAlbumTitle] = album }
+        if let artwork { trackKeys[MPMediaItemPropertyArtwork] = artwork }
+        if let duration { trackKeys[MPMediaItemPropertyPlaybackDuration] = duration }
+        if let contentId { trackKeys[MPNowPlayingInfoPropertyExternalContentIdentifier] = contentId }
+        markDirty()
+    }
+
+    /// nil `elapsedSec` updates rate only, keeping the last known anchor.
+    /// No-op while no track is set (a late write must not resurrect cleared state).
+    func setTransport(elapsedSec: Double?, rate: Double) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard !trackKeys.isEmpty else { return }
+        if let elapsedSec {
+            transport = TransportAnchor(elapsedSec: elapsedSec, anchorNs: now(), rate: rate)
+        } else if var existing = transport {
+            existing.rate = rate
+            transport = existing
+        } else {
+            transport = TransportAnchor(elapsedSec: nil, anchorNs: now(), rate: rate)
+        }
+        markDirty()
+    }
+
+    /// Empties both groups, cancels any scheduled flush, assigns nil once.
+    func clear() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        trackKeys.removeAll()
+        transport = nil
+        generation &+= 1
+        flushScheduled = false
+        sink(nil)
+    }
+
+    private func markDirty() {
+        guard !flushScheduled else { return }
+        flushScheduled = true
+        let scheduledGeneration = generation
+        scheduleFlush { [weak self] in
+            guard let self = self,
+                  self.flushScheduled,
+                  self.generation == scheduledGeneration else { return }
+            self.flushNow()
+        }
+    }
+
+    /// Composes both groups, projecting the anchor to now. Tests call this directly.
+    func flushNow() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        flushScheduled = false
+        var info = trackKeys
+        if let transport {
+            info[MPNowPlayingInfoPropertyPlaybackRate] = transport.rate
+            if let elapsedSec = transport.elapsedSec {
+                let secondsSinceAnchor = Double(now() &- transport.anchorNs) / Self.nsPerSecond
+                let projected = elapsedSec + secondsSinceAnchor * transport.rate
+                let duration = (trackKeys[MPMediaItemPropertyPlaybackDuration] as? Double)
+                    ?? .greatestFiniteMagnitude
+                info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = max(0, min(projected, duration))
+            }
+        }
+        sink(info)
+    }
+}

--- a/iosApp/NowPlayingManager.swift
+++ b/iosApp/NowPlayingManager.swift
@@ -13,10 +13,13 @@ class NowPlayingManager {
 
     static let shared = NowPlayingManager()
 
+    /// Sole writer of `MPNowPlayingInfoCenter.default().nowPlayingInfo`; all
+    /// dictionary mutations in this class go through it.
+    private let infoStore = NowPlayingInfoStore()
+
     private var commandHandler: CommandHandler?
 
     // State for caching and flicker prevention
-    private var lastTrackIdentifier: String?
     private var cachedArtwork: MPMediaItemArtwork?
     private var currentArtworkLoad: Cancellable?
 
@@ -39,7 +42,6 @@ class NowPlayingManager {
         logDebug("Initializing")
         configureAudioSession()
         setupRemoteCommands() // Setup commands once
-        printDebugState("After init")
     }
 
     /// Sets the category only — does NOT activate. Activation interrupts other
@@ -170,15 +172,9 @@ class NowPlayingManager {
         // intentionally only touch rate (and elapsed if known) — title/artist stay
         // on the previous track until artwork arrives.
         if abs(playbackRate) < 0.001 {
-            var currentInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
-            currentInfo[MPNowPlayingInfoPropertyPlaybackRate] = 0.0
-            if let elapsed = elapsedTime {
-                let dur = duration
-                    ?? (currentInfo[MPMediaItemPropertyPlaybackDuration] as? Double)
-                    ?? .greatestFiniteMagnitude
-                currentInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = max(0, min(elapsed, dur))
+            DispatchQueue.main.async { [weak self] in
+                self?.infoStore.setTransport(elapsedSec: elapsedTime, rate: 0.0)
             }
-            MPNowPlayingInfoCenter.default().nowPlayingInfo = currentInfo
         }
 
         // Cancel any previous pending load
@@ -232,24 +228,10 @@ class NowPlayingManager {
         self.currentAlbum = album
     }
 
-    /// Merges new fields into the existing `MPNowPlayingInfoCenter.nowPlayingInfo`
-    /// dict.
-    ///
-    /// When `isNewTrack` is `false` (same-track tick): nil-valued fields are
-    /// skipped (preserving iOS's last-known value) and non-nil fields overwrite.
-    /// This is the right semantics for position-tick / pause-rate updates where
-    /// upstream legitimately doesn't know elapsed.
-    ///
-    /// When `isNewTrack` is `true`: previous-track fields are explicitly cleared
-    /// before the merge — otherwise transitioning to a track that has, say, no
-    /// artwork URL would leave the previous track's cover pinned in the dict
-    /// because the skip-on-nil rule preserves it. The merge then writes whatever
-    /// values the caller has; missing values become absent rather than
-    /// previous-track holdovers.
-    ///
-    /// The stable `contentId` is always set so iOS doesn't auto-assign a fresh
-    /// `ContentItemIdentifier` per call (which would make `mediaremoted` fire
-    /// `PlaybackQueueInvalidation` on every position tick).
+    /// One update = track-group + transport-group write. `isNewTrack` rebuilds the
+    /// track group (else nil fields keep last-known values, which would pin stale
+    /// artwork across a track change). A stable `contentId` prevents mediaremoted
+    /// firing `PlaybackQueueInvalidation` on every position tick.
     private func applyMergedUpdate(
         title: String?,
         artist: String?,
@@ -261,39 +243,18 @@ class NowPlayingManager {
         contentId: String,
         isNewTrack: Bool
     ) {
-        DispatchQueue.main.async {
-            var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
-
-            if isNewTrack {
-                // Wipe previous-track holdovers so a missing field on the new
-                // track doesn't render as a pinned stale value.
-                info.removeValue(forKey: MPMediaItemPropertyTitle)
-                info.removeValue(forKey: MPMediaItemPropertyArtist)
-                info.removeValue(forKey: MPMediaItemPropertyAlbumTitle)
-                info.removeValue(forKey: MPMediaItemPropertyArtwork)
-                info.removeValue(forKey: MPMediaItemPropertyPlaybackDuration)
-                info.removeValue(forKey: MPNowPlayingInfoPropertyElapsedPlaybackTime)
-            }
-
-            if let title = title { info[MPMediaItemPropertyTitle] = title }
-            if let artist = artist { info[MPMediaItemPropertyArtist] = artist }
-            if let album = album { info[MPMediaItemPropertyAlbumTitle] = album }
-            if let duration = duration { info[MPMediaItemPropertyPlaybackDuration] = duration }
-            if let elapsed = elapsedTime {
-                // Clamp against the freshly supplied duration if we have one,
-                // otherwise the duration already cached on iOS, otherwise unbounded.
-                let dur = duration
-                    ?? (info[MPMediaItemPropertyPlaybackDuration] as? Double)
-                    ?? .greatestFiniteMagnitude
-                info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = max(0, min(elapsed, dur))
-            }
-            info[MPNowPlayingInfoPropertyPlaybackRate] = playbackRate
-            if let artwork = artwork {
-                info[MPMediaItemPropertyArtwork] = artwork
-            }
-            info[MPNowPlayingInfoPropertyExternalContentIdentifier] = contentId
-
-            MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.infoStore.setTrackKeys(
+                title: title,
+                artist: artist,
+                album: album,
+                artwork: artwork,
+                duration: duration,
+                contentId: contentId,
+                replacingExisting: isNewTrack
+            )
+            self.infoStore.setTransport(elapsedSec: elapsedTime, rate: playbackRate)
         }
     }
 
@@ -302,28 +263,20 @@ class NowPlayingManager {
         logInfo("Clearing Now Playing info")
         configureAudioSession(mode: .default)
         DispatchQueue.main.async { [weak self] in
-            MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+            self?.infoStore.clear()
             self?.cachedArtwork = nil
             self?.updateCurrentState(title: nil, artist: nil, album: nil)
             self?.updateRemoteCommandMode(isLongFormContent: false)
         }
     }
 
-    // MARK: - Debug
-    private func printDebugState(_ context: String) {
-        // ... (Keep existing debug logic if needed, or remove for brevity)
-    }
-
     // MARK: - Private
 
     private func applyRemoteSeekPosition(_ position: TimeInterval) {
-        DispatchQueue.main.async {
-            var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
-            let duration = (info[MPMediaItemPropertyPlaybackDuration] as? Double) ?? .greatestFiniteMagnitude
-            info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = max(0, min(position, duration))
-            // Stop iOS interpolation immediately; KMP will publish the confirmed rate.
-            info[MPNowPlayingInfoPropertyPlaybackRate] = 0.0
-            MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+        DispatchQueue.main.async { [weak self] in
+            // Rate 0 stops iOS interpolation immediately; KMP will publish the
+            // confirmed rate once the seek lands.
+            self?.infoStore.setTransport(elapsedSec: position, rate: 0.0)
         }
     }
 

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -9,8 +9,12 @@
 /* Begin PBXBuildFile section */
 		058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557BA273AAA24004C7B11 /* Assets.xcassets */; };
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
+		06FCDF5F9AC6BE4A12AA70C9 /* NowPlayingInfoStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E184B96B79725950AACD5BE7 /* NowPlayingInfoStore.swift */; };
+		0B4C257E50350DDBF95D87D5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA991F8C8A0917FDD5510709 /* Foundation.framework */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
+		6CF3E16270B477C8D3CDB192 /* NowPlayingInfoStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E184B96B79725950AACD5BE7 /* NowPlayingInfoStore.swift */; };
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
+		C29F123E61DAA17B671EC955 /* NowPlayingInfoStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FE624765BDE4DC4138CA710 /* NowPlayingInfoStoreTests.swift */; };
 		C85119262F18C7A900185678 /* Copus in Frameworks */ = {isa = PBXBuildFile; productRef = C85119252F18C7A900185678 /* Copus */; };
 		C85119282F18C7A900185678 /* Opus in Frameworks */ = {isa = PBXBuildFile; productRef = C85119272F18C7A900185678 /* Opus */; };
 		C851192B2F18C88B00185678 /* FLAC in Frameworks */ = {isa = PBXBuildFile; productRef = C851192A2F18C88B00185678 /* FLAC */; };
@@ -28,9 +32,12 @@
 		058557BA273AAA24004C7B11 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
+		2FE624765BDE4DC4138CA710 /* NowPlayingInfoStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NowPlayingInfoStoreTests.swift; sourceTree = "<group>"; };
+		59B7DA191C857DA4E4F3A44A /* iosAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iosAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF7B242A565900829871 /* MusicAssistantClient.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MusicAssistantClient.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF82242A565900829871 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AA991F8C8A0917FDD5510709 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		C8AV00032F2C000000000003 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = en; path = en.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
 		C8CP00032F1A000000000001 /* CarPlaySceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlaySceneDelegate.swift; sourceTree = "<group>"; };
@@ -39,9 +46,18 @@
 		C8FCC1962F17E001005E8312 /* NativeAudioController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeAudioController.swift; sourceTree = "<group>"; };
 		C8FCC1982F17E001005E8312 /* AudioDecoders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDecoders.swift; sourceTree = "<group>"; };
 		C8SI00022F1B000000000001 /* SiriIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiriIntentHandler.swift; sourceTree = "<group>"; };
+		E184B96B79725950AACD5BE7 /* NowPlayingInfoStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NowPlayingInfoStore.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		27BD6D1EFE0BB0E065ACEAA2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0B4C257E50350DDBF95D87D5 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B92378962B6B1156000C7307 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -67,8 +83,18 @@
 		42799AB246E5F90AF97AA0EF /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				A26246071203143DFB91C5EC /* iOS */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		6697875A889242950A65544F /* iosAppTests */ = {
+			isa = PBXGroup;
+			children = (
+				2FE624765BDE4DC4138CA710 /* NowPlayingInfoStoreTests.swift */,
+			);
+			name = iosAppTests;
+			path = iosAppTests;
 			sourceTree = "<group>";
 		};
 		7555FF72242A565900829871 = {
@@ -81,6 +107,8 @@
 				7555FF7D242A565900829871 /* iosApp */,
 				7555FF7C242A565900829871 /* Products */,
 				42799AB246E5F90AF97AA0EF /* Frameworks */,
+				E184B96B79725950AACD5BE7 /* NowPlayingInfoStore.swift */,
+				6697875A889242950A65544F /* iosAppTests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -88,6 +116,7 @@
 			isa = PBXGroup;
 			children = (
 				7555FF7B242A565900829871 /* MusicAssistantClient.app */,
+				59B7DA191C857DA4E4F3A44A /* iosAppTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -104,6 +133,14 @@
 				C8AV00022F2C000000000002 /* AppIntentVocabulary.plist */,
 			);
 			path = iosApp;
+			sourceTree = "<group>";
+		};
+		A26246071203143DFB91C5EC /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				AA991F8C8A0917FDD5510709 /* Foundation.framework */,
+			);
+			name = iOS;
 			sourceTree = "<group>";
 		};
 		AB1DB47929225F7C00F7AF9C /* Configuration */ = {
@@ -127,6 +164,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		63EFA1ACA4B3EB88918F65A1 /* iosAppTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BD3D187223CC93EE01C96CB9 /* Build configuration list for PBXNativeTarget "iosAppTests" */;
+			buildPhases = (
+				37904671475C70F92C9A3F89 /* Sources */,
+				27BD6D1EFE0BB0E065ACEAA2 /* Frameworks */,
+				F16FE85132637763AF7932BA /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = iosAppTests;
+			productName = iosAppTests;
+			productReference = 59B7DA191C857DA4E4F3A44A /* iosAppTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		7555FF7A242A565900829871 /* iosApp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7555FFA5242A565B00829871 /* Build configuration list for PBXNativeTarget "iosApp" */;
@@ -186,6 +240,7 @@
 			projectRoot = "";
 			targets = (
 				7555FF7A242A565900829871 /* iosApp */,
+				63EFA1ACA4B3EB88918F65A1 /* iosAppTests */,
 			);
 		};
 /* End PBXProject section */
@@ -198,6 +253,13 @@
 				058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */,
 				058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */,
 				C8AV00012F2C000000000001 /* AppIntentVocabulary.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F16FE85132637763AF7932BA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -226,6 +288,15 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		37904671475C70F92C9A3F89 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C29F123E61DAA17B671EC955 /* NowPlayingInfoStoreTests.swift in Sources */,
+				6CF3E16270B477C8D3CDB192 /* NowPlayingInfoStore.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7555FF77242A565900829871 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -238,6 +309,7 @@
 				C8CP00012F1A000000000001 /* CarPlaySceneDelegate.swift in Sources */,
 				C8CP00022F1A000000000002 /* CarPlayContentManager.swift in Sources */,
 				C8SI00012F1B000000000001 /* SiriIntentHandler.swift in Sources */,
+				06FCDF5F9AC6BE4A12AA70C9 /* NowPlayingInfoStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -255,6 +327,23 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		71BE7A433C230BFC4631BAEC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.music-assistant.client.iosAppTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		7555FFA3242A565B00829871 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
@@ -433,6 +522,22 @@
 			};
 			name = Release;
 		};
+		7AA734D8DA7ECBAE9344A7A2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.music-assistant.client.iosAppTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -450,6 +555,15 @@
 			buildConfigurations = (
 				7555FFA6242A565B00829871 /* Debug */,
 				7555FFA7242A565B00829871 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		BD3D187223CC93EE01C96CB9 /* Build configuration list for PBXNativeTarget "iosAppTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				71BE7A433C230BFC4631BAEC /* Release */,
+				7AA734D8DA7ECBAE9344A7A2 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
+++ b/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
@@ -29,6 +29,18 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "63EFA1ACA4B3EB88918F65A1"
+               BuildableName = "iosAppTests.xctest"
+               BlueprintName = "iosAppTests"
+               ReferencedContainer = "container:iosApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/iosApp/iosAppTests/NowPlayingInfoStoreTests.swift
+++ b/iosApp/iosAppTests/NowPlayingInfoStoreTests.swift
@@ -1,0 +1,235 @@
+import XCTest
+import MediaPlayer
+
+/// Exercises `NowPlayingInfoStore` with an injected clock, flush scheduler, and dict
+/// sink so coalescing and anchor projection are fully deterministic.
+final class NowPlayingInfoStoreTests: XCTestCase {
+
+    /// Test double bundling the injectable seams: a manually advanced clock, a queue
+    /// of captured flush closures, and a log of every dict assignment.
+    private final class Harness {
+        static let nsPerSecond = 1_000_000_000.0
+        var nowNs: UInt64 = 1_000_000_000  // arbitrary nonzero start
+        var scheduledFlushes: [() -> Void] = []
+        var sinkCalls: [[String: Any]?] = []
+        let store: NowPlayingInfoStore
+
+        init() {
+            var capturedSelf: Harness?
+            store = NowPlayingInfoStore(
+                now: { capturedSelf!.nowNs },
+                scheduleFlush: { capturedSelf!.scheduledFlushes.append($0) },
+                sink: { capturedSelf!.sinkCalls.append($0) }
+            )
+            capturedSelf = self
+        }
+
+        func advanceClock(seconds: Double) {
+            nowNs += UInt64(seconds * Self.nsPerSecond)
+        }
+
+        /// Runs every captured flush closure in order, like the main loop draining
+        /// its queue.
+        func runScheduledFlushes() {
+            let pending = scheduledFlushes
+            scheduledFlushes = []
+            pending.forEach { $0() }
+        }
+    }
+
+    private func setSampleTrack(_ harness: Harness, title: String = "Song") {
+        harness.store.setTrackKeys(
+            title: title,
+            artist: "Artist",
+            album: "Album",
+            artwork: nil,
+            duration: 300.0,
+            contentId: "item-1",
+            replacingExisting: true
+        )
+    }
+
+    func testCoalescesMutationsIntoOneAssignment() {
+        let harness = Harness()
+
+        setSampleTrack(harness)
+        harness.store.setTransport(elapsedSec: 10.0, rate: 1.0)
+        harness.store.setTrackKeys(
+            title: nil, artist: nil, album: nil, artwork: nil,
+            duration: nil, contentId: nil, replacingExisting: false
+        )
+        harness.store.setTransport(elapsedSec: 12.0, rate: 1.0)
+
+        XCTAssertEqual(harness.sinkCalls.count, 0, "nothing assigned before the flush runs")
+        XCTAssertEqual(harness.scheduledFlushes.count, 1, "many mutations schedule one flush")
+
+        harness.runScheduledFlushes()
+
+        XCTAssertEqual(harness.sinkCalls.count, 1, "one main-loop pass, one assignment")
+        let info = try! XCTUnwrap(harness.sinkCalls[0])
+        XCTAssertEqual(info[MPMediaItemPropertyTitle] as? String, "Song")
+        XCTAssertEqual(info[MPNowPlayingInfoPropertyElapsedPlaybackTime] as? Double, 12.0)
+        XCTAssertEqual(info[MPNowPlayingInfoPropertyPlaybackRate] as? Double, 1.0)
+    }
+
+    func testProjectsAnchorAtFlush() {
+        let harness = Harness()
+
+        setSampleTrack(harness)
+        harness.store.setTransport(elapsedSec: 100.0, rate: 1.0)
+        harness.runScheduledFlushes()
+
+        // Playback runs on for 5 s, then a metadata-only correction arrives. The
+        // flush must publish the position projected to flush time, never the stale
+        // raw elapsed captured 5 s ago.
+        harness.advanceClock(seconds: 5.0)
+        harness.store.setTrackKeys(
+            title: "Song (corrected)", artist: nil, album: nil, artwork: nil,
+            duration: nil, contentId: nil, replacingExisting: false
+        )
+        harness.runScheduledFlushes()
+
+        let info = try! XCTUnwrap(harness.sinkCalls.last!)
+        XCTAssertEqual(info[MPMediaItemPropertyTitle] as? String, "Song (corrected)")
+        let elapsed = try! XCTUnwrap(info[MPNowPlayingInfoPropertyElapsedPlaybackTime] as? Double)
+        XCTAssertEqual(elapsed, 105.0, accuracy: 0.001)
+    }
+
+    func testProjectionClampsToDuration() {
+        let harness = Harness()
+
+        setSampleTrack(harness)  // duration 300
+        harness.store.setTransport(elapsedSec: 295.0, rate: 1.0)
+        harness.advanceClock(seconds: 60.0)
+        harness.runScheduledFlushes()
+
+        let info = try! XCTUnwrap(harness.sinkCalls.last!)
+        XCTAssertEqual(info[MPNowPlayingInfoPropertyElapsedPlaybackTime] as? Double, 300.0)
+    }
+
+    func testKeyGroupsAreIsolated() {
+        let harness = Harness()
+
+        setSampleTrack(harness)
+        harness.store.setTransport(elapsedSec: 50.0, rate: 1.0)
+        harness.runScheduledFlushes()
+
+        // A same-item track write must not disturb transport keys.
+        harness.store.setTrackKeys(
+            title: "Retitled", artist: nil, album: nil, artwork: nil,
+            duration: nil, contentId: nil, replacingExisting: false
+        )
+        harness.runScheduledFlushes()
+        var info = try! XCTUnwrap(harness.sinkCalls.last!)
+        XCTAssertEqual(info[MPMediaItemPropertyTitle] as? String, "Retitled")
+        XCTAssertEqual(info[MPNowPlayingInfoPropertyElapsedPlaybackTime] as? Double, 50.0)
+        XCTAssertEqual(info[MPNowPlayingInfoPropertyPlaybackRate] as? Double, 1.0)
+
+        // A transport write must not disturb track keys.
+        harness.store.setTransport(elapsedSec: 60.0, rate: 0.0)
+        harness.runScheduledFlushes()
+        info = try! XCTUnwrap(harness.sinkCalls.last!)
+        XCTAssertEqual(info[MPMediaItemPropertyTitle] as? String, "Retitled")
+        XCTAssertEqual(info[MPMediaItemPropertyArtist] as? String, "Artist")
+        XCTAssertEqual(info[MPMediaItemPropertyPlaybackDuration] as? Double, 300.0)
+        XCTAssertEqual(info[MPNowPlayingInfoPropertyElapsedPlaybackTime] as? Double, 60.0)
+        XCTAssertEqual(info[MPNowPlayingInfoPropertyPlaybackRate] as? Double, 0.0)
+    }
+
+    func testNilElapsedKeepsAnchorAndUpdatesRate() {
+        let harness = Harness()
+
+        setSampleTrack(harness)
+        harness.store.setTransport(elapsedSec: 40.0, rate: 1.0)
+        harness.runScheduledFlushes()
+
+        // Position unknown, only the rate changes: the previous anchor is kept.
+        // Pins parity-with-main behavior: the new rate applies retroactively from
+        // the old anchor, so a nil-elapsed pause 5 s in snaps back to 40, not 45.
+        // Revisit when rate changes re-anchor at the projected position.
+        harness.advanceClock(seconds: 5.0)
+        harness.store.setTransport(elapsedSec: nil, rate: 0.0)
+        harness.runScheduledFlushes()
+
+        let info = try! XCTUnwrap(harness.sinkCalls.last!)
+        XCTAssertEqual(info[MPNowPlayingInfoPropertyElapsedPlaybackTime] as? Double, 40.0)
+        XCTAssertEqual(info[MPNowPlayingInfoPropertyPlaybackRate] as? Double, 0.0)
+    }
+
+    func testReplacingTrackResetsTransport() {
+        let harness = Harness()
+
+        setSampleTrack(harness)
+        harness.store.setTransport(elapsedSec: 250.0, rate: 1.0)
+        harness.runScheduledFlushes()
+
+        // New track: the old anchor must not leak into the new item's dict.
+        setSampleTrack(harness, title: "Next Song")
+        harness.runScheduledFlushes()
+
+        let info = try! XCTUnwrap(harness.sinkCalls.last!)
+        XCTAssertEqual(info[MPMediaItemPropertyTitle] as? String, "Next Song")
+        XCTAssertNil(info[MPNowPlayingInfoPropertyElapsedPlaybackTime])
+        XCTAssertNil(info[MPNowPlayingInfoPropertyPlaybackRate])
+    }
+
+    func testProjectionClampsToZero() {
+        let harness = Harness()
+
+        setSampleTrack(harness)
+        harness.store.setTransport(elapsedSec: 2.0, rate: -1.0)
+        harness.advanceClock(seconds: 10.0)
+        harness.runScheduledFlushes()
+
+        let info = try! XCTUnwrap(harness.sinkCalls.last!)
+        XCTAssertEqual(info[MPNowPlayingInfoPropertyElapsedPlaybackTime] as? Double, 0.0)
+    }
+
+    func testProjectsNonUnitaryRate() {
+        let harness = Harness()
+
+        setSampleTrack(harness)
+        harness.store.setTransport(elapsedSec: 100.0, rate: 2.0)
+        harness.advanceClock(seconds: 5.0)
+        harness.runScheduledFlushes()
+
+        let info = try! XCTUnwrap(harness.sinkCalls.last!)
+        let elapsed = try! XCTUnwrap(info[MPNowPlayingInfoPropertyElapsedPlaybackTime] as? Double)
+        XCTAssertEqual(elapsed, 110.0, accuracy: 0.001)
+    }
+
+    func testRejectsTransportAfterClear() {
+        let harness = Harness()
+
+        setSampleTrack(harness)
+        harness.store.setTransport(elapsedSec: 10.0, rate: 1.0)
+        harness.runScheduledFlushes()
+
+        harness.store.clear()
+        XCTAssertNil(harness.sinkCalls.last!)
+        let callsAfterClear = harness.sinkCalls.count
+
+        // A straggler position write with no track present must be dropped.
+        harness.store.setTransport(elapsedSec: 20.0, rate: 1.0)
+        harness.runScheduledFlushes()
+
+        XCTAssertEqual(harness.sinkCalls.count, callsAfterClear,
+                       "transport write without a track must not publish anything")
+    }
+
+    func testClearAssignsNilOnceAndCancelsFlush() {
+        let harness = Harness()
+
+        setSampleTrack(harness)
+        XCTAssertEqual(harness.scheduledFlushes.count, 1)
+
+        // Clear lands before the scheduled flush runs.
+        harness.store.clear()
+        XCTAssertEqual(harness.sinkCalls.count, 1)
+        XCTAssertNil(harness.sinkCalls[0])
+
+        // The stale scheduled closure must now be a no-op.
+        harness.runScheduledFlushes()
+        XCTAssertEqual(harness.sinkCalls.count, 1, "cancelled flush must not publish")
+    }
+}


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

Introduce NowPlayingInfoStore as the single writer of MPNowPlayingInfoCenter.nowPlayingInfo. The store splits keys into two disjoint groups (track metadata vs transport), coalesces mutations into one assignment per main-loop pass, and stores position as a monotonic anchor (elapsed + timestamp + rate) projected at flush time so metadata writes can no longer rewind the progress bar. Transport rides the track lifecycle: it is rejected while no track is set and reset on track replacement. Main-thread use is enforced with dispatchPrecondition.

NowPlayingManager keeps all policy but no longer touches nowPlayingInfo directly. Adds an iosAppTests XCTest target with unit tests covering coalescing, anchor projection, clamping, and clear semantics.

## Are there any additional changes not related to the issue above?

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

