### PR TITLE
Tolerate missing legacy stream DSP

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerQueueItem.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerQueueItem.kt
@@ -34,7 +34,7 @@ data class StreamDetails(
 //    @SerialName("target_loudness") val targetLoudness: Double,
 //    @SerialName("strip_silence_begin") val stripSilenceBegin: Boolean,
 //    @SerialName("strip_silence_end") val stripSilenceEnd: Boolean,
-    @SerialName("dsp") val dsp: Map<String, DSPSettings>,
+    @SerialName("dsp") val dsp: Map<String, DSPSettings> = emptyMap(),
 )
 
 @Serializable

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/ServerQueueItemSerializationTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/ServerQueueItemSerializationTest.kt
@@ -1,0 +1,65 @@
+package io.music_assistant.client.data.model.server
+
+import io.music_assistant.client.utils.myJson
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class ServerQueueItemSerializationTest {
+    @Test
+    fun deserializesStreamDetailsWithoutLegacyDsp() {
+        val json = """
+            {
+              "queue_item_id": "queue-item-1",
+              "streamdetails": {
+                "provider": "library",
+                "audio_format": {
+                  "content_type": "audio/flac",
+                  "sample_rate": 44100
+                }
+              }
+            }
+        """.trimIndent()
+
+        val queueItem = myJson.decodeFromString<ServerQueueItem>(json)
+        val streamDetails = assertNotNull(queueItem.streamDetails)
+
+        assertEquals("library", streamDetails.provider)
+        assertEquals("audio/flac", streamDetails.audioFormat.contentType)
+        assertEquals(44_100, streamDetails.audioFormat.sampleRate)
+        assertEquals(emptyMap(), streamDetails.dsp)
+    }
+
+    @Test
+    fun deserializesStreamDetailsWithLegacyDsp() {
+        val json = """
+            {
+              "queue_item_id": "queue-item-1",
+              "streamdetails": {
+                "audio_format": {
+                  "content_type": "audio/flac"
+                },
+                "dsp": {
+                  "player-1": {
+                    "output_format": {
+                      "content_type": "audio/pcm_s16le",
+                      "sample_rate": 48000,
+                      "bit_depth": 16,
+                      "channels": 2
+                    }
+                  }
+                }
+              }
+            }
+        """.trimIndent()
+
+        val queueItem = myJson.decodeFromString<ServerQueueItem>(json)
+        val streamDetails = assertNotNull(queueItem.streamDetails)
+        val outputFormat = assertNotNull(streamDetails.dsp["player-1"]?.outputFormat)
+
+        assertEquals("audio/pcm_s16le", outputFormat.contentType)
+        assertEquals(48_000, outputFormat.sampleRate)
+        assertEquals(16, outputFormat.bitDepth)
+        assertEquals(2, outputFormat.channels)
+    }
+}


### PR DESCRIPTION
Queue stream details will stop including the legacy top-level DSP map.

- Accept payloads where `dsp` is omitted
- Preserve decoding of legacy per-player DSP payloads