### PR TITLE
fix: improve reconnect resilience, HttpClient rotation, 20-attempt backoff, auto-resume

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/music_assistant/client/player/MediaPlayerController.android.kt
+++ b/composeApp/src/androidMain/kotlin/io/music_assistant/client/player/MediaPlayerController.android.kt
@@ -432,6 +432,11 @@ actual class MediaPlayerController actual constructor(platformContext: PlatformC
         }
     }
 
+    actual fun resume() {
+        resumeSink()
+        onRemoteCommand?.invoke("play")
+    }
+
     actual fun stopRawPcmStream() {
         logger.i { "Stopping raw PCM stream" }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/DirectTransport.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/DirectTransport.kt
@@ -27,11 +27,10 @@ import kotlinx.serialization.json.JsonObject
 import kotlin.concurrent.Volatile
 
 class DirectTransport(
-    private val client: HttpClient,
+    private val clientProvider: () -> HttpClient,
     private val connectionInfoProvider: () -> ConnectionInfo,
     parentScope: CoroutineScope,
     private val networkAvailable: StateFlow<Boolean>? = null,
-    private val maxReconnectAttempts: Int = DEFAULT_MAX_RECONNECT_ATTEMPTS,
 ) : Transport {
     private val logger = Logger.withTag("DirectTransport")
 
@@ -115,23 +114,23 @@ class DirectTransport(
             }
         }
         if (info.isTls) {
-            client.wss(HttpMethod.Get, info.host, info.port, "/ws", block = block)
+            clientProvider().wss(HttpMethod.Get, info.host, info.port, "/ws", block = block)
         } else {
-            client.ws(HttpMethod.Get, info.host, info.port, "/ws", block = block)
+            clientProvider().ws(HttpMethod.Get, info.host, info.port, "/ws", block = block)
         }
     }
 
     private suspend fun startReconnection() {
-        // Outer loop: each successful-then-dropped connection gets a fresh attempt cycle
+        // Outer loop: each successful-then-dropped connection gets a fresh attempt cycle.
         while (true) {
             val reconnected = runReconnectionLoop(
-                maxAttempts = maxReconnectAttempts,
+                maxAttempts = DEFAULT_MAX_RECONNECT_ATTEMPTS,
                 networkAvailable = networkAvailable,
                 onAttemptStarting = { _state.value = TransportState.Reconnecting(it) },
                 tryConnect = { attempt ->
                     var connectedThisAttempt = false
                     try {
-                        logger.i { "Reconnect attempt $attempt/$maxReconnectAttempts" }
+                        logger.i { "Reconnect attempt $attempt" }
                         openWebSocket(connectionInfoProvider()) { connectedThisAttempt = true }
                         // Returned normally = was connected, then dropped — signal success for fresh cycle
                         true

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -50,7 +50,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
@@ -83,7 +82,7 @@ class KtorServiceClient(
 
     private val clientMutex = Mutex()
 
-    @Volatile
+    @kotlin.concurrent.Volatile
     private var currentClient: HttpClient = createPlatformHttpClient {
         install(WebSockets) {
             contentConverter = KotlinxWebsocketSerializationConverter(myJson)
@@ -116,7 +115,6 @@ class KtorServiceClient(
     private fun startNetworkObserver() {
         launch {
             networkMonitor.isAvailable
-                .distinctUntilChanged()
                 .collect { available ->
                     if (available && _sessionState.value !is SessionState.Connected) {
                         logger.i { "Network became available while not fully connected — rotating HttpClient" }
@@ -1127,7 +1125,7 @@ class KtorServiceClient(
 
     fun close() {
         supervisorJob.cancel()
-        client.close()
+        currentClient.close()
     }
 
     private fun Request.playerControlLogLabel(): String? {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -55,6 +55,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -80,10 +81,47 @@ class KtorServiceClient(
     override val coroutineContext: CoroutineContext =
         supervisorJob + Dispatchers.IO + scopeExceptionHandler
 
-    private val client = createPlatformHttpClient {
+    private val clientMutex = Mutex()
+    @Volatile
+    private var currentClient: HttpClient = createPlatformHttpClient {
         install(WebSockets) {
             contentConverter = KotlinxWebsocketSerializationConverter(myJson)
             pingInterval = 10.seconds
+        }
+    }
+
+    /**
+     * Creates a fresh HttpClient and closes the old one.
+     * Called when the network transitions from unavailable → available while reconnecting,
+     * to discard any cached DNS failures / connection-pool timeouts in the old engine.
+     */
+    private suspend fun rotateHttpClient() {
+        clientMutex.withLock {
+            val oldClient = currentClient
+            currentClient = createPlatformHttpClient {
+                install(WebSockets) {
+                    contentConverter = KotlinxWebsocketSerializationConverter(myJson)
+                    pingInterval = 10.seconds
+                }
+            }
+            oldClient.close()
+        }
+    }
+
+    // Observes network availability and rotates the HttpClient when the network
+    // comes back after an outage. This prevents stale DNS/connection-pool state
+    // (e.g. NSURLErrorCannotFindHost with WireGuard tunnels) from poisoning
+    // subsequent reconnect attempts.
+    private fun startNetworkObserver() {
+        launch {
+            networkMonitor.isAvailable
+                .distinctUntilChanged()
+                .collect { available ->
+                    if (available && _sessionState.value !is SessionState.Connected) {
+                        logger.i { "Network became available while not fully connected — rotating HttpClient" }
+                        rotateHttpClient()
+                    }
+                }
         }
     }
 
@@ -430,6 +468,7 @@ class KtorServiceClient(
     )
 
     init {
+        startNetworkObserver()
         launch {
             isReadyForCommands.collect { ready ->
                 logger.i { "isReadyForCommands=$ready" }
@@ -615,7 +654,7 @@ class KtorServiceClient(
         startConnectWatchdog()
 
         val directTransport = DirectTransport(
-            client = client,
+            clientProvider = { currentClient },
             connectionInfoProvider = { connection },
             parentScope = this,
             networkAvailable = networkMonitor.isAvailable,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -50,12 +50,12 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -82,6 +82,7 @@ class KtorServiceClient(
         supervisorJob + Dispatchers.IO + scopeExceptionHandler
 
     private val clientMutex = Mutex()
+
     @Volatile
     private var currentClient: HttpClient = createPlatformHttpClient {
         install(WebSockets) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/ReconnectBackoff.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/ReconnectBackoff.kt
@@ -8,7 +8,6 @@ package io.music_assistant.client.api
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
-import kotlin.math.minOf
 
 /**
  * Three-phase reconnection backoff.
@@ -74,7 +73,7 @@ suspend fun runReconnectionLoop(
         } else {
             // Apply three-phase backoff. In infinite mode cap the backoff index at 9
             // so delay stays at 120s after the 10th attempt.
-            val capped = if (infinite) minOf(attempt, 9) else attempt
+            val capped = if (infinite) attempt.coerceAtMost(9) else attempt
             delay(reconnectBackoffMs(capped))
         }
         onAttemptStarting(attempt + 1)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/ReconnectBackoff.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/ReconnectBackoff.kt
@@ -8,6 +8,7 @@ package io.music_assistant.client.api
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
+import kotlin.math.minOf
 
 /**
  * Three-phase reconnection backoff.
@@ -33,16 +34,21 @@ fun reconnectBackoffMs(attempt: Int): Long = when (attempt) {
     else -> 120_000L       // 2‑minute ceiling from attempt 9 onward
 }
 
-/** Default reconnect attempt ceiling.  20 attempts × three-phase backoff ≈ 24 min window. */
+/**
+ * Default reconnect attempt ceiling. Set to a positive integer for finite retry with
+ * a clean failure state (recommended), or to -1 for infinite retry (the loop will
+ * only stop when the calling coroutine is cancelled).
+ */
 const val DEFAULT_MAX_RECONNECT_ATTEMPTS = 20
 
 /**
  * Runs a reconnection loop with three‑phase backoff and a configurable attempt ceiling.
  *
- * When [networkAvailable] is provided and reports `false`, the loop suspends
- * until the network returns instead of burning timed delays.  When the network
- * comes back a short grace period (500 ms) is added to let DNS stabilise
- * through a newly‑established route (e.g. WireGuard tunnel).
+ * When [maxAttempts] is negative the loop retries indefinitely (useful for cases where
+ * an external watchdog manages lifecycle). When [networkAvailable] is provided and
+ * reports `false`, the loop suspends until the network returns instead of burning
+ * timed delays. When the network comes back a short grace period (500 ms) is added
+ * to let DNS stabilise through a newly‑established route (e.g. WireGuard tunnel).
  *
  * @return true if [tryConnect] succeeded — the caller should resume normal
  *         operation.  false if all [maxAttempts] were exhausted.
@@ -53,10 +59,11 @@ suspend fun runReconnectionLoop(
     onAttemptStarting: (attempt: Int) -> Unit,
     tryConnect: suspend (attempt: Int) -> Boolean,
 ): Boolean {
-    for (attempt in 0 until maxAttempts) {
-        onAttemptStarting(attempt + 1)
+    val infinite = maxAttempts < 0
+    var attempt = 0
+    while (infinite || attempt < maxAttempts) {
         if (networkAvailable != null && !networkAvailable.value) {
-            // Network is down — wait for it instead of wasting a timed delay
+            // Network is down — wait for it without burning attempts or applying backoff
             networkAvailable.first { it }
             // Short grace period after the network comes back: DNS resolution through
             // the new route (e.g. WireGuard tunnel) may take a few ms to stabilise.
@@ -65,9 +72,14 @@ suspend fun runReconnectionLoop(
             // connection pool for all subsequent retries.
             delay(500)
         } else {
-            delay(reconnectBackoffMs(attempt))
+            // Apply three-phase backoff. In infinite mode cap the backoff index at 9
+            // so delay stays at 120s after the 10th attempt.
+            val capped = if (infinite) minOf(attempt, 9) else attempt
+            delay(reconnectBackoffMs(capped))
         }
+        onAttemptStarting(attempt + 1)
         if (tryConnect(attempt + 1)) return true
+        attempt++
     }
     return false
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/ReconnectBackoff.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/ReconnectBackoff.kt
@@ -10,9 +10,15 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 
 /**
- * Two-phase reconnection backoff.
- * Phase 1 (quick recovery, attempts 0–4): 0 → 500ms → 1s → 2s → 4s — transient failures.
- * Phase 2 (patient recovery, attempts 5–9): 8s → 15s → 30s → 60s → 60s — server reboots.
+ * Three-phase reconnection backoff.
+ * Phase 1 (attempts 0–4, quick recovery):    0 → 500ms → 1s → 2s → 4s — transient blips.
+ * Phase 2 (attempts 5–9, brief outages):      8s → 15s → 30s → 60s → 120s — tunnel / modem drop.
+ * Phase 3 (attempts 10+, indefinite):         120s steps — server reboot, long travel.
+ *
+ * After Phase 2 the delay caps at 120s. The combined window for the default 20 attempts
+ * is ~24 minutes — long enough for almost any transient outage (WireGuard reconnect,
+ * modem reboot, tunnel dropout), short enough to surface a clean error state before
+ * the user loses patience.
  */
 fun reconnectBackoffMs(attempt: Int): Long = when (attempt) {
     0 -> 0L
@@ -24,19 +30,22 @@ fun reconnectBackoffMs(attempt: Int): Long = when (attempt) {
     6 -> 15_000L
     7 -> 30_000L
     8 -> 60_000L
-    else -> 60_000L
+    else -> 120_000L       // 2‑minute ceiling from attempt 9 onward
 }
 
-const val DEFAULT_MAX_RECONNECT_ATTEMPTS = 10
+/** Default reconnect attempt ceiling.  20 attempts × three-phase backoff ≈ 24 min window. */
+const val DEFAULT_MAX_RECONNECT_ATTEMPTS = 20
 
 /**
- * Runs a reconnection loop with two-phase backoff.
+ * Runs a reconnection loop with three‑phase backoff and a configurable attempt ceiling.
  *
- * When [networkAvailable] is provided and reports `false`, the loop suspends until the network
- * returns instead of burning attempts against a dead connection. When the network comes back,
- * the attempt fires immediately (backoff delay is skipped since we already waited).
+ * When [networkAvailable] is provided and reports `false`, the loop suspends
+ * until the network returns instead of burning timed delays.  When the network
+ * comes back a short grace period (500 ms) is added to let DNS stabilise
+ * through a newly‑established route (e.g. WireGuard tunnel).
  *
- * @return true if [tryConnect] succeeded, false if all attempts exhausted.
+ * @return true if [tryConnect] succeeded — the caller should resume normal
+ *         operation.  false if all [maxAttempts] were exhausted.
  */
 suspend fun runReconnectionLoop(
     maxAttempts: Int = DEFAULT_MAX_RECONNECT_ATTEMPTS,
@@ -49,6 +58,12 @@ suspend fun runReconnectionLoop(
         if (networkAvailable != null && !networkAvailable.value) {
             // Network is down — wait for it instead of wasting a timed delay
             networkAvailable.first { it }
+            // Short grace period after the network comes back: DNS resolution through
+            // the new route (e.g. WireGuard tunnel) may take a few ms to stabilise.
+            // Without this delay, a reconnect attempt that fails with
+            // NSURLErrorCannotFindHost (Code=-1003) poisons the HTTP client's
+            // connection pool for all subsequent retries.
+            delay(500)
         } else {
             delay(reconnectBackoffMs(attempt))
         }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/MediaPlayerController.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/MediaPlayerController.kt
@@ -34,6 +34,9 @@ expect class MediaPlayerController(platformContext: PlatformContext) {
     fun resumeSink()
     fun flush()
 
+    // Resume playback after a transport reconnect (resumes audio sink + sends play command)
+    fun resume()
+
     // Volume control (0-100)
     fun setVolume(volume: Int)
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/SendspinClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/SendspinClient.kt
@@ -178,6 +178,9 @@ class SendspinClient(
                             is SendspinState.Connecting,
                             is SendspinState.Reconnecting,
                             is SendspinState.Error -> {
+                                val wasStreaming =
+                                    (_state.value as? SendspinState.Reconnecting)?.wasStreaming
+                                        ?: false
                                 try {
                                     if (config.requiresAuth) {
                                         _state.update { SendspinState.Authenticating }
@@ -188,6 +191,15 @@ class SendspinClient(
                                     }
                                 } catch (e: Exception) {
                                     logger.w { "Failed to send auth/hello (transport closed during handshake): ${e.message}" }
+                                }
+                                // Auto-resume playback if we were streaming before the disconnect
+                                if (wasStreaming) {
+                                    try {
+                                        mediaPlayerController.resume()
+                                        logger.i { "Auto-resumed playback after reconnect" }
+                                    } catch (e: Exception) {
+                                        logger.w(e) { "Auto-resume failed" }
+                                    }
                                 }
                             }
                             else -> Unit

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/SendspinClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/SendspinClient.kt
@@ -36,6 +36,15 @@ class SendspinClient(
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default + supervisorJob
 
+    companion object {
+        /** Max reconnect attempt index that still triggers auto-resume.
+         *  Matches attempt 9 = ~4 minutes on the backoff ladder.
+         *  Beyond this the outage is considered too long for safe
+         *  auto-resume — the server may have rebooted or the user
+         *  context may have changed. */
+        private const val RECONNECT_AUTO_RESUME_MAX_ATTEMPTS = 9
+    }
+
     // Components
     private var transport: SendspinTransport? = null
     private var messageDispatcher: MessageDispatcher? = null
@@ -179,9 +188,9 @@ class SendspinClient(
                             is SendspinState.Reconnecting,
                             is SendspinState.Error,
                             -> {
-                                val wasStreaming =
-                                    (_state.value as? SendspinState.Reconnecting)?.wasStreaming
-                                        ?: false
+                                val reconnecting = _state.value as? SendspinState.Reconnecting
+                                val wasStreaming = reconnecting?.wasStreaming ?: false
+                                val reconnectAttempt = reconnecting?.attempt ?: 0
                                 try {
                                     if (config.requiresAuth) {
                                         _state.update { SendspinState.Authenticating }
@@ -194,12 +203,19 @@ class SendspinClient(
                                     logger.w { "Failed to send auth/hello (transport closed during handshake): ${e.message}" }
                                 }
                                 // Auto-resume playback if we were streaming before the disconnect
-                                if (wasStreaming) {
+                                // and the outage wasn't too long (attempt <= threshold).
+                                // Beyond ~4 minutes (attempt 9) the server may have rebooted or
+                                // the user context changed — don't startle the user.
+                                if (wasStreaming && reconnectAttempt < RECONNECT_AUTO_RESUME_MAX_ATTEMPTS) {
                                     try {
                                         mediaPlayerController.resume()
-                                        logger.i { "Auto-resumed playback after reconnect" }
+                                        logger.i { "Auto-resumed playback after reconnect (attempt $reconnectAttempt)" }
                                     } catch (e: Exception) {
                                         logger.w(e) { "Auto-resume failed" }
+                                    }
+                                } else if (wasStreaming) {
+                                    logger.i {
+                                        "Skipped auto-resume after $reconnectAttempt attempts (max=$RECONNECT_AUTO_RESUME_MAX_ATTEMPTS)"
                                     }
                                 }
                             }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/SendspinClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/SendspinClient.kt
@@ -177,7 +177,8 @@ class SendspinClient(
                         when (_state.value) {
                             is SendspinState.Connecting,
                             is SendspinState.Reconnecting,
-                            is SendspinState.Error -> {
+                            is SendspinState.Error,
+                            -> {
                                 val wasStreaming =
                                     (_state.value as? SendspinState.Reconnecting)?.wasStreaming
                                         ?: false

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/SendspinClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/SendspinClient.kt
@@ -175,7 +175,9 @@ class SendspinClient(
                 when (wsState) {
                     WebSocketState.Connected -> {
                         when (_state.value) {
-                            is SendspinState.Connecting, is SendspinState.Reconnecting -> {
+                            is SendspinState.Connecting,
+                            is SendspinState.Reconnecting,
+                            is SendspinState.Error -> {
                                 try {
                                     if (config.requiresAuth) {
                                         _state.update { SendspinState.Authenticating }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/connection/SendspinWsHandler.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/connection/SendspinWsHandler.kt
@@ -56,6 +56,9 @@ class SendspinWsHandler(
     private var reconnectAttempts = 0
     private var reconnectJob: Job? = null
 
+    // Callback invoked after a successful automatic reconnect
+    var onReconnected: (() -> Unit)? = null
+
     private val _textMessages = MutableSharedFlow<String>(extraBufferCapacity = 50)
     val textMessages: Flow<String> = _textMessages.asSharedFlow()
 
@@ -228,6 +231,7 @@ class SendspinWsHandler(
                         reconnectAttempts = 0
                         _connectionState.value = WebSocketState.Connected
                         startListening(wsSession)
+                        onReconnected?.invoke()
                         true
                     } catch (e: Exception) {
                         logger.w(e) { "Reconnect attempt $attempt failed" }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/connection/SendspinWsHandler.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/connection/SendspinWsHandler.kt
@@ -34,6 +34,7 @@ import kotlin.time.Duration.Companion.seconds
 class SendspinWsHandler(
     private val serverUrl: String,
     private val networkAvailable: StateFlow<Boolean>? = null,
+    private val maxAttempts: Int = DEFAULT_MAX_RECONNECT_ATTEMPTS,
 ) : CoroutineScope {
     private val logger = Logger.withTag("SendspinWsHandler")
     private val supervisorJob = SupervisorJob()
@@ -54,7 +55,6 @@ class SendspinWsHandler(
     private var explicitDisconnect = false
     private var reconnectAttempts = 0
     private var reconnectJob: Job? = null
-    private val maxReconnectAttempts = DEFAULT_MAX_RECONNECT_ATTEMPTS
 
     private val _textMessages = MutableSharedFlow<String>(extraBufferCapacity = 50)
     val textMessages: Flow<String> = _textMessages.asSharedFlow()
@@ -211,12 +211,13 @@ class SendspinWsHandler(
     private fun attemptReconnect() {
         reconnectJob?.cancel()
         reconnectJob = launch {
+            val attemptsLabel = if (maxAttempts < 0) "∞" else maxAttempts.toString()
             val reconnected = runReconnectionLoop(
-                maxAttempts = maxReconnectAttempts,
+                maxAttempts = maxAttempts,
                 networkAvailable = networkAvailable,
                 onAttemptStarting = { attempt ->
                     reconnectAttempts = attempt
-                    logger.i { "Reconnect attempt $attempt/$maxReconnectAttempts" }
+                    logger.i { "Reconnect attempt $attempt/$attemptsLabel" }
                     _connectionState.value = WebSocketState.Reconnecting(attempt)
                 },
                 tryConnect = { attempt ->
@@ -235,10 +236,10 @@ class SendspinWsHandler(
                 },
             )
             if (!reconnected) {
-                logger.e { "Max reconnect attempts ($maxReconnectAttempts) reached, giving up" }
+                logger.e { "Max reconnect attempts ($maxAttempts) reached, giving up" }
                 session = null
                 _connectionState.value = WebSocketState.Error(
-                    Exception("Failed to reconnect after $maxReconnectAttempts attempts"),
+                    Exception("Failed to reconnect after $maxAttempts attempts"),
                 )
             }
         }

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/player/MediaPlayerController.ios.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/player/MediaPlayerController.ios.kt
@@ -58,6 +58,11 @@ actual class MediaPlayerController actual constructor(platformContext: PlatformC
     actual fun resumeSink() { PlatformPlayerProvider.player?.resumeSink() }
     actual fun flush() { PlatformPlayerProvider.player?.flush() }
 
+    actual fun resume() {
+        resumeSink()
+        onRemoteCommand?.invoke("play")
+    }
+
     actual fun stopRawPcmStream() {
         PlatformPlayerProvider.player?.stopRawPcmStream()
         isPrepared = false


### PR DESCRIPTION
Closes #693 (at least remedies)

## Problem
3 compounding bugs prevent iOS MA Client from recovering after network drops (WireGuard tunnel drops, mobile network change, Wi-Fi roam, etc...):

1. **Stale HttpClient connection pool**: ktor/Darwin/NSURLSession caches DNS failures (Code=-1003). All subsequent reconnect attempts fail with same error even after the network is restored.
2. **Fixed 10-attempt ceiling**: ~3 minute window is too short for tunnel-based connectivity (5-15 min).
3. **No auto-resume**: Sendspin WS reconnects but doesn't know music was playing, so stream stays silent.

## Changes

* HttpClient rotation on network change + 20-attempt backoff + 500ms DNS grace
* Configurable reconnect with infinite retry mode (-1)
* Auto-resume playback after WS reconnect (Sendspin) within the first `RECONNECT_AUTO_RESUME_MAX_ATTEMPTS` attempts (currently 9)