### PR TITLE
Add now playing state channels

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -181,6 +181,44 @@ class MainDataSource(
             data?.let { applyFavoriteOverride(it, overrides) }
         }.stateIn(this, SharingStarted.Eagerly, null)
 
+    /** Track metadata for the local player's system-media presentation. */
+    val nowPlayingTrack: StateFlow<NowPlayingTrack?> =
+        localPlayer
+            .map(::buildNowPlayingTrack)
+            .distinctUntilChanged()
+            .stateIn(this, SharingStarted.Eagerly, null)
+
+    /**
+     * Transport anchors for the local player's system-media presentation.
+     * The content identity is retained only for deduplication so a new track
+     * always emits a fresh anchor. No-track states remain explicit nulls.
+     */
+    val nowPlayingTransport: StateFlow<NowPlayingTransport?> =
+        localPlayer
+            .map { playerData ->
+                NowPlayingTransportEmission(
+                    mediaItemId = playerData?.queueInfo?.currentItem?.track?.itemId,
+                    transport = buildNowPlayingTransport(playerData, positionTracker),
+                )
+            }
+            .distinctUntilChanged { old, new ->
+                NowPlayingChannelChangeDetection.sameTransport(
+                    oldMediaItemId = old.mediaItemId,
+                    old = old.transport,
+                    newMediaItemId = new.mediaItemId,
+                    new = new.transport,
+                )
+            }
+            .map { it.transport }
+            .stateIn(this, SharingStarted.Eagerly, null)
+
+    /** Queue modes and their shared availability gate for system-media controls. */
+    val nowPlayingModes: StateFlow<NowPlayingModes?> =
+        localPlayer
+            .map(::buildNowPlayingModes)
+            .distinctUntilChanged()
+            .stateIn(this, SharingStarted.Eagerly, null)
+
     val isAnythingPlaying =
         playersData
             .mapNotNull { it as? DataState.Data<List<PlayerData>> }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/NowPlayingChannels.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/NowPlayingChannels.kt
@@ -67,25 +67,19 @@ internal object NowPlayingChannelChangeDetection {
         if (old == null || new == null) return old == new
         if (old.isPlaying != new.isPlaying || old.rate != new.rate) return false
 
-        return when {
-            old.elapsedSec == null && new.elapsedSec == null -> true
-            old.elapsedSec == null || new.elapsedSec == null -> false
-            else -> {
-                val projectedOld = old.elapsedSec +
-                    (new.anchorMs - old.anchorMs) / 1000.0 * old.rate
-                abs(projectedOld - new.elapsedSec) < ELAPSED_ANCHOR_EPSILON_S
-            }
+        if (old.elapsedSec == null || new.elapsedSec == null) {
+            return old.elapsedSec == new.elapsedSec
         }
+
+        val projectedOld = old.elapsedSec +
+            (new.anchorMs - old.anchorMs) / 1000.0 * old.rate
+        return abs(projectedOld - new.elapsedSec) < ELAPSED_ANCHOR_EPSILON_S
     }
 }
 
 /** Maps local-player state to the metadata channel. */
 internal fun buildNowPlayingTrack(playerData: PlayerData?): NowPlayingTrack? =
-    buildNowPlayingTrackFromItem(playerData?.queueInfo?.currentItem?.track)
-
-/** Maps one playable item without requiring a full player or queue fixture. */
-internal fun buildNowPlayingTrackFromItem(item: PlayableItem?): NowPlayingTrack? =
-    item?.toNowPlayingTrack()
+    playerData?.queueInfo?.currentItem?.track?.toNowPlayingTrack()
 
 /**
  * Maps local-player state to an anchor, or null when there is no current item.

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/NowPlayingChannels.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/NowPlayingChannels.kt
@@ -1,0 +1,148 @@
+package io.music_assistant.client.data
+
+import io.music_assistant.client.data.model.client.ImageType
+import io.music_assistant.client.data.model.client.PlayerData
+import io.music_assistant.client.data.model.client.RepeatMode
+import io.music_assistant.client.data.model.client.items.PlayableItem
+import io.music_assistant.client.data.model.client.items.image
+import io.music_assistant.client.data.model.client.items.isLongFormSpokenContent
+import io.music_assistant.client.utils.monotonicMs
+import kotlin.math.abs
+
+/**
+ * Metadata that changes with the content identity rather than with transport.
+ *
+ * [mediaItemId] identifies the content, not its queue entry. Consequently, the
+ * same song queued twice produces the same value and does not re-render system
+ * metadata unless one of its displayed fields changed.
+ */
+data class NowPlayingTrack(
+    val mediaItemId: String,
+    val title: String?,
+    val artist: String?,
+    val album: String?,
+    val artworkUrl: String?,
+    val duration: Double?,
+    val isLongFormContent: Boolean,
+)
+
+/**
+ * A transport anchor. [anchorMs] belongs only to the Kotlin monotonic clock;
+ * it must never be compared with a timestamp produced across the language
+ * bridge. Swift re-anchors the elapsed value with its own clock on delivery.
+ * [rate] is zero while paused or seek-frozen; otherwise it carries the queue's
+ * playback speed so variable-rate spoken content remains synchronized.
+ */
+data class NowPlayingTransport(
+    val isPlaying: Boolean,
+    val elapsedSec: Double?,
+    val anchorMs: Long,
+    val rate: Double,
+)
+
+/** Current queue modes and whether their system controls are available. */
+data class NowPlayingModes(
+    val shuffleEnabled: Boolean,
+    val repeatMode: RepeatMode?,
+    val togglesEnabled: Boolean,
+)
+
+/** Change detection shared by the channel flow and its plain-value tests. */
+internal object NowPlayingChannelChangeDetection {
+    /** Position drift below this threshold is already covered by iOS interpolation. */
+    const val ELAPSED_ANCHOR_EPSILON_S = 2.0
+
+    /**
+     * Returns whether two transport values can share one system-media anchor.
+     * The caller supplies content identity because a new track always needs a
+     * fresh anchor, even when its position happens to equal the old track's.
+     */
+    fun sameTransport(
+        oldMediaItemId: String?,
+        old: NowPlayingTransport?,
+        newMediaItemId: String?,
+        new: NowPlayingTransport?,
+    ): Boolean {
+        if (oldMediaItemId != newMediaItemId) return false
+        if (old == null || new == null) return old == new
+        if (old.isPlaying != new.isPlaying || old.rate != new.rate) return false
+
+        return when {
+            old.elapsedSec == null && new.elapsedSec == null -> true
+            old.elapsedSec == null || new.elapsedSec == null -> false
+            else -> {
+                val projectedOld = old.elapsedSec +
+                    (new.anchorMs - old.anchorMs) / 1000.0 * old.rate
+                abs(projectedOld - new.elapsedSec) < ELAPSED_ANCHOR_EPSILON_S
+            }
+        }
+    }
+}
+
+/** Maps local-player state to the metadata channel. */
+internal fun buildNowPlayingTrack(playerData: PlayerData?): NowPlayingTrack? =
+    buildNowPlayingTrackFromItem(playerData?.queueInfo?.currentItem?.track)
+
+/** Maps one playable item without requiring a full player or queue fixture. */
+internal fun buildNowPlayingTrackFromItem(item: PlayableItem?): NowPlayingTrack? =
+    item?.toNowPlayingTrack()
+
+/**
+ * Maps local-player state to an anchor, or null when there is no current item.
+ * Tracker interpolation and the published rate use the same queue speed.
+ */
+internal fun buildNowPlayingTransport(
+    playerData: PlayerData?,
+    positionTracker: PlayerPositionTracker,
+    anchorMs: Long = monotonicMs(),
+): NowPlayingTransport? {
+    val queueInfo = playerData?.queueInfo ?: return null
+    queueInfo.currentItem?.track ?: return null
+    val isPlaying = playerData.player.isPlaying
+    return NowPlayingTransport(
+        isPlaying = isPlaying,
+        elapsedSec = positionTracker.effectiveSec(queueInfo.id) ?: queueInfo.elapsedTime,
+        anchorMs = anchorMs,
+        rate = if (isPlaying && !positionTracker.isFrozenUntilConfirmed(queueInfo.id)) {
+            queueInfo.playbackSpeed ?: 1.0
+        } else {
+            0.0
+        },
+    )
+}
+
+/** Maps queue modes and the shared availability gates to the modes channel. */
+internal fun buildNowPlayingModes(playerData: PlayerData?): NowPlayingModes? {
+    val queueInfo = playerData?.queueInfo ?: return null
+    val track = queueInfo.currentItem?.track ?: return null
+    return NowPlayingModes(
+        shuffleEnabled = queueInfo.shuffleEnabled,
+        repeatMode = queueInfo.repeatMode,
+        togglesEnabled = nowPlayingTogglesEnabled(
+            isDynamicPlaylist = queueInfo.isDynamicPlaylist,
+            isLongFormContent = track.isLongFormSpokenContent,
+        ),
+    )
+}
+
+/** The same availability gates used by the in-app controls and Android media UI. */
+internal fun nowPlayingTogglesEnabled(
+    isDynamicPlaylist: Boolean,
+    isLongFormContent: Boolean,
+): Boolean = !isDynamicPlaylist && !isLongFormContent
+
+private fun PlayableItem.toNowPlayingTrack(): NowPlayingTrack = NowPlayingTrack(
+    mediaItemId = itemId,
+    title = displayName,
+    artist = subtitle,
+    album = parentName,
+    artworkUrl = image(ImageType.THUMB)?.url,
+    duration = duration,
+    isLongFormContent = isLongFormSpokenContent,
+)
+
+/** Internal key used to reset transport comparison at a content transition. */
+internal data class NowPlayingTransportEmission(
+    val mediaItemId: String?,
+    val transport: NowPlayingTransport?,
+)

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/NowPlayingChannelsTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/NowPlayingChannelsTest.kt
@@ -105,9 +105,12 @@ class NowPlayingTrackChannelTest {
                 duration = 240.0,
                 isLongFormContent = false,
             ),
-            buildNowPlayingTrackFromItem(item),
+            buildNowPlayingTrack(playerData(item, queueInfo(queueId = "queue-1"))),
         )
-        assertTrue(buildNowPlayingTrackFromItem(testAudiobook())!!.isLongFormContent)
+        assertTrue(
+            buildNowPlayingTrack(playerData(testAudiobook(), queueInfo(queueId = "queue-1")))!!
+                .isLongFormContent,
+        )
     }
 }
 

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/NowPlayingChannelsTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/NowPlayingChannelsTest.kt
@@ -1,0 +1,319 @@
+package io.music_assistant.client.data
+
+import io.music_assistant.client.data.model.client.ImageInfo
+import io.music_assistant.client.data.model.client.ImageType
+import io.music_assistant.client.data.model.client.Player
+import io.music_assistant.client.data.model.client.PlayerData
+import io.music_assistant.client.data.model.client.PlayerType
+import io.music_assistant.client.data.model.client.Queue
+import io.music_assistant.client.data.model.client.QueueInfo
+import io.music_assistant.client.data.model.client.QueueTrack
+import io.music_assistant.client.data.model.client.RepeatMode
+import io.music_assistant.client.data.model.client.items.Album
+import io.music_assistant.client.data.model.client.items.Artist
+import io.music_assistant.client.data.model.client.items.PlayableItem
+import io.music_assistant.client.data.model.client.items.Track
+import io.music_assistant.client.data.model.client.testAudiobook
+import io.music_assistant.client.data.model.client.testTrack
+import io.music_assistant.client.ui.compose.common.DataState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class NowPlayingTrackChannelTest {
+    private val track = NowPlayingTrack(
+        mediaItemId = "track-1",
+        title = "About Farewell",
+        artist = "Alela Diane",
+        album = "About Farewell",
+        artworkUrl = "https://example.invalid/cover.jpg",
+        duration = 240.0,
+        isLongFormContent = false,
+    )
+
+    @Test
+    fun valueEqualityDedupesSameSongQueuedTwice() {
+        assertTrue(track == track.copy())
+        assertFalse(track == track.copy(mediaItemId = "track-2"))
+    }
+
+    @Test
+    fun displayedMetadataChangeEmits() {
+        assertFalse(track == track.copy(title = "Different"))
+    }
+
+    @Test
+    fun mapperPreservesIdentityMetadataArtworkDurationAndLongFormFlag() {
+        val artist = Artist(
+            itemId = "artist-1",
+            provider = "test",
+            name = "Artist",
+            providerMappings = null,
+            metadata = null,
+            favorite = null,
+            uri = null,
+            images = emptyMap(),
+        )
+        val album = Album(
+            itemId = "album-1",
+            provider = "test",
+            name = "Album",
+            providerMappings = null,
+            metadata = null,
+            favorite = null,
+            uri = null,
+            images = emptyMap(),
+            version = null,
+            year = null,
+            artists = listOf(artist),
+        )
+        val image = ImageInfo(
+            type = ImageType.THUMB,
+            path = "cover.jpg",
+            isRemotelyAccessible = true,
+            provider = "test",
+            url = "https://example.invalid/cover.jpg",
+        )
+        val item = Track(
+            itemId = "track-42",
+            provider = "test",
+            name = "Song",
+            providerMappings = null,
+            metadata = null,
+            favorite = null,
+            uri = null,
+            images = mapOf(ImageType.THUMB to image),
+            duration = 240.0,
+            isPlayable = true,
+            artists = listOf(artist),
+            album = album,
+            discNumber = null,
+            trackNumber = null,
+            position = null,
+            version = null,
+        )
+
+        assertEquals(
+            NowPlayingTrack(
+                mediaItemId = "track-42",
+                title = "Song",
+                artist = "Artist",
+                album = "Album",
+                artworkUrl = "https://example.invalid/cover.jpg",
+                duration = 240.0,
+                isLongFormContent = false,
+            ),
+            buildNowPlayingTrackFromItem(item),
+        )
+        assertTrue(buildNowPlayingTrackFromItem(testAudiobook())!!.isLongFormContent)
+    }
+}
+
+class NowPlayingTransportDedupTest {
+    private val playing = NowPlayingTransport(
+        isPlaying = true,
+        elapsedSec = 30.0,
+        anchorMs = 10_000L,
+        rate = 1.0,
+    )
+
+    @Test
+    fun uninterruptedPlaybackProjectsOldAnchorBeforeComparing() {
+        val later = playing.copy(anchorMs = 20_000L, elapsedSec = 40.0)
+        assertTrue(
+            NowPlayingChannelChangeDetection.sameTransport("track-1", playing, "track-1", later),
+        )
+    }
+
+    @Test
+    fun realPositionJumpEmits() {
+        val jumped = playing.copy(anchorMs = 20_000L, elapsedSec = 43.0)
+        assertFalse(
+            NowPlayingChannelChangeDetection.sameTransport("track-1", playing, "track-1", jumped),
+        )
+    }
+
+    @Test
+    fun playingAndRateChangesEmit() {
+        assertFalse(
+            NowPlayingChannelChangeDetection.sameTransport(
+                "track-1",
+                playing,
+                "track-1",
+                playing.copy(isPlaying = false, rate = 0.0),
+            ),
+        )
+    }
+
+    @Test
+    fun nullElapsedMatchesOnlyNullElapsed() {
+        val old = playing.copy(elapsedSec = null)
+        assertTrue(
+            NowPlayingChannelChangeDetection.sameTransport(
+                "track-1",
+                old,
+                "track-1",
+                old.copy(anchorMs = 20_000L),
+            ),
+        )
+        assertFalse(
+            NowPlayingChannelChangeDetection.sameTransport("track-1", old, "track-1", playing),
+        )
+    }
+
+    @Test
+    fun identityChangeAlwaysEmitsFreshAnchor() {
+        val samePosition = playing.copy(anchorMs = 20_000L, elapsedSec = 40.0)
+        assertFalse(
+            NowPlayingChannelChangeDetection.sameTransport(
+                "track-1",
+                playing,
+                "track-2",
+                samePosition,
+            ),
+        )
+    }
+
+    @Test
+    fun nullTransportIsReplayedAsNull() {
+        assertTrue(
+            NowPlayingChannelChangeDetection.sameTransport(null, null, null, null),
+        )
+        assertNull(buildNowPlayingTransport(null, PlayerPositionTracker(), anchorMs = 1_000L))
+        assertNull(NowPlayingTransportEmission("track-1", null).transport)
+    }
+
+    @Test
+    fun mapperPreservesVariablePlaybackRate() {
+        val queueId = "queue-1"
+        val transport = buildNowPlayingTransport(
+            playerData(testTrack(), queueInfo(queueId = queueId, playbackSpeed = 1.25)),
+            PlayerPositionTracker(),
+            anchorMs = 10_000L,
+        )
+
+        assertEquals(1.25, transport?.rate)
+    }
+
+    @Test
+    fun mapperCollapsesFrozenPlayingStateToZeroRate() {
+        val queueId = "queue-1"
+        val tracker = PlayerPositionTracker()
+        tracker.setAnchor(queueId, elapsedSec = 30.0, isPlaying = true)
+        tracker.setOptimisticSeek(queueId, elapsedSec = 90.0)
+
+        val transport = buildNowPlayingTransport(
+            playerData(testTrack(), queueInfo(queueId = queueId)),
+            tracker,
+            anchorMs = 10_000L,
+        )
+
+        assertEquals(0.0, transport?.rate)
+        assertTrue(transport?.isPlaying == true)
+    }
+}
+
+class NowPlayingModesChannelTest {
+    @Test
+    fun modeValuesAreComparedByValue() {
+        val modes = NowPlayingModes(true, RepeatMode.ONE, true)
+        assertTrue(modes == modes.copy())
+        assertFalse(modes == modes.copy(shuffleEnabled = false))
+        assertFalse(modes == modes.copy(repeatMode = RepeatMode.ALL))
+    }
+
+    @Test
+    fun togglesEnabledGatesDynamicAndLongFormContent() {
+        assertTrue(nowPlayingTogglesEnabled(isDynamicPlaylist = false, isLongFormContent = false))
+        assertFalse(nowPlayingTogglesEnabled(isDynamicPlaylist = true, isLongFormContent = false))
+        assertFalse(nowPlayingTogglesEnabled(isDynamicPlaylist = false, isLongFormContent = true))
+        assertFalse(nowPlayingTogglesEnabled(isDynamicPlaylist = true, isLongFormContent = true))
+    }
+
+    @Test
+    fun nullPlayerProducesNoModes() {
+        assertNull(buildNowPlayingModes(null))
+    }
+
+    @Test
+    fun mapperReadsQueueModesAndAppliesBothAvailabilityGates() {
+        val base = playerData(testTrack(), queueInfo(queueId = "queue-1"))
+        assertEquals(
+            NowPlayingModes(shuffleEnabled = false, repeatMode = RepeatMode.OFF, togglesEnabled = true),
+            buildNowPlayingModes(base),
+        )
+        assertFalse(
+            buildNowPlayingModes(
+                playerData(testTrack(), queueInfo(queueId = "queue-1", isDynamicPlaylist = true)),
+            )!!.togglesEnabled,
+        )
+        assertFalse(
+            buildNowPlayingModes(playerData(testAudiobook(), queueInfo(queueId = "queue-1")))!!.togglesEnabled,
+        )
+    }
+}
+
+private fun queueInfo(
+    queueId: String,
+    isDynamicPlaylist: Boolean = false,
+    playbackSpeed: Double? = null,
+): QueueInfo = QueueInfo(
+    id = queueId,
+    available = true,
+    currentIndex = 0,
+    shuffleEnabled = false,
+    repeatMode = RepeatMode.OFF,
+    autoPlayEnabled = null,
+    elapsedTime = 30.0,
+    elapsedTimeLastUpdated = null,
+    currentItem = QueueTrack(
+        id = "queue-item-1",
+        track = testTrack(),
+        isPlayable = true,
+        format = null,
+        dsp = null,
+        provider = "test",
+    ),
+    radioSource = emptyList(),
+    isDynamicPlaylist = isDynamicPlaylist,
+    playbackSpeed = playbackSpeed,
+)
+
+private fun playerData(item: PlayableItem, queueInfo: QueueInfo): PlayerData = PlayerData(
+    player = Player(
+        id = "player-1",
+        name = "Test player",
+        provider = "test",
+        type = PlayerType.PLAYER,
+        shouldBeShown = true,
+        canSetVolume = false,
+        canPower = false,
+        isPowered = true,
+        volumeLevel = null,
+        volumeControl = null,
+        volumeMuted = false,
+        canMute = false,
+        queueId = queueInfo.id,
+        isPlaying = true,
+        isAnnouncing = false,
+        canGroupWith = null,
+        groupMembers = null,
+        staticGroupMembers = null,
+        activeGroup = null,
+        syncedTo = null,
+        groupVolume = null,
+        groupVolumeMuted = false,
+        currentMedia = null,
+    ),
+    queue = DataState.Data(
+        Queue(
+            queueInfo.copy(currentItem = queueInfo.currentItem?.copy(track = item)),
+            DataState.NoData(),
+        ),
+    ),
+    parentBind = null,
+    childrenBinds = emptyList(),
+    isLocal = true,
+)


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

Publish track metadata, transport anchors, and queue modes as separate replayable StateFlows from MainDataSource. Transport change detection projects the previous anchor before applying the two-second tolerance, resets on track identity changes, and collapses frozen playback to rate zero. Add focused tests for metadata mapping, null state, transport deduplication, freeze handling, and shuffle/repeat availability gates.

## Are there any additional changes not related to the issue above?

This one is pure scaffolding (and tests for the scaffolding) for the next couple of PRs. Nothing actually reads / uses this code, yet.

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

