### PR TITLE
Make search inputs consistent

### DIFF
--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/LibraryTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/LibraryTest.kt
@@ -140,7 +140,7 @@ class LibraryTest {
     }
 
     @Test
-    fun `can search item`() {
+    fun `can search within items`() {
         val album1 = ServerMediaItemFixtures.album(name = "Balloon Trapeze Experience")
         val album2 = ServerMediaItemFixtures.album(name = "Frontal Lobe Annihilation Puzzle")
         serviceClient.addToLibrary(album1, album2)
@@ -152,6 +152,21 @@ class LibraryTest {
             .search("lobe")
             .assertMediaDisplayed(album2.name)
             .assertMediaNotDisplayed(album1.name)
+    }
+
+    @Test
+    fun `can search outside of library if there are no results`() {
+        val album = ServerMediaItemFixtures.album(name = "Balloon Trapeze Experience")
+        serviceClient.addToGlobalItems(album)
+
+        launchLoggedInApp(composeTestRule, serviceClient)
+            .clickLibrary()
+            .clickAlbums()
+            .openSearch()
+            .search("balloon")
+            .assertNoItems()
+            .clickSearchEverywhere("balloon")
+            .assertResult(album.name)
     }
 
     @Test

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/SearchTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/SearchTest.kt
@@ -13,6 +13,7 @@ import io.music_assistant.client.support.pages.clickHome
 import io.music_assistant.client.support.pages.clickSearch
 import io.music_assistant.client.support.rules.createTestRuleChain
 import musicassistantclient.composeapp.generated.resources.Res
+import musicassistantclient.composeapp.generated.resources.media_type_albums
 import musicassistantclient.composeapp.generated.resources.nav_home
 import musicassistantclient.composeapp.generated.resources.nav_search
 import org.junit.Rule
@@ -41,6 +42,23 @@ class SearchTest {
             .clickSearch()
             .search("onion")
             .assertResult(album.name)
+            .clickOnMedia(album)
+    }
+
+    @Test
+    fun `can filter search results`() {
+        val album = ServerMediaItemFixtures.album(name = "The Exploding Onion Conspiracy")
+        val track = ServerMediaItemFixtures.track(name = "Onion Dip")
+        serviceClient.addToLibrary(album, track)
+
+        launchLoggedInApp(composeTestRule, serviceClient)
+            .clickSearch()
+            .search("onion")
+            .assertResult(album.name)
+            .assertResult(track.name)
+            .enableFilter(Res.string.media_type_albums.get())
+            .assertResult(album.name)
+            .assertNoResult(track.name)
             .clickOnMedia(album)
     }
 

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -43,6 +43,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.encodeToJsonElement
+import kotlin.collections.addAll
 
 class FakeServiceClient : ServiceClient {
     private var legacyVersion: LegacyVersion? = null
@@ -55,9 +56,16 @@ class FakeServiceClient : ServiceClient {
     private val queues = mutableListOf<ServerQueue>()
     private val queueItems = mutableMapOf<String, List<ServerQueueItem>>()
     private val items = mutableSetOf<ServerMediaItem>()
+    private val globalItems = mutableListOf<ServerMediaItem>()
+
     private val albums: List<ServerMediaItem>
         get() {
             return items.filter { it.mediaType == MediaType.ALBUM.serverValue }
+        }
+
+    private val globalAlbums: List<ServerMediaItem>
+        get() {
+            return globalItems.filter { it.mediaType == MediaType.ALBUM.serverValue }
         }
 
     private val artists: List<ServerMediaItem>
@@ -199,7 +207,7 @@ class FakeServiceClient : ServiceClient {
                             request = request,
                             result = SearchResult(
                                 artists = searchItems(request, searchArg, artists),
-                                albums = searchItems(request, searchArg, albums),
+                                albums = searchItems(request, searchArg, albums + globalAlbums),
                                 tracks = searchItems(request, searchArg, tracks),
                                 playlists = searchItems(request, searchArg, playlists),
                                 podcasts = searchItems(request, searchArg, podcasts),
@@ -217,7 +225,7 @@ class FakeServiceClient : ServiceClient {
                                     emptyList()
                                 },
                                 albums = if (mediaTypes.contains(MediaType.ALBUM.serverValue)) {
-                                    searchItems(request, searchArg, albums)
+                                    searchItems(request, searchArg, albums + globalAlbums)
                                 } else {
                                     emptyList()
                                 },
@@ -686,6 +694,10 @@ class FakeServiceClient : ServiceClient {
                 this.items.add(it)
             }
         }
+    }
+
+    fun addToGlobalItems(vararg items: ServerMediaItem) {
+        this.globalItems.addAll(items)
     }
 
     fun addPlayers(vararg players: ServerPlayer) {

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -189,18 +189,57 @@ class FakeServiceClient : ServiceClient {
             }
 
             APICommands.MUSIC_SEARCH -> {
-                Result.success(
-                    answer(
-                        request = request,
-                        result = SearchResult(
-                            artists = emptyList(),
-                            albums = searchItems(request, "search_query", items),
-                            tracks = emptyList(),
-                            playlists = emptyList(),
-                            podcasts = emptyList(),
+                val searchArg = "search_query"
+                val mediaTypes =
+                    (request.args!!["media_types"] as JsonArray).map { (it as JsonPrimitive).content }
+
+                if (mediaTypes.isEmpty()) {
+                    Result.success(
+                        answer(
+                            request = request,
+                            result = SearchResult(
+                                artists = searchItems(request, searchArg, artists),
+                                albums = searchItems(request, searchArg, albums),
+                                tracks = searchItems(request, searchArg, tracks),
+                                playlists = searchItems(request, searchArg, playlists),
+                                podcasts = searchItems(request, searchArg, podcasts),
+                            ),
                         ),
-                    ),
-                )
+                    )
+                } else {
+                    Result.success(
+                        answer(
+                            request = request,
+                            result = SearchResult(
+                                artists = if (mediaTypes.contains(MediaType.ARTIST.serverValue)) {
+                                    searchItems(request, searchArg, artists)
+                                } else {
+                                    emptyList()
+                                },
+                                albums = if (mediaTypes.contains(MediaType.ALBUM.serverValue)) {
+                                    searchItems(request, searchArg, albums)
+                                } else {
+                                    emptyList()
+                                },
+                                tracks = if (mediaTypes.contains(MediaType.TRACK.serverValue)) {
+                                    searchItems(request, searchArg, tracks)
+                                } else {
+                                    emptyList()
+                                },
+                                playlists = if (mediaTypes.contains(MediaType.PLAYLIST.serverValue)) {
+                                    searchItems(request, searchArg, playlists)
+                                } else {
+                                    emptyList()
+                                },
+                                podcasts = if (mediaTypes.contains(MediaType.PODCAST.serverValue)) {
+                                    searchItems(request, searchArg, podcasts)
+                                } else {
+                                    emptyList()
+                                },
+                            ),
+                        ),
+                    )
+                }
             }
 
             APICommands.musicGet(APICommands.KIND_ALBUMS) -> {

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ItemListPage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ItemListPage.kt
@@ -12,7 +12,9 @@ import androidx.compose.ui.test.performTextInput
 import io.music_assistant.client.data.model.server.ServerMediaItem
 import io.music_assistant.client.support.get
 import musicassistantclient.composeapp.generated.resources.Res
+import musicassistantclient.composeapp.generated.resources.library_empty
 import musicassistantclient.composeapp.generated.resources.library_quick_search
+import musicassistantclient.composeapp.generated.resources.library_search_global
 import musicassistantclient.composeapp.generated.resources.nav_home
 import musicassistantclient.composeapp.generated.resources.nav_library
 import musicassistantclient.composeapp.generated.resources.nav_search
@@ -50,5 +52,17 @@ class ItemListPage(private val type: String, composeTestRule: ComposeTestRule) :
     fun openSearch(): ItemListPage {
         composeTestRule.onNodeWithContentDescription(Res.string.library_quick_search.get()).performClick()
         return this
+    }
+
+    fun assertNoItems(): ItemListPage {
+        composeTestRule.onNodeWithText(Res.string.library_empty.get()).assertIsDisplayed()
+        return this
+    }
+
+    fun clickSearchEverywhere(query: String): SearchPage {
+        composeTestRule.onNodeWithText(Res.string.library_search_global.get())
+            .assertIsDisplayed()
+            .performClick()
+        return SearchPage(composeTestRule, query = query).assertOnPage()
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ItemListPage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ItemListPage.kt
@@ -19,6 +19,7 @@ import musicassistantclient.composeapp.generated.resources.nav_home
 import musicassistantclient.composeapp.generated.resources.nav_library
 import musicassistantclient.composeapp.generated.resources.nav_search
 import musicassistantclient.composeapp.generated.resources.nav_settings
+import musicassistantclient.composeapp.generated.resources.search_query_label
 
 class ItemListPage(private val type: String, composeTestRule: ComposeTestRule) :
     ComposePage(composeTestRule) {
@@ -40,7 +41,7 @@ class ItemListPage(private val type: String, composeTestRule: ComposeTestRule) :
     }
 
     fun search(query: String): ItemListPage {
-        composeTestRule.onNodeWithText(Res.string.library_quick_search.get())
+        composeTestRule.onNodeWithText(Res.string.search_query_label.get())
             .assertIsDisplayed()
             .performTextInput(query)
 

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SearchPage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SearchPage.kt
@@ -19,9 +19,14 @@ import musicassistantclient.composeapp.generated.resources.nav_settings
 import musicassistantclient.composeapp.generated.resources.search_query_label
 import musicassistantclient.composeapp.generated.resources.search_start
 
-class SearchPage(composeTestRule: ComposeTestRule) : ComposePage(composeTestRule) {
+class SearchPage(composeTestRule: ComposeTestRule, val query: String? = null) : ComposePage(composeTestRule) {
     override fun assert() {
-        composeTestRule.onNodeWithText(Res.string.search_start.get()).assertIsDisplayed()
+        if (query != null) {
+            composeTestRule.onNodeWithText(query).assertIsDisplayed()
+        } else {
+            composeTestRule.onNodeWithText(Res.string.search_start.get()).assertIsDisplayed()
+        }
+
         assertNavBar(
             items = listOf(
                 Res.string.nav_home.get(),

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SearchPage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SearchPage.kt
@@ -1,6 +1,7 @@
 package io.music_assistant.client.support.pages
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -48,8 +49,18 @@ class SearchPage(composeTestRule: ComposeTestRule) : ComposePage(composeTestRule
         return this
     }
 
+    fun assertNoResult(result: String): SearchPage {
+        composeTestRule.onNodeWithText(result).assertIsNotDisplayed()
+        return this
+    }
+
     fun assertNoResults(): SearchPage {
         composeTestRule.onNodeWithText(Res.string.search_start.get()).assertIsDisplayed()
+        return this
+    }
+
+    fun enableFilter(filter: String): SearchPage {
+        composeTestRule.onNodeWithContentDescription("Filter $filter").performClick()
         return this
     }
 

--- a/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/search/SearchInputTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/search/SearchInputTest.kt
@@ -1,13 +1,20 @@
 package io.music_assistant.client.ui.compose.search
 
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotFocused
 import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextReplacement
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.music_assistant.client.support.get
+import musicassistantclient.composeapp.generated.resources.Res
+import musicassistantclient.composeapp.generated.resources.common_clear
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -39,5 +46,18 @@ class SearchInputTest {
 
         restorationTester.emulateSavedInstanceStateRestore()
         composeTestRule.onNodeWithText("blah").assertIsNotFocused()
+    }
+
+    @Test
+    fun `clears text when clear pressed`() {
+        composeTestRule.setContent {
+            SearchInput(onSearch = {}, placeHolder = "Search query")
+        }
+
+        composeTestRule.onNodeWithText("Search query").performTextReplacement("something")
+        composeTestRule.onNodeWithContentDescription(Res.string.common_clear.get()).performClick()
+
+        composeTestRule.onNodeWithText("something").assertIsNotDisplayed()
+        composeTestRule.onNodeWithText("Search query").assertIsDisplayed()
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/search/SearchInputTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/search/SearchInputTest.kt
@@ -1,20 +1,12 @@
 package io.music_assistant.client.ui.compose.search
 
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsFocused
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotFocused
 import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.v2.createComposeRule
-import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performTextReplacement
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.music_assistant.client.support.get
-import musicassistantclient.composeapp.generated.resources.Res
-import musicassistantclient.composeapp.generated.resources.common_clear
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -28,36 +20,20 @@ class SearchInputTest {
     @Test
     fun `requests focus`() {
         composeTestRule.setContent {
-            SearchInput(onSearch = {}, placeHolder = "Search query")
+            SearchInput(query = "", placeHolder = "Search query")
         }
 
         composeTestRule.onNodeWithText("Search query").assertIsFocused()
     }
 
     @Test
-    fun `does not request focus when query is not empty after restore`() {
+    fun `does not request focus when query is not empty`() {
         val restorationTester = StateRestorationTester(composeTestRule)
 
         restorationTester.setContent {
-            SearchInput(onSearch = {}, placeHolder = "Search query")
+            SearchInput(query = "blah", placeHolder = "Search query")
         }
 
-        composeTestRule.onNodeWithText("Search query").performTextReplacement("blah")
-
-        restorationTester.emulateSavedInstanceStateRestore()
         composeTestRule.onNodeWithText("blah").assertIsNotFocused()
-    }
-
-    @Test
-    fun `clears text when clear pressed`() {
-        composeTestRule.setContent {
-            SearchInput(onSearch = {}, placeHolder = "Search query")
-        }
-
-        composeTestRule.onNodeWithText("Search query").performTextReplacement("something")
-        composeTestRule.onNodeWithContentDescription(Res.string.common_clear.get()).performClick()
-
-        composeTestRule.onNodeWithText("something").assertIsNotDisplayed()
-        composeTestRule.onNodeWithText("Search query").assertIsDisplayed()
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/search/SearchInputTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/search/SearchInputTest.kt
@@ -7,6 +7,9 @@ import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.music_assistant.client.support.get
+import musicassistantclient.composeapp.generated.resources.Res
+import musicassistantclient.composeapp.generated.resources.search_query_label
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -20,10 +23,10 @@ class SearchInputTest {
     @Test
     fun `requests focus`() {
         composeTestRule.setContent {
-            SearchInput(query = "", placeHolder = "Search query")
+            SearchInput(query = "")
         }
 
-        composeTestRule.onNodeWithText("Search query").assertIsFocused()
+        composeTestRule.onNodeWithText(Res.string.search_query_label.get()).assertIsFocused()
     }
 
     @Test
@@ -31,7 +34,7 @@ class SearchInputTest {
         val restorationTester = StateRestorationTester(composeTestRule)
 
         restorationTester.setContent {
-            SearchInput(query = "blah", placeHolder = "Search query")
+            SearchInput(query = "blah")
         }
 
         composeTestRule.onNodeWithText("blah").assertIsNotFocused()

--- a/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/search/SearchInputTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/search/SearchInputTest.kt
@@ -21,7 +21,7 @@ class SearchInputTest {
     @Test
     fun `requests focus`() {
         composeTestRule.setContent {
-            SearchInput(placeHolder = "Search query", onSearch = {})
+            SearchInput(onSearch = {}, placeHolder = "Search query")
         }
 
         composeTestRule.onNodeWithText("Search query").assertIsFocused()
@@ -32,7 +32,7 @@ class SearchInputTest {
         val restorationTester = StateRestorationTester(composeTestRule)
 
         restorationTester.setContent {
-            SearchInput(placeHolder = "Search query", onSearch = {})
+            SearchInput(onSearch = {}, placeHolder = "Search query")
         }
 
         composeTestRule.onNodeWithText("Search query").performTextReplacement("blah")

--- a/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/search/SearchInputTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/search/SearchInputTest.kt
@@ -1,34 +1,43 @@
 package io.music_assistant.client.ui.compose.search
 
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertIsNotFocused
+import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTextReplacement
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
+@OptIn(ExperimentalTestApi::class)
 class SearchInputTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
     @Test
-    fun `requests focus when query is empty`() {
+    fun `requests focus`() {
         composeTestRule.setContent {
-            SearchInput(placeHolder = "Search query", query = "", onSearch = {})
+            SearchInput(placeHolder = "Search query", onSearch = {})
         }
 
         composeTestRule.onNodeWithText("Search query").assertIsFocused()
     }
 
     @Test
-    fun `does not request focus when query is not empty`() {
-        composeTestRule.setContent {
-            SearchInput(placeHolder = "Search query", query = "con", onSearch = {})
+    fun `does not request focus when query is not empty after restore`() {
+        val restorationTester = StateRestorationTester(composeTestRule)
+
+        restorationTester.setContent {
+            SearchInput(placeHolder = "Search query", onSearch = {})
         }
 
-        composeTestRule.onNodeWithText("con").assertIsNotFocused()
+        composeTestRule.onNodeWithText("Search query").performTextReplacement("blah")
+
+        restorationTester.emulateSavedInstanceStateRestore()
+        composeTestRule.onNodeWithText("blah").assertIsNotFocused()
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/search/SearchInputTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/search/SearchInputTest.kt
@@ -17,7 +17,7 @@ class SearchInputTest {
     @Test
     fun `requests focus when query is empty`() {
         composeTestRule.setContent {
-            SearchInput(query = "", onQueryChanged = {}, onSearchTriggered = {})
+            SearchInput(placeHolder = "Search query", query = "", onSearch = {})
         }
 
         composeTestRule.onNodeWithText("Search query").assertIsFocused()
@@ -26,7 +26,7 @@ class SearchInputTest {
     @Test
     fun `does not request focus when query is not empty`() {
         composeTestRule.setContent {
-            SearchInput(query = "con", onQueryChanged = {}, onSearchTriggered = {})
+            SearchInput(placeHolder = "Search query", query = "con", onSearch = {})
         }
 
         composeTestRule.onNodeWithText("con").assertIsNotFocused()

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -234,7 +234,7 @@
   <string name="search_error">Error loading search results</string>
   <string name="search_in_library_only">In library only</string>
   <string name="search_no_results">No results found</string>
-  <string name="search_query_label">Search query</string>
+  <string name="search_query_label">Search…</string>
   <string name="search_start">Start searching…</string>
   <string name="search_title">Global search</string>
   <string name="server_id_mismatch_error">Server ID was changed. Re-authentication required.</string>

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemListScreen.kt
@@ -13,11 +13,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
-import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ViewList
-import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.Search
@@ -30,10 +28,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.SearchBarDefaults
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -43,8 +38,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import compose.icons.TablerIcons
@@ -72,12 +65,12 @@ import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.nav.TopBarLayout
 import io.music_assistant.client.ui.compose.nav.TwoRowTopAppBar
+import io.music_assistant.client.ui.compose.search.SearchInput
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.cd_add_playlist
 import musicassistantclient.composeapp.generated.resources.cd_library_filters
 import musicassistantclient.composeapp.generated.resources.cd_toggle_view_mode
 import musicassistantclient.composeapp.generated.resources.common_back
-import musicassistantclient.composeapp.generated.resources.common_clear
 import musicassistantclient.composeapp.generated.resources.library_empty
 import musicassistantclient.composeapp.generated.resources.library_error
 import musicassistantclient.composeapp.generated.resources.library_quick_search
@@ -211,41 +204,10 @@ private fun ItemListTopBar(
         TwoRowTopAppBar(
             title = {
                 if (showSearch) {
-                    val focusRequester = remember { FocusRequester() }
-                    LaunchedEffect(Unit) {
-                        focusRequester.requestFocus()
-                    }
-
-                    Surface(
-                        shape = SearchBarDefaults.inputFieldShape,
-                        color = SearchBarDefaults.colors().containerColor,
-                        contentColor = contentColorFor(SearchBarDefaults.colors().containerColor),
-                        tonalElevation = SearchBarDefaults.TonalElevation,
-                        shadowElevation = SearchBarDefaults.ShadowElevation,
-                    ) {
-                        SearchBarDefaults.InputField(
-                            modifier = Modifier.focusRequester(focusRequester),
-                            state = TextFieldState(initialText = searchQuery),
-                            onSearch = { onSearchQueryChanged(it) },
-                            expanded = false,
-                            onExpandedChange = {},
-                            placeholder = {
-                                Text(stringResource(Res.string.library_quick_search))
-                            },
-                            trailingIcon = if (searchQuery.isNotEmpty()) {
-                                {
-                                    IconButton(onClick = { onSearchQueryChanged("") }) {
-                                        Icon(
-                                            Icons.Default.Clear,
-                                            contentDescription = stringResource(Res.string.common_clear),
-                                        )
-                                    }
-                                }
-                            } else {
-                                null
-                            },
-                        )
-                    }
+                    SearchInput(
+                        placeHolder = stringResource(Res.string.library_quick_search),
+                        onSearch = onSearchQueryChanged,
+                    )
                 } else {
                     val title = when (mediaType) {
                         MediaType.ARTIST -> stringResource(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemListScreen.kt
@@ -205,8 +205,8 @@ private fun ItemListTopBar(
             title = {
                 if (showSearch) {
                     SearchInput(
-                        placeHolder = stringResource(Res.string.library_quick_search),
                         onSearch = onSearchQueryChanged,
+                        placeHolder = stringResource(Res.string.library_quick_search),
                     )
                 } else {
                     val title = when (mediaType) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemListScreen.kt
@@ -119,9 +119,8 @@ fun ItemListScreen(
                 onToggleViewMode = itemListViewModel::toggleViewMode,
                 viewMode = state.viewMode,
                 searchQuery = state.searchQuery,
-                onSearchQueryChanged = {
-                    itemListViewModel.onSearchQueryChanged(it)
-                },
+                onSearchQueryChanged = itemListViewModel::onSearchQueryChanged,
+                onSearch = itemListViewModel::onSearch,
                 onSortChanged = { itemListViewModel.onSortChanged(it) },
                 mediaType = state.mediaType,
                 sortOption = state.sortOption,
@@ -173,6 +172,7 @@ private fun ItemListTopBar(
     viewMode: ViewMode,
     searchQuery: String,
     onSearchQueryChanged: (String) -> Unit,
+    onSearch: () -> Unit,
     onSortChanged: (SortOption) -> Unit,
     mediaType: MediaType,
     sortOption: SortOption,
@@ -205,7 +205,9 @@ private fun ItemListTopBar(
             title = {
                 if (showSearch) {
                     SearchInput(
-                        onSearch = onSearchQueryChanged,
+                        query = searchQuery,
+                        onQueryChanged = onSearchQueryChanged,
+                        onSearch = onSearch,
                         placeHolder = stringResource(Res.string.library_quick_search),
                     )
                 } else {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemListScreen.kt
@@ -208,7 +208,6 @@ private fun ItemListTopBar(
                         query = searchQuery,
                         onQueryChanged = onSearchQueryChanged,
                         onSearch = onSearch,
-                        placeHolder = stringResource(Res.string.library_quick_search),
                     )
                 } else {
                     val title = when (mediaType) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemListViewModel.kt
@@ -27,8 +27,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import musicassistantclient.composeapp.generated.resources.Res
@@ -43,6 +41,8 @@ class ItemListViewModel(
     private val settingsRepository: SettingsRepository,
     private val mediaItemRepository: MediaItemRepository,
 ) : ViewModel() {
+    private val searchTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
     private val _state = MutableStateFlow(
         State(
             dataState = DataState.Loading(),
@@ -66,12 +66,11 @@ class ItemListViewModel(
 
     init {
         viewModelScope.launch {
-            _state.map {
-                listOf(it.searchQuery, it.sortOption, it.filters)
-            }
-                .distinctUntilChanged()
+            searchTrigger
                 .debounce { Timings.INPUT_DEBOUNCE }
-                .collect { loadFirstPage() }
+                .collect {
+                    loadFirstPage()
+                }
         }
 
         viewModelScope.launch {
@@ -85,6 +84,7 @@ class ItemListViewModel(
         viewModelScope.launch {
             settingsRepository.libraryFilters(mediaType).collect { filters ->
                 _state.update { it.copy(filters = filters) }
+                searchTrigger.tryEmit(Unit)
             }
         }
 
@@ -105,6 +105,8 @@ class ItemListViewModel(
                 }
             }
         }
+
+        searchTrigger.tryEmit(Unit)
     }
 
     private fun removeItem(deleted: AppMediaItem) {
@@ -215,12 +217,17 @@ class ItemListViewModel(
         else -> null
     }
 
+    fun onSearch() {
+        searchTrigger.tryEmit(Unit)
+    }
+
     fun onSearchQueryChanged(query: String) {
         _state.update { it.copy(searchQuery = query) }
     }
 
     fun onSortChanged(sortOption: SortOption) {
         _state.update { it.copy(sortOption = sortOption) }
+        searchTrigger.tryEmit(Unit)
     }
 
     fun loadMore() {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/TwoRowTopAppBar.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/TwoRowTopAppBar.kt
@@ -19,9 +19,9 @@ import androidx.compose.ui.Modifier
 @Composable
 fun TwoRowTopAppBar(
     title: @Composable () -> Unit,
-    navigationIcon: @Composable () -> Unit,
-    actions: @Composable RowScope.() -> Unit,
-    secondRow: @Composable RowScope.() -> Unit,
+    navigationIcon: @Composable () -> Unit = {},
+    actions: @Composable RowScope.() -> Unit = {},
+    secondRow: @Composable RowScope.() -> Unit = {},
 ) {
     Column {
         TopAppBar(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchInput.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchInput.kt
@@ -1,8 +1,6 @@
 package io.music_assistant.client.ui.compose.search
 
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.text.input.clearText
-import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -28,15 +26,15 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun SearchInput(
     modifier: Modifier = Modifier,
-    onSearch: (String) -> Unit,
+    query: String,
+    onQueryChanged: (String) -> Unit = {},
+    onSearch: () -> Unit = {},
     focusManager: FocusManager = LocalFocusManager.current,
     placeHolder: String,
 ) {
-    val textFieldState = rememberTextFieldState()
-
     val focusRequester = remember { FocusRequester() }
     LaunchedEffect(Unit) {
-        if (textFieldState.text.isEmpty()) {
+        if (query.isEmpty()) {
             focusRequester.requestFocus()
         }
     }
@@ -51,9 +49,10 @@ fun SearchInput(
     ) {
         SearchBarDefaults.InputField(
             modifier = Modifier.focusRequester(focusRequester),
-            state = textFieldState,
+            query = query,
+            onQueryChange = onQueryChanged,
             onSearch = {
-                onSearch(it)
+                onSearch()
                 focusManager.clearFocus()
             },
             expanded = false,
@@ -61,12 +60,12 @@ fun SearchInput(
             placeholder = {
                 Text(placeHolder)
             },
-            trailingIcon = if (textFieldState.text.isNotEmpty()) {
+            trailingIcon = if (query.isNotEmpty()) {
                 {
                     IconButton(
                         onClick = {
-                            textFieldState.clearText()
-                            onSearch("")
+                            onQueryChanged("")
+                            onSearch()
                         },
                     ) {
                         Icon(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchInput.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchInput.kt
@@ -110,3 +110,11 @@ fun SearchInputPreview() {
 fun SearchInputEmptyPreview() {
     SearchInput(query = "")
 }
+
+@Preview
+@Composable
+fun SearchInputLongQueryPreview() {
+    SearchInput(
+        query = "a really long query for something that isn't likely to be something anyone would actually ever type",
+    )
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchInput.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchInput.kt
@@ -11,11 +11,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SearchBarDefaults
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
-import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -27,6 +25,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.common_clear
 import musicassistantclient.composeapp.generated.resources.search_query_label
@@ -48,65 +47,56 @@ fun SearchInput(
         }
     }
 
-    Surface(
-        modifier = modifier.fillMaxWidth(),
+    val textStyle = MaterialTheme.typography.bodyLarge
+    TextField(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(54.dp)
+            .focusRequester(focusRequester),
         shape = SearchBarDefaults.inputFieldShape,
-        color = SearchBarDefaults.colors().containerColor,
-        contentColor = contentColorFor(SearchBarDefaults.colors().containerColor),
-        tonalElevation = SearchBarDefaults.TonalElevation,
-        shadowElevation = SearchBarDefaults.ShadowElevation,
-    ) {
-        val textStyle = MaterialTheme.typography.bodyLarge
-
-        TextField(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(SearchBarDefaults.InputFieldHeight)
-                .focusRequester(focusRequester),
-            value = query,
-            onValueChange = onQueryChanged,
-            placeholder = {
-                Text(
-                    stringResource(Res.string.search_query_label),
-                    style = textStyle,
-                )
+        value = query,
+        onValueChange = onQueryChanged,
+        placeholder = {
+            Text(
+                stringResource(Res.string.search_query_label),
+                style = textStyle,
+            )
+        },
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+        keyboardActions = KeyboardActions(
+            onSearch = {
+                onSearch()
+                focusManager.clearFocus()
             },
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-            keyboardActions = KeyboardActions(
-                onSearch = {
-                    onSearch()
-                    focusManager.clearFocus()
-                },
-            ),
-            textStyle = textStyle,
-            trailingIcon = if (query.isNotEmpty()) {
-                {
-                    IconButton(
-                        onClick = {
-                            onQueryChanged("")
-                            onSearch()
-                        },
-                    ) {
-                        Icon(
-                            Icons.Default.Clear,
-                            contentDescription = stringResource(Res.string.common_clear),
-                        )
-                    }
+        ),
+        textStyle = textStyle,
+        trailingIcon = if (query.isNotEmpty()) {
+            {
+                IconButton(
+                    onClick = {
+                        onQueryChanged("")
+                        onSearch()
+                    },
+                ) {
+                    Icon(
+                        Icons.Default.Clear,
+                        contentDescription = stringResource(Res.string.common_clear),
+                    )
                 }
-            } else {
-                null
-            },
-            colors = TextFieldDefaults.colors(
-                focusedContainerColor = SearchBarDefaults.colors().containerColor,
-                unfocusedContainerColor = SearchBarDefaults.colors().containerColor,
-                disabledContainerColor = SearchBarDefaults.colors().containerColor,
-                focusedIndicatorColor = Color.Transparent,
-                unfocusedIndicatorColor = Color.Transparent,
-                disabledIndicatorColor = Color.Transparent,
-            ),
-        )
-    }
+            }
+        } else {
+            null
+        },
+        colors = TextFieldDefaults.colors(
+            focusedContainerColor = SearchBarDefaults.colors().containerColor,
+            unfocusedContainerColor = SearchBarDefaults.colors().containerColor,
+            disabledContainerColor = SearchBarDefaults.colors().containerColor,
+            focusedIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent,
+            disabledIndicatorColor = Color.Transparent,
+        ),
+    )
 }
 
 @Preview

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchInput.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchInput.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.common_clear
 import musicassistantclient.composeapp.generated.resources.search_query_label
@@ -76,7 +77,7 @@ fun SearchInput(
                 onSearch = {
                     onSearch()
                     focusManager.clearFocus()
-                }
+                },
             ),
             textStyle = textStyle,
             trailingIcon = if (query.isNotEmpty()) {
@@ -106,4 +107,16 @@ fun SearchInput(
             ),
         )
     }
+}
+
+@Preview
+@Composable
+fun SearchInputPreview() {
+    SearchInput(query = "A query for something")
+}
+
+@Preview
+@Composable
+fun SearchInputEmptyPreview() {
+    SearchInput(query = "")
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchInput.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchInput.kt
@@ -1,16 +1,15 @@
 package io.music_assistant.client.ui.compose.search
 
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
-import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SearchBarDefaults
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -19,19 +18,16 @@ import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.text.input.ImeAction
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.common_clear
-import musicassistantclient.composeapp.generated.resources.search_query_label
-import musicassistantclient.composeapp.generated.resources.search_title
 import org.jetbrains.compose.resources.stringResource
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SearchInput(
-    modifier: Modifier = Modifier,
+    placeHolder: String,
     query: String,
-    onQueryChanged: (String) -> Unit,
-    onSearchTriggered: () -> Unit,
+    onSearch: (String) -> Unit,
     focusManager: FocusManager = LocalFocusManager.current,
 ) {
     val focusRequester = remember { FocusRequester() }
@@ -41,47 +37,37 @@ fun SearchInput(
         }
     }
 
-    OutlinedTextField(
-        modifier = modifier
-            .fillMaxWidth()
-            .focusRequester(focusRequester),
-        value = query,
-        onValueChange = onQueryChanged,
-        maxLines = 1,
-        label = { Text(stringResource(Res.string.search_query_label)) },
-        trailingIcon = {
-            Row {
-                if (query.isNotEmpty()) {
-                    IconButton(
-                        onClick = {
-                            onQueryChanged("")
-                            onSearchTriggered()
-                        },
-                    ) {
+    Surface(
+        shape = SearchBarDefaults.inputFieldShape,
+        color = SearchBarDefaults.colors().containerColor,
+        contentColor = contentColorFor(SearchBarDefaults.colors().containerColor),
+        tonalElevation = SearchBarDefaults.TonalElevation,
+        shadowElevation = SearchBarDefaults.ShadowElevation,
+    ) {
+        SearchBarDefaults.InputField(
+            modifier = Modifier.focusRequester(focusRequester),
+            state = TextFieldState(initialText = query),
+            onSearch = {
+                onSearch(it)
+                focusManager.clearFocus()
+            },
+            expanded = false,
+            onExpandedChange = {},
+            placeholder = {
+                Text(placeHolder)
+            },
+            trailingIcon = if (query.isNotEmpty()) {
+                {
+                    IconButton(onClick = { onSearch("") }) {
                         Icon(
                             Icons.Default.Clear,
                             contentDescription = stringResource(Res.string.common_clear),
                         )
                     }
                 }
-                IconButton(
-                    onClick = {
-                        focusManager.clearFocus()
-                        onSearchTriggered()
-                    },
-                    enabled = query.isNotBlank(),
-                ) {
-                    Icon(
-                        Icons.Default.Search,
-                        contentDescription = stringResource(Res.string.search_title),
-                    )
-                }
-            }
-        },
-        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-        keyboardActions = KeyboardActions(onSearch = {
-            focusManager.clearFocus()
-            onSearchTriggered()
-        }),
-    )
+            } else {
+                null
+            },
+        )
+    }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchInput.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchInput.kt
@@ -1,14 +1,20 @@
 package io.music_assistant.client.ui.compose.search
 
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -17,7 +23,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.input.ImeAction
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.common_clear
 import musicassistantclient.composeapp.generated.resources.search_query_label
@@ -47,19 +55,30 @@ fun SearchInput(
         tonalElevation = SearchBarDefaults.TonalElevation,
         shadowElevation = SearchBarDefaults.ShadowElevation,
     ) {
-        SearchBarDefaults.InputField(
-            modifier = Modifier.focusRequester(focusRequester),
-            query = query,
-            onQueryChange = onQueryChanged,
-            onSearch = {
-                onSearch()
-                focusManager.clearFocus()
-            },
-            expanded = false,
-            onExpandedChange = {},
+        val textStyle = MaterialTheme.typography.bodyLarge
+
+        TextField(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(SearchBarDefaults.InputFieldHeight)
+                .focusRequester(focusRequester),
+            value = query,
+            onValueChange = onQueryChanged,
             placeholder = {
-                Text(stringResource(Res.string.search_query_label))
+                Text(
+                    stringResource(Res.string.search_query_label),
+                    style = textStyle,
+                )
             },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+            keyboardActions = KeyboardActions(
+                onSearch = {
+                    onSearch()
+                    focusManager.clearFocus()
+                }
+            ),
+            textStyle = textStyle,
             trailingIcon = if (query.isNotEmpty()) {
                 {
                     IconButton(
@@ -77,6 +96,14 @@ fun SearchInput(
             } else {
                 null
             },
+            colors = TextFieldDefaults.colors(
+                focusedContainerColor = SearchBarDefaults.colors().containerColor,
+                unfocusedContainerColor = SearchBarDefaults.colors().containerColor,
+                disabledContainerColor = SearchBarDefaults.colors().containerColor,
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
+                disabledIndicatorColor = Color.Transparent,
+            ),
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchInput.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchInput.kt
@@ -50,7 +50,7 @@ fun SearchInput(
         shadowElevation = SearchBarDefaults.ShadowElevation,
     ) {
         SearchBarDefaults.InputField(
-            modifier = modifier.focusRequester(focusRequester),
+            modifier = Modifier.focusRequester(focusRequester),
             state = textFieldState,
             onSearch = {
                 onSearch(it)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchInput.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchInput.kt
@@ -1,6 +1,7 @@
 package io.music_assistant.client.ui.compose.search
 
-import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.clearText
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -26,13 +27,14 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun SearchInput(
     placeHolder: String,
-    query: String,
     onSearch: (String) -> Unit,
     focusManager: FocusManager = LocalFocusManager.current,
 ) {
+    val textFieldState = rememberTextFieldState()
+
     val focusRequester = remember { FocusRequester() }
     LaunchedEffect(Unit) {
-        if (query.isEmpty()) {
+        if (textFieldState.text.isEmpty()) {
             focusRequester.requestFocus()
         }
     }
@@ -46,7 +48,7 @@ fun SearchInput(
     ) {
         SearchBarDefaults.InputField(
             modifier = Modifier.focusRequester(focusRequester),
-            state = TextFieldState(initialText = query),
+            state = textFieldState,
             onSearch = {
                 onSearch(it)
                 focusManager.clearFocus()
@@ -56,9 +58,14 @@ fun SearchInput(
             placeholder = {
                 Text(placeHolder)
             },
-            trailingIcon = if (query.isNotEmpty()) {
+            trailingIcon = if (textFieldState.text.isNotEmpty()) {
                 {
-                    IconButton(onClick = { onSearch("") }) {
+                    IconButton(
+                        onClick = {
+                            textFieldState.clearText()
+                            onSearch("")
+                        },
+                    ) {
                         Icon(
                             Icons.Default.Clear,
                             contentDescription = stringResource(Res.string.common_clear),

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchInput.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchInput.kt
@@ -1,5 +1,6 @@
 package io.music_assistant.client.ui.compose.search
 
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.input.clearText
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
@@ -26,9 +27,10 @@ import org.jetbrains.compose.resources.stringResource
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SearchInput(
-    placeHolder: String,
+    modifier: Modifier = Modifier,
     onSearch: (String) -> Unit,
     focusManager: FocusManager = LocalFocusManager.current,
+    placeHolder: String,
 ) {
     val textFieldState = rememberTextFieldState()
 
@@ -40,6 +42,7 @@ fun SearchInput(
     }
 
     Surface(
+        modifier = modifier.fillMaxWidth(),
         shape = SearchBarDefaults.inputFieldShape,
         color = SearchBarDefaults.colors().containerColor,
         contentColor = contentColorFor(SearchBarDefaults.colors().containerColor),
@@ -47,7 +50,7 @@ fun SearchInput(
         shadowElevation = SearchBarDefaults.ShadowElevation,
     ) {
         SearchBarDefaults.InputField(
-            modifier = Modifier.focusRequester(focusRequester),
+            modifier = modifier.focusRequester(focusRequester),
             state = textFieldState,
             onSearch = {
                 onSearch(it)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchInput.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchInput.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalFocusManager
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.common_clear
+import musicassistantclient.composeapp.generated.resources.search_query_label
 import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -30,7 +31,6 @@ fun SearchInput(
     onQueryChanged: (String) -> Unit = {},
     onSearch: () -> Unit = {},
     focusManager: FocusManager = LocalFocusManager.current,
-    placeHolder: String,
 ) {
     val focusRequester = remember { FocusRequester() }
     LaunchedEffect(Unit) {
@@ -58,7 +58,7 @@ fun SearchInput(
             expanded = false,
             onExpandedChange = {},
             placeholder = {
-                Text(placeHolder)
+                Text(stringResource(Res.string.search_query_label))
             },
             trailingIcon = if (query.isNotEmpty()) {
                 {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
@@ -81,6 +81,7 @@ import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.search_error
 import musicassistantclient.composeapp.generated.resources.search_in_library_only
 import musicassistantclient.composeapp.generated.resources.search_no_results
+import musicassistantclient.composeapp.generated.resources.search_query_label
 import musicassistantclient.composeapp.generated.resources.search_start
 import musicassistantclient.composeapp.generated.resources.search_title
 import org.jetbrains.compose.resources.stringResource
@@ -118,7 +119,6 @@ fun SearchScreen(
             SearchTopBar(
                 searchState.searchState,
                 onQueryChanged = searchViewModel::onQueryChanged,
-                onSearchTriggered = searchViewModel::onSearchTriggered,
                 onMediaTypeToggled = searchViewModel::onMediaTypeToggled,
                 onLibraryOnlyToggled = searchViewModel::onLibraryOnlyToggled,
             )
@@ -164,7 +164,6 @@ fun SearchScreen(
 private fun SearchTopBar(
     searchState: SearchViewModel.SearchState,
     onQueryChanged: (String) -> Unit,
-    onSearchTriggered: () -> Unit,
     onMediaTypeToggled: (MediaType, Boolean) -> Unit,
     onLibraryOnlyToggled: (Boolean) -> Unit,
 ) {
@@ -178,17 +177,15 @@ private fun SearchTopBar(
                         .wrapContentHeight(Alignment.CenterVertically),
                     text = stringResource(Res.string.search_title),
                 )
-                val modifier = Modifier.padding(end = 16.dp)
+
                 SearchInput(
-                    modifier = modifier,
+                    placeHolder = stringResource(Res.string.search_query_label),
                     query = searchState.query,
-                    onQueryChanged = onQueryChanged,
-                    onSearchTriggered = onSearchTriggered,
+                    onSearch = onQueryChanged,
                 )
 
                 // Search filters (always visible)
                 SearchFilters(
-                    modifier = modifier,
                     searchState = searchState,
                     onMediaTypeToggled = onMediaTypeToggled,
                     onLibraryOnlyToggled = onLibraryOnlyToggled,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
@@ -33,6 +33,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -416,9 +418,14 @@ private fun SearchFilters(
                         )
                     },
                     label = {
+                        val text = stringResource(mediaTypeSelect.type.stringResource())
+
                         Text(
-                            text = stringResource(mediaTypeSelect.type.stringResource()),
+                            text = text,
                             style = MaterialTheme.typography.bodySmall,
+                            modifier = Modifier.semantics {
+                                contentDescription = "Filter $text"
+                            },
                         )
                     },
                 )

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -83,7 +82,6 @@ import musicassistantclient.composeapp.generated.resources.search_in_library_onl
 import musicassistantclient.composeapp.generated.resources.search_no_results
 import musicassistantclient.composeapp.generated.resources.search_query_label
 import musicassistantclient.composeapp.generated.resources.search_start
-import musicassistantclient.composeapp.generated.resources.search_title
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -169,15 +167,7 @@ private fun SearchTopBar(
 ) {
     TopAppBar(
         title = {
-            Column(modifier = Modifier.padding(vertical = 4.dp)) {
-                Text(
-                    modifier = Modifier
-                        .height(56.dp)
-                        .fillMaxWidth()
-                        .wrapContentHeight(Alignment.CenterVertically),
-                    text = stringResource(Res.string.search_title),
-                )
-
+            Column {
                 SearchInput(
                     placeHolder = stringResource(Res.string.search_query_label),
                     onSearch = onQueryChanged,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
@@ -82,7 +82,6 @@ import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.search_error
 import musicassistantclient.composeapp.generated.resources.search_in_library_only
 import musicassistantclient.composeapp.generated.resources.search_no_results
-import musicassistantclient.composeapp.generated.resources.search_query_label
 import musicassistantclient.composeapp.generated.resources.search_start
 import org.jetbrains.compose.resources.stringResource
 
@@ -176,7 +175,6 @@ private fun SearchTopBar(
                 query = searchState.query,
                 onQueryChanged = onQueryChanged,
                 onSearch = onSearch,
-                placeHolder = stringResource(Res.string.search_query_label),
             )
         },
         secondRow = {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
@@ -119,6 +119,7 @@ fun SearchScreen(
             SearchTopBar(
                 searchState.searchState,
                 onQueryChanged = searchViewModel::onQueryChanged,
+                onSearch = searchViewModel::onSearch,
                 onMediaTypeToggled = searchViewModel::onMediaTypeToggled,
                 onLibraryOnlyToggled = searchViewModel::onLibraryOnlyToggled,
             )
@@ -164,6 +165,7 @@ fun SearchScreen(
 private fun SearchTopBar(
     searchState: SearchViewModel.SearchState,
     onQueryChanged: (String) -> Unit,
+    onSearch: () -> Unit,
     onMediaTypeToggled: (MediaType, Boolean) -> Unit,
     onLibraryOnlyToggled: (Boolean) -> Unit,
 ) {
@@ -171,7 +173,9 @@ private fun SearchTopBar(
         title = {
             SearchInput(
                 modifier = Modifier.padding(end = 16.dp),
-                onSearch = onQueryChanged,
+                query = searchState.query,
+                onQueryChanged = onQueryChanged,
+                onSearch = onSearch,
                 placeHolder = stringResource(Res.string.search_query_label),
             )
         },

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
@@ -180,7 +180,6 @@ private fun SearchTopBar(
 
                 SearchInput(
                     placeHolder = stringResource(Res.string.search_query_label),
-                    query = searchState.query,
                     onSearch = onQueryChanged,
                 )
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarState
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
@@ -74,6 +73,7 @@ import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.nav.ScreenState
 import io.music_assistant.client.ui.compose.nav.TopBarLayout
+import io.music_assistant.client.ui.compose.nav.TwoRowTopAppBar
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import musicassistantclient.composeapp.generated.resources.Res
@@ -165,21 +165,21 @@ private fun SearchTopBar(
     onMediaTypeToggled: (MediaType, Boolean) -> Unit,
     onLibraryOnlyToggled: (Boolean) -> Unit,
 ) {
-    TopAppBar(
+    TwoRowTopAppBar(
         title = {
-            Column {
-                SearchInput(
-                    placeHolder = stringResource(Res.string.search_query_label),
-                    onSearch = onQueryChanged,
-                )
-
-                // Search filters (always visible)
-                SearchFilters(
-                    searchState = searchState,
-                    onMediaTypeToggled = onMediaTypeToggled,
-                    onLibraryOnlyToggled = onLibraryOnlyToggled,
-                )
-            }
+            SearchInput(
+                modifier = Modifier.padding(end = 16.dp),
+                onSearch = onQueryChanged,
+                placeHolder = stringResource(Res.string.search_query_label),
+            )
+        },
+        secondRow = {
+            SearchFilters(
+                modifier = Modifier.padding(end = 16.dp),
+                searchState = searchState,
+                onMediaTypeToggled = onMediaTypeToggled,
+                onLibraryOnlyToggled = onLibraryOnlyToggled,
+            )
         },
     )
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchViewModel.kt
@@ -127,6 +127,9 @@ class SearchViewModel(
 
     fun onQueryChanged(query: String) {
         _state.update { it.copy(searchState = it.searchState.copy(query = query)) }
+    }
+
+    fun onSearch() {
         searchTrigger.tryEmit(Unit)
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/search/SearchViewModel.kt
@@ -127,9 +127,6 @@ class SearchViewModel(
 
     fun onQueryChanged(query: String) {
         _state.update { it.copy(searchState = it.searchState.copy(query = query)) }
-    }
-
-    fun onSearchTriggered() {
         searchTrigger.tryEmit(Unit)
     }
 


### PR DESCRIPTION
Work towards #775

## Is there anything about the code changes here that should be highlighted?

We're now using the same component in both places which just meant adapting the `ViewModel`s slightly used in Library/Search so they work with the `SearchInputs` input/output structure. 

## Are there any additional changes not related to the issue above?

I've also made `SearchInput` use a (mostly) customized `TextField` as opposed to the Material search default one. This gives us way more control over shape and size and allowed me to use slightly smaller text and drop the height to make the whole thing look less "bulbous".

I've also backfilled some tests for things I didn't want to break (or did break) while making these changes.

## Before submitting this PR, make sure you have:
- [x] Given this PR a readable name that can be used in the app's changelog
- [x] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

