### PR TITLE
Add tests for audio chain

### DIFF
--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/AudioChainTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/AudioChainTest.kt
@@ -5,6 +5,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.music_assistant.client.api.ServiceClient
 import io.music_assistant.client.data.model.server.AudioFormat
 import io.music_assistant.client.support.FakeServiceClient
+import io.music_assistant.client.support.FakeServiceClient.LegacyVersion
 import io.music_assistant.client.support.Qualifiers
 import io.music_assistant.client.support.ServerMediaItemFixtures
 import io.music_assistant.client.support.ServerPlayerFixtures
@@ -29,7 +30,31 @@ class AudioChainTest {
     private val serviceClient: FakeServiceClient by inject(ServiceClient::class.java)
 
     @Test
-    fun `can view output format for current queue item`() {
+    fun `does not crash`() {
+        val album = ServerMediaItemFixtures.album()
+        val track = ServerMediaItemFixtures.track(album = album)
+        serviceClient.addToLibrary(track)
+
+        val audioFormat = AudioFormat(
+            contentType = "s16le",
+            sampleRate = 48000,
+            bitDepth = 16,
+        )
+
+        val player = ServerPlayerFixtures.player()
+        serviceClient.addPlayers(player)
+        serviceClient.setPlayerAudioFormat(player, audioFormat)
+
+        launchLoggedInApp(composeTestRule, serviceClient)
+            .clickOnMedia(album)
+            .clickPlay()
+            .expandPlayer(player.displayName, playing = true, item = track.name)
+    }
+
+    @Test
+    fun `can view output format for current queue item in legacy versions`() {
+        serviceClient.setLegacyVersion(LegacyVersion.V2_9)
+
         val album = ServerMediaItemFixtures.album()
         val track = ServerMediaItemFixtures.track(album = album)
         serviceClient.addToLibrary(track)

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/AudioChainTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/AudioChainTest.kt
@@ -1,0 +1,54 @@
+package io.music_assistant.client.feature
+
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.music_assistant.client.api.ServiceClient
+import io.music_assistant.client.data.model.server.AudioFormat
+import io.music_assistant.client.support.FakeServiceClient
+import io.music_assistant.client.support.Qualifiers
+import io.music_assistant.client.support.ServerMediaItemFixtures
+import io.music_assistant.client.support.ServerPlayerFixtures
+import io.music_assistant.client.support.launchLoggedInApp
+import io.music_assistant.client.support.pages.expandPlayer
+import io.music_assistant.client.support.rules.createTestRuleChain
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.java.KoinJavaComponent.inject
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(qualifiers = Qualifiers.MEDIUM_PHONE)
+class AudioChainTest {
+    @get:Rule
+    val testRuleChain = createTestRuleChain()
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val serviceClient: FakeServiceClient by inject(ServiceClient::class.java)
+
+    @Test
+    fun `can view output format for current queue item`() {
+        val album = ServerMediaItemFixtures.album()
+        val track = ServerMediaItemFixtures.track(album = album)
+        serviceClient.addToLibrary(track)
+
+        val audioFormat = AudioFormat(
+            contentType = "s16le",
+            sampleRate = 48000,
+            bitDepth = 16,
+        )
+
+        val player = ServerPlayerFixtures.player()
+        serviceClient.addPlayers(player)
+        serviceClient.setPlayerAudioFormat(player, audioFormat)
+
+        launchLoggedInApp(composeTestRule, serviceClient)
+            .clickOnMedia(album)
+            .clickPlay()
+            .expandPlayer(player.displayName, playing = true, item = track.name)
+            .clickQualityTier("HQ")
+            .assertFormatDisplayed(audioFormat)
+    }
+}

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -582,9 +582,13 @@ class FakeServiceClient : ServiceClient {
         val queueIndex = queues.indexOfFirst { it.queueId == queueId }
         val player = findPlayer { it.activeSource == queueId }.second
 
-        val dsp = mapOf(
-            player.playerId to DSPSettings(outputFormat = playerAudioFormats[player.playerId]),
-        )
+        val dsp = legacyVersion.let {
+            if (it != null && it <= LegacyVersion.V2_9) {
+                mapOf(player.playerId to DSPSettings(outputFormat = playerAudioFormats[player.playerId]))
+            } else {
+                null
+            }
+        }
 
         val firstItem = items.firstOrNull()
         val currentItem = firstItem?.copy(
@@ -934,6 +938,7 @@ class FakeServiceClient : ServiceClient {
 
     enum class LegacyVersion {
         V2_8,
+        V2_9
     }
 }
 

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -938,7 +938,7 @@ class FakeServiceClient : ServiceClient {
 
     enum class LegacyVersion {
         V2_8,
-        V2_9
+        V2_9,
     }
 }
 

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -6,7 +6,9 @@ import io.music_assistant.client.api.ConnectionInfo
 import io.music_assistant.client.api.Request
 import io.music_assistant.client.api.ServiceClient
 import io.music_assistant.client.data.model.client.MediaType
+import io.music_assistant.client.data.model.server.AudioFormat
 import io.music_assistant.client.data.model.server.AuthProvider
+import io.music_assistant.client.data.model.server.DSPSettings
 import io.music_assistant.client.data.model.server.EventType
 import io.music_assistant.client.data.model.server.PlayerState
 import io.music_assistant.client.data.model.server.ProviderManifest
@@ -19,6 +21,7 @@ import io.music_assistant.client.data.model.server.ServerQueue
 import io.music_assistant.client.data.model.server.ServerQueueItem
 import io.music_assistant.client.data.model.server.ServerUser
 import io.music_assistant.client.data.model.server.ServerUserPreferences
+import io.music_assistant.client.data.model.server.StreamDetails
 import io.music_assistant.client.data.model.server.User
 import io.music_assistant.client.data.model.server.events.Event
 import io.music_assistant.client.data.model.server.events.PlayerUpdatedEvent
@@ -54,6 +57,7 @@ class FakeServiceClient : ServiceClient {
     private val uniqueIdGenerator = UniqueIdGenerator()
 
     private val players = mutableListOf<ServerPlayer>()
+    private val playerAudioFormats = mutableMapOf<String, AudioFormat>()
     private val queues = mutableListOf<ServerQueue>()
     private val queueItems = mutableMapOf<String, List<ServerQueueItem>>()
     private val items = mutableSetOf<ServerMediaItem>()
@@ -576,8 +580,22 @@ class FakeServiceClient : ServiceClient {
         items: List<ServerQueueItem>,
     ) {
         val queueIndex = queues.indexOfFirst { it.queueId == queueId }
+        val player = findPlayer { it.activeSource == queueId }.second
 
-        val currentItem = items.firstOrNull()
+        val dsp = mapOf(
+            player.playerId to DSPSettings(outputFormat = playerAudioFormats[player.playerId]),
+        )
+
+        val firstItem = items.firstOrNull()
+        val currentItem = firstItem?.copy(
+            streamDetails = firstItem.streamDetails.let { streamDetails ->
+                streamDetails?.copy(dsp = dsp) ?: StreamDetails(
+                    audioFormat = AudioFormat(),
+                    dsp = dsp,
+                )
+            },
+        ) ?: firstItem
+
         queues[queueIndex] =
             queues[queueIndex].copy(currentItem = currentItem)
         queueItems[queueId] = items
@@ -604,16 +622,22 @@ class FakeServiceClient : ServiceClient {
         search: (ServerPlayer) -> Boolean,
         update: (ServerPlayer) -> ServerPlayer,
     ) {
-        val playerIndex = players.indexOfFirst(search)
-        val player = update(players[playerIndex])
-        players[playerIndex] = player
+        val (playerIndex, originalPlayer) = findPlayer(search)
+        val updatedPlayer = update(originalPlayer)
+        players[playerIndex] = updatedPlayer
         _events.emit(
             PlayerUpdatedEvent(
                 event = EventType.PLAYER_UPDATED,
-                objectId = player.playerId,
-                data = player,
+                objectId = updatedPlayer.playerId,
+                data = updatedPlayer,
             ),
         )
+    }
+
+    private fun findPlayer(search: (ServerPlayer) -> Boolean): Pair<Int, ServerPlayer> {
+        val playerIndex = players.indexOfFirst(search)
+        val originalPlayer = players[playerIndex]
+        return Pair(playerIndex, originalPlayer)
     }
 
     override suspend fun login(username: String, password: String) {
@@ -902,6 +926,10 @@ class FakeServiceClient : ServiceClient {
                 items.add(it)
             }
         }
+    }
+
+    fun setPlayerAudioFormat(player: ServerPlayer, audioFormat: AudioFormat) {
+        playerAudioFormats[player.playerId] = audioFormat
     }
 
     enum class LegacyVersion {

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/AudioChainPage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/AudioChainPage.kt
@@ -1,0 +1,21 @@
+package io.music_assistant.client.support.pages
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onNodeWithText
+import io.music_assistant.client.data.model.client.items.description
+import io.music_assistant.client.data.model.server.AudioFormat
+import io.music_assistant.client.support.get
+import musicassistantclient.composeapp.generated.resources.Res
+import musicassistantclient.composeapp.generated.resources.quality_dialog_title
+
+class AudioChainPage(composeTestRule: ComposeTestRule) : ComposePage(composeTestRule) {
+    override fun assert() {
+        composeTestRule.onNodeWithText(Res.string.quality_dialog_title.get()).assertIsDisplayed()
+    }
+
+    fun assertFormatDisplayed(audioFormat: AudioFormat): AudioChainPage {
+        composeTestRule.onNodeWithText(audioFormat.description).assertIsDisplayed()
+        return this
+    }
+}

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ExpandedPlayerPage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ExpandedPlayerPage.kt
@@ -94,4 +94,9 @@ class ExpandedPlayerPage(
 
         return this
     }
+
+    fun clickQualityTier(tier: String): AudioChainPage {
+        composeTestRule.onNodeWithText(tier).performClick()
+        return AudioChainPage(composeTestRule).assertOnPage()
+    }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerQueueItem.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerQueueItem.kt
@@ -34,7 +34,7 @@ data class StreamDetails(
 //    @SerialName("target_loudness") val targetLoudness: Double,
 //    @SerialName("strip_silence_begin") val stripSilenceBegin: Boolean,
 //    @SerialName("strip_silence_end") val stripSilenceEnd: Boolean,
-    @SerialName("dsp") val dsp: Map<String, DSPSettings> = emptyMap(),
+    @SerialName("dsp") val dsp: Map<String, DSPSettings>? = null,
 )
 
 @Serializable

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/ServerQueueItemSerializationTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/ServerQueueItemSerializationTest.kt
@@ -6,7 +6,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 class ServerQueueItemSerializationTest {
-
     /**
      * Required to support server v2.9 and 2.10
      */

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/ServerQueueItemSerializationTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/ServerQueueItemSerializationTest.kt
@@ -27,7 +27,7 @@ class ServerQueueItemSerializationTest {
         assertEquals("library", streamDetails.provider)
         assertEquals("audio/flac", streamDetails.audioFormat.contentType)
         assertEquals(44_100, streamDetails.audioFormat.sampleRate)
-        assertEquals(emptyMap(), streamDetails.dsp)
+        assertEquals(null, streamDetails.dsp)
     }
 
     @Test
@@ -55,7 +55,7 @@ class ServerQueueItemSerializationTest {
 
         val queueItem = myJson.decodeFromString<ServerQueueItem>(json)
         val streamDetails = assertNotNull(queueItem.streamDetails)
-        val outputFormat = assertNotNull(streamDetails.dsp["player-1"]?.outputFormat)
+        val outputFormat = assertNotNull(streamDetails.dsp?.get("player-1")?.outputFormat)
 
         assertEquals("audio/pcm_s16le", outputFormat.contentType)
         assertEquals(48_000, outputFormat.sampleRate)

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/ServerQueueItemSerializationTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/ServerQueueItemSerializationTest.kt
@@ -6,8 +6,12 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 class ServerQueueItemSerializationTest {
+
+    /**
+     * Required to support server v2.9 and 2.10
+     */
     @Test
-    fun deserializesStreamDetailsWithoutLegacyDsp() {
+    fun deserializesStreamDetailsWithoutDsp() {
         val json = """
             {
               "queue_item_id": "queue-item-1",
@@ -30,8 +34,11 @@ class ServerQueueItemSerializationTest {
         assertEquals(null, streamDetails.dsp)
     }
 
+    /**
+     * Required to support server v2.9 and 2.10
+     */
     @Test
-    fun deserializesStreamDetailsWithLegacyDsp() {
+    fun deserializesStreamDetailsWithDsp() {
         val json = """
             {
               "queue_item_id": "queue-item-1",


### PR DESCRIPTION
Follow up to https://github.com/music-assistant/mobile-app/pull/789

## Is there anything about the code changes here that should be highlighted?

I'd like to be able to have all the testing against `FakeServiceClient` here, but that results in us having to deal with maintaining different serialization classes (or handwriting JSON) for responses. I think the mix of behavioural tests using our "tolerant" serialization classes and a check for that the latter works with both API version responses is probably the right mix for now.

## Before submitting this PR, make sure you have:
- [x] Given this PR a readable name that can be used in the app's changelog
- [x] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

