### PR TITLE
Skip chore-labeled PRs in release changelogs

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,7 @@
+# Configures GitHub's auto-generated release notes (the
+# `generate_release_notes: true` step in the release workflows).
+# PRs labeled 'chore' are housekeeping and stay out of user-facing notes.
+changelog:
+  exclude:
+    labels:
+      - chore

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -73,11 +73,28 @@ jobs:
         run: ./gradlew :androidApp:bundleRelease
 
       - name: Generate Play Store release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p distribution/whatsnew
           PREV_TAG=$(git tag -l 'android-v*' --sort=-v:refname | head -1)
           if [ -n "$PREV_TAG" ]; then
-            NOTES=$(git log --first-parent --pretty=format:"- %s" "$PREV_TAG"..HEAD -- . ':!.github')
+            RAW=$(git log --first-parent --pretty=format:"- %s" "$PREV_TAG"..HEAD -- . ':!.github')
+            # Drop entries whose PR carries the 'chore' label. Each first-parent
+            # subject names its PR ("Merge pull request #N" / squash "title (#N)");
+            # entries without a PR number (direct pushes) are kept.
+            NOTES=""
+            while IFS= read -r LINE; do
+              [ -z "$LINE" ] && continue
+              PR=$(printf '%s' "$LINE" | grep -oE '#[0-9]+' | head -1 | tr -d '#' || true)
+              if [ -n "$PR" ]; then
+                if gh pr view "$PR" --json labels --jq '.labels[].name' 2>/dev/null | grep -qx 'chore'; then
+                  echo "Skipping chore PR #$PR: $LINE"
+                  continue
+                fi
+              fi
+              NOTES="${NOTES}${LINE}"$'\n'
+            done <<< "$RAW"
           else
             NOTES="Initial release"
           fi
@@ -223,5 +240,5 @@ jobs:
               core.info(`Created PR #${prNumber}`);
             }
             await github.rest.issues.addLabels({
-              owner, repo, issue_number: prNumber, labels: ['automated'],
+              owner, repo, issue_number: prNumber, labels: ['automated', 'chore'],
             });

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -257,7 +257,7 @@ jobs:
               core.info(`Created PR #${prNumber}`);
             }
             await github.rest.issues.addLabels({
-              owner, repo, issue_number: prNumber, labels: ['automated'],
+              owner, repo, issue_number: prNumber, labels: ['automated', 'chore'],
             });
 
       - name: Summary


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

Two changelog surfaces, one rule:

- Play Store whatsnew: the Android release-notes step now looks up each first-parent subject's PR labels via gh and drops entries whose PR is labeled 'chore'. Entries without a PR number (direct pushes) and PRs whose lookup fails are kept.
- GitHub Releases: .github/release.yml excludes 'chore' from the auto-generated notes (both Android and iOS releases use the same generate_release_notes mechanism).

Both release workflows' automated post-release version-bump PRs now carry the chore label so the filters exclude them; the iOS bump matters for the Android changelog too, since its merge commits sit on main's first-parent line inside the whatsnew range.

Verified locally against the android-v0.7.0..HEAD range: the chore-labeled #796 is dropped, all other entries survive.

## Are there any additional changes not related to the issue above?

I am checking the box below ironically.

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [ ] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

