### PR TITLE
Backfill artist albums tests

### DIFF
--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/AlbumTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/AlbumTest.kt
@@ -39,7 +39,7 @@ class AlbumTest {
         val track1 = ServerMediaItemFixtures.track(album = album)
         val track2 = ServerMediaItemFixtures.track(album = album)
         val track3 = ServerMediaItemFixtures.track(album = album)
-        serviceClient.addToLibrary(track1, track2, track3)
+        serviceClient.addItems(track1, track2, track3)
 
         val player = ServerPlayerFixtures.player()
         serviceClient.addPlayers(player)
@@ -57,7 +57,7 @@ class AlbumTest {
         val track1 = ServerMediaItemFixtures.track(album = album)
         val track2 = ServerMediaItemFixtures.track(album = album)
         val track3 = ServerMediaItemFixtures.track(album = album)
-        serviceClient.addToLibrary(track1, track2, track3)
+        serviceClient.addItems(track1, track2, track3)
 
         val player = ServerPlayerFixtures.player()
         serviceClient.addPlayers(player)

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
@@ -8,6 +8,7 @@ import io.music_assistant.client.support.FakeServiceClient
 import io.music_assistant.client.support.Qualifiers
 import io.music_assistant.client.support.ServerMediaItemFixtures
 import io.music_assistant.client.support.launchLoggedInApp
+import io.music_assistant.client.support.pages.assertMediaNotDisplayed
 import io.music_assistant.client.support.rules.createTestRuleChain
 import io.music_assistant.client.ui.compose.home.HomeScreenSemantics
 import org.junit.Rule
@@ -51,5 +52,28 @@ class ArtistTest {
             .assertMediaDisplayed(libraryAlbum, provider = ServerMediaItem.LIBRARY_PROVIDER)
             .assertMediaDisplayed(libraryAlbum)
             .assertMediaDisplayed(nonLibraryAlbum)
+    }
+
+    /**
+     * This is not the ideal behavior - we should show albums from all providers in someway. This
+     * will be fixed by https://github.com/music-assistant/mobile-app/issues/801.
+     */
+    @Test
+    fun `shows albums for one provider when artists are matched across providers`() {
+        val provider1 = ServerMediaItemFixtures.provider(domain = "domain1", instance = "instance1")
+        val provider2 = ServerMediaItemFixtures.provider(domain = "domain2", instance = "instance2")
+        val artist1 = ServerMediaItemFixtures.artist(provider = provider1)
+        val artist2 = ServerMediaItemFixtures.artist(provider = provider2)
+        val album1 = ServerMediaItemFixtures.album(artist = artist1, provider = provider1)
+        val album2 = ServerMediaItemFixtures.album(artist = artist2, provider = provider2)
+
+        serviceClient.addItems(album1, album2)
+        serviceClient.addToLibrary(artist1)
+        serviceClient.matchItem(artist1, artist2)
+
+        launchLoggedInApp(composeTestRule, serviceClient)
+            .clickOnMedia(artist1, withinTag = HomeScreenSemantics.rowTag("recently_added_artists"))
+            .assertMediaDisplayed(album1, provider = provider1.first)
+            .assertMediaNotDisplayed(album2, provider = provider2.first)
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
@@ -1,0 +1,41 @@
+package io.music_assistant.client.feature
+
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.music_assistant.client.api.ServiceClient
+import io.music_assistant.client.support.FakeServiceClient
+import io.music_assistant.client.support.Qualifiers
+import io.music_assistant.client.support.ServerMediaItemFixtures
+import io.music_assistant.client.support.launchLoggedInApp
+import io.music_assistant.client.support.pages.assertMediaDisplayed
+import io.music_assistant.client.support.rules.createTestRuleChain
+import io.music_assistant.client.ui.compose.home.HomeScreenSemantics
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.java.KoinJavaComponent.inject
+import org.robolectric.annotation.Config
+import kotlin.getValue
+
+@RunWith(AndroidJUnit4::class)
+@Config(qualifiers = Qualifiers.MEDIUM_PHONE)
+class ArtistTest {
+    @get:Rule
+    val testRuleChain = createTestRuleChain()
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val serviceClient: FakeServiceClient by inject(ServiceClient::class.java)
+
+    @Test
+    fun `show artist albums`() {
+        val artist = ServerMediaItemFixtures.artist()
+        val album = ServerMediaItemFixtures.album(artist = artist)
+        serviceClient.addItems(album)
+
+        launchLoggedInApp(composeTestRule, serviceClient)
+            .clickOnMedia(artist, withinTag = HomeScreenSemantics.rowTag("recently_added_artists"))
+            .assertMediaDisplayed(album)
+    }
+}

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
@@ -3,6 +3,7 @@ package io.music_assistant.client.feature
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.music_assistant.client.api.ServiceClient
+import io.music_assistant.client.data.model.server.ServerMediaItem
 import io.music_assistant.client.support.FakeServiceClient
 import io.music_assistant.client.support.Qualifiers
 import io.music_assistant.client.support.ServerMediaItemFixtures
@@ -47,6 +48,7 @@ class ArtistTest {
 
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickOnMedia(artist, withinTag = HomeScreenSemantics.rowTag("recently_added_artists"))
+            .assertMediaDisplayed(libraryAlbum, provider = ServerMediaItem.LIBRARY_PROVIDER)
             .assertMediaDisplayed(libraryAlbum)
             .assertMediaDisplayed(nonLibraryAlbum)
     }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
@@ -7,7 +7,6 @@ import io.music_assistant.client.support.FakeServiceClient
 import io.music_assistant.client.support.Qualifiers
 import io.music_assistant.client.support.ServerMediaItemFixtures
 import io.music_assistant.client.support.launchLoggedInApp
-import io.music_assistant.client.support.pages.assertMediaDisplayed
 import io.music_assistant.client.support.rules.createTestRuleChain
 import io.music_assistant.client.ui.compose.home.HomeScreenSemantics
 import org.junit.Rule
@@ -15,7 +14,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.koin.java.KoinJavaComponent.inject
 import org.robolectric.annotation.Config
-import kotlin.getValue
 
 @RunWith(AndroidJUnit4::class)
 @Config(qualifiers = Qualifiers.MEDIUM_PHONE)
@@ -37,5 +35,19 @@ class ArtistTest {
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickOnMedia(artist, withinTag = HomeScreenSemantics.rowTag("recently_added_artists"))
             .assertMediaDisplayed(album)
+    }
+
+    @Test
+    fun `shows in library and all artist albums on provider`() {
+        val artist = ServerMediaItemFixtures.artist()
+        val libraryAlbum = ServerMediaItemFixtures.album(artist = artist)
+        val nonLibraryAlbum = ServerMediaItemFixtures.album(artist = artist)
+        serviceClient.addItems(libraryAlbum, nonLibraryAlbum)
+        serviceClient.addToLibrary(libraryAlbum)
+
+        launchLoggedInApp(composeTestRule, serviceClient)
+            .clickOnMedia(artist, withinTag = HomeScreenSemantics.rowTag("recently_added_artists"))
+            .assertMediaDisplayed(libraryAlbum)
+            .assertMediaDisplayed(nonLibraryAlbum)
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/AudioChainTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/AudioChainTest.kt
@@ -33,7 +33,7 @@ class AudioChainTest {
     fun `does not crash`() {
         val album = ServerMediaItemFixtures.album()
         val track = ServerMediaItemFixtures.track(album = album)
-        serviceClient.addToLibrary(track)
+        serviceClient.addItems(track)
 
         val audioFormat = AudioFormat(
             contentType = "s16le",
@@ -57,7 +57,7 @@ class AudioChainTest {
 
         val album = ServerMediaItemFixtures.album()
         val track = ServerMediaItemFixtures.track(album = album)
-        serviceClient.addToLibrary(track)
+        serviceClient.addItems(track)
 
         val audioFormat = AudioFormat(
             contentType = "s16le",

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/HomeTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/HomeTest.kt
@@ -30,13 +30,13 @@ class HomeTest {
     @Test
     fun `can refresh home recommendations`() {
         val album1 = ServerMediaItemFixtures.album()
-        serviceClient.addToLibrary(album1)
+        serviceClient.addItems(album1)
 
         val homePage = launchLoggedInApp(composeTestRule, serviceClient)
             .assertMediaDisplayed(album1.name)
 
         val album2 = ServerMediaItemFixtures.album()
-        serviceClient.addToLibrary(album2)
+        serviceClient.addItems(album2)
 
         homePage.refresh()
             .assertMediaDisplayed(album2.name)
@@ -45,7 +45,7 @@ class HomeTest {
     @Test
     fun `can refresh home shortcuts`() {
         val album = ServerMediaItemFixtures.album()
-        serviceClient.addToLibrary(album)
+        serviceClient.addItems(album)
 
         val homePage = launchLoggedInApp(composeTestRule, serviceClient)
 
@@ -58,7 +58,7 @@ class HomeTest {
     @Test
     fun `shows error if data can't be loaded and can recover with refresh`() {
         val album = ServerMediaItemFixtures.album()
-        serviceClient.addToLibrary(album)
+        serviceClient.addItems(album)
         val homePage = launchLoggedInApp(composeTestRule, serviceClient)
 
         serviceClient.setRequestErrors(true)

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/HomeTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/HomeTest.kt
@@ -33,13 +33,13 @@ class HomeTest {
         serviceClient.addItems(album1)
 
         val homePage = launchLoggedInApp(composeTestRule, serviceClient)
-            .assertMediaDisplayed(album1.name)
+            .assertMediaDisplayed(album1)
 
         val album2 = ServerMediaItemFixtures.album()
         serviceClient.addItems(album2)
 
         homePage.refresh()
-            .assertMediaDisplayed(album2.name)
+            .assertMediaDisplayed(album2)
     }
 
     @Test
@@ -64,10 +64,10 @@ class HomeTest {
         serviceClient.setRequestErrors(true)
         homePage.refresh()
             .assertErrorLoadingData()
-            .assertMediaNotDisplayed(album.name)
+            .assertMediaNotDisplayed(album)
 
         serviceClient.setRequestErrors(false)
         homePage.refresh()
-            .assertMediaDisplayed(album.name)
+            .assertMediaDisplayed(album)
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ItemNavigationTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ItemNavigationTest.kt
@@ -32,7 +32,7 @@ class ItemNavigationTest {
     fun `can navigate from album to artist`() {
         val artist = ServerMediaItemFixtures.artist()
         val album = ServerMediaItemFixtures.album(artist = artist)
-        serviceClient.addToLibrary(album)
+        serviceClient.addItems(album)
 
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickOnMedia(album)
@@ -43,7 +43,7 @@ class ItemNavigationTest {
     fun `can navigate to artist from expanded player`() {
         val artist = ServerMediaItemFixtures.artist()
         val track = ServerMediaItemFixtures.track(artists = listOf(artist))
-        serviceClient.addToLibrary(track)
+        serviceClient.addItems(track)
 
         val player = ServerPlayerFixtures.player()
         serviceClient.addPlayers(player)
@@ -58,7 +58,7 @@ class ItemNavigationTest {
     fun `can navigate to album from expanded player`() {
         val album = ServerMediaItemFixtures.album()
         val track = ServerMediaItemFixtures.track(album = album)
-        serviceClient.addToLibrary(track)
+        serviceClient.addItems(track)
 
         val player = ServerPlayerFixtures.player()
         serviceClient.addPlayers(player)

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/LibraryTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/LibraryTest.kt
@@ -47,8 +47,8 @@ class LibraryTest {
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickLibrary()
             .clickAlbums()
-            .assertMediaDisplayed(album1.name)
-            .assertMediaDisplayed(album2.name)
+            .assertMediaDisplayed(album1)
+            .assertMediaDisplayed(album2)
     }
 
     @Test
@@ -61,8 +61,8 @@ class LibraryTest {
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickLibrary()
             .clickArtists()
-            .assertMediaDisplayed(artist1.name)
-            .assertMediaDisplayed(artist2.name)
+            .assertMediaDisplayed(artist1)
+            .assertMediaDisplayed(artist2)
     }
 
     @Test
@@ -75,8 +75,8 @@ class LibraryTest {
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickLibrary()
             .clickPlaylists()
-            .assertMediaDisplayed(playlist1.name)
-            .assertMediaDisplayed(playlist2.name)
+            .assertMediaDisplayed(playlist1)
+            .assertMediaDisplayed(playlist2)
     }
 
     @Test
@@ -89,8 +89,8 @@ class LibraryTest {
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickLibrary()
             .clickTracks()
-            .assertMediaDisplayed(track1.name)
-            .assertMediaDisplayed(track2.name)
+            .assertMediaDisplayed(track1)
+            .assertMediaDisplayed(track2)
     }
 
     @Test
@@ -103,8 +103,8 @@ class LibraryTest {
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickLibrary()
             .clickAudiobooks()
-            .assertMediaDisplayed(audiobook1.name)
-            .assertMediaDisplayed(audiobook2.name)
+            .assertMediaDisplayed(audiobook1)
+            .assertMediaDisplayed(audiobook2)
     }
 
     @Test
@@ -117,8 +117,8 @@ class LibraryTest {
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickLibrary()
             .clickPodcasts()
-            .assertMediaDisplayed(podcast1.name)
-            .assertMediaDisplayed(podcast2.name)
+            .assertMediaDisplayed(podcast1)
+            .assertMediaDisplayed(podcast2)
     }
 
     @Test
@@ -131,8 +131,8 @@ class LibraryTest {
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickLibrary()
             .clickRadio()
-            .assertMediaDisplayed(radio1.name)
-            .assertMediaDisplayed(radio2.name)
+            .assertMediaDisplayed(radio1)
+            .assertMediaDisplayed(radio2)
     }
 
     @Test
@@ -145,8 +145,8 @@ class LibraryTest {
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickLibrary()
             .clickGenres()
-            .assertMediaDisplayed(genre1.name)
-            .assertMediaDisplayed(genre2.name)
+            .assertMediaDisplayed(genre1)
+            .assertMediaDisplayed(genre2)
     }
 
     @Test
@@ -162,8 +162,8 @@ class LibraryTest {
             .enableFilter {
                 it.enableSwitch(Res.string.filter_favorites.get())
             }
-            .assertMediaNotDisplayed(album1.name)
-            .assertMediaDisplayed(album2.name)
+            .assertMediaNotDisplayed(album1)
+            .assertMediaDisplayed(album2)
     }
 
     @Test
@@ -178,8 +178,8 @@ class LibraryTest {
             .clickAlbums()
             .openSearch()
             .search("lobe")
-            .assertMediaDisplayed(album2.name)
-            .assertMediaNotDisplayed(album1.name)
+            .assertMediaDisplayed(album2)
+            .assertMediaNotDisplayed(album1)
     }
 
     @Test

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/LibraryTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/LibraryTest.kt
@@ -41,6 +41,7 @@ class LibraryTest {
     fun `can browse albums`() {
         val album1 = ServerMediaItemFixtures.album()
         val album2 = ServerMediaItemFixtures.album()
+        serviceClient.addItems(album1, album2)
         serviceClient.addToLibrary(album1, album2)
 
         launchLoggedInApp(composeTestRule, serviceClient)
@@ -54,6 +55,7 @@ class LibraryTest {
     fun `can browse artists`() {
         val artist1 = ServerMediaItemFixtures.artist()
         val artist2 = ServerMediaItemFixtures.artist()
+        serviceClient.addItems(artist1, artist2)
         serviceClient.addToLibrary(artist1, artist2)
 
         launchLoggedInApp(composeTestRule, serviceClient)
@@ -67,6 +69,7 @@ class LibraryTest {
     fun `can browse playlists`() {
         val playlist1 = ServerMediaItemFixtures.playlist()
         val playlist2 = ServerMediaItemFixtures.playlist()
+        serviceClient.addItems(playlist1, playlist2)
         serviceClient.addToLibrary(playlist1, playlist2)
 
         launchLoggedInApp(composeTestRule, serviceClient)
@@ -80,6 +83,7 @@ class LibraryTest {
     fun `can browse tracks`() {
         val track1 = ServerMediaItemFixtures.track()
         val track2 = ServerMediaItemFixtures.track()
+        serviceClient.addItems(track1, track2)
         serviceClient.addToLibrary(track1, track2)
 
         launchLoggedInApp(composeTestRule, serviceClient)
@@ -93,6 +97,7 @@ class LibraryTest {
     fun `can browse audiobooks`() {
         val audiobook1 = ServerMediaItemFixtures.audiobook()
         val audiobook2 = ServerMediaItemFixtures.audiobook()
+        serviceClient.addItems(audiobook1, audiobook2)
         serviceClient.addToLibrary(audiobook1, audiobook2)
 
         launchLoggedInApp(composeTestRule, serviceClient)
@@ -106,6 +111,7 @@ class LibraryTest {
     fun `can browse podcasts`() {
         val podcast1 = ServerMediaItemFixtures.podcast()
         val podcast2 = ServerMediaItemFixtures.podcast()
+        serviceClient.addItems(podcast1, podcast2)
         serviceClient.addToLibrary(podcast1, podcast2)
 
         launchLoggedInApp(composeTestRule, serviceClient)
@@ -119,6 +125,7 @@ class LibraryTest {
     fun `can browse radio`() {
         val radio1 = ServerMediaItemFixtures.radio()
         val radio2 = ServerMediaItemFixtures.radio()
+        serviceClient.addItems(radio1, radio2)
         serviceClient.addToLibrary(radio1, radio2)
 
         launchLoggedInApp(composeTestRule, serviceClient)
@@ -132,6 +139,7 @@ class LibraryTest {
     fun `can browse genres`() {
         val genre1 = ServerMediaItemFixtures.genre()
         val genre2 = ServerMediaItemFixtures.genre()
+        serviceClient.addItems(genre1, genre2)
         serviceClient.addToLibrary(genre1, genre2)
 
         launchLoggedInApp(composeTestRule, serviceClient)
@@ -145,6 +153,7 @@ class LibraryTest {
     fun `can filter to only favorites`() {
         val album1 = ServerMediaItemFixtures.album(favorite = false)
         val album2 = ServerMediaItemFixtures.album(favorite = true)
+        serviceClient.addItems(album1, album2)
         serviceClient.addToLibrary(album1, album2)
 
         launchLoggedInApp(composeTestRule, serviceClient)
@@ -161,6 +170,7 @@ class LibraryTest {
     fun `can search within items`() {
         val album1 = ServerMediaItemFixtures.album(name = "Balloon Trapeze Experience")
         val album2 = ServerMediaItemFixtures.album(name = "Frontal Lobe Annihilation Puzzle")
+        serviceClient.addItems(album1, album2)
         serviceClient.addToLibrary(album1, album2)
 
         launchLoggedInApp(composeTestRule, serviceClient)
@@ -174,8 +184,9 @@ class LibraryTest {
 
     @Test
     fun `can search outside of library if there are no results`() {
-        val album = ServerMediaItemFixtures.album(name = "Balloon Trapeze Experience")
-        serviceClient.addToGlobalItems(album)
+        val album =
+            ServerMediaItemFixtures.album(name = "Balloon Trapeze Experience")
+        serviceClient.addItems(album)
 
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickLibrary()
@@ -191,6 +202,7 @@ class LibraryTest {
     fun `library has its own backstack`() {
         val album1 = ServerMediaItemFixtures.album()
         val album2 = ServerMediaItemFixtures.album()
+        serviceClient.addItems(album1, album2)
         serviceClient.addToLibrary(album1, album2)
 
         launchLoggedInApp(composeTestRule, serviceClient)
@@ -217,6 +229,7 @@ class LibraryTest {
     @Test
     fun `clicking library while on it clears backstack`() {
         val album = ServerMediaItemFixtures.album()
+        serviceClient.addItems(album)
         serviceClient.addToLibrary(album)
 
         launchLoggedInApp(composeTestRule, serviceClient)

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/LibraryTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/LibraryTest.kt
@@ -195,7 +195,7 @@ class LibraryTest {
             .search("balloon")
             .assertNoItems()
             .clickSearchEverywhere("balloon")
-            .assertResult(album.name)
+            .assertMediaDisplayed(album)
     }
 
     @Test

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/PlayerTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/PlayerTest.kt
@@ -49,7 +49,7 @@ class PlayerTest {
     fun `can play album`() {
         val album = ServerMediaItemFixtures.album()
         val track = ServerMediaItemFixtures.track(album = album)
-        serviceClient.addToLibrary(track)
+        serviceClient.addItems(track)
 
         val player = ServerPlayerFixtures.player()
         serviceClient.addPlayers(player)
@@ -71,7 +71,7 @@ class PlayerTest {
         val album = ServerMediaItemFixtures.album()
         val track1 = ServerMediaItemFixtures.track(album = album)
         val track2 = ServerMediaItemFixtures.track(album = album)
-        serviceClient.addToLibrary(track1, track2)
+        serviceClient.addItems(track1, track2)
 
         val player = ServerPlayerFixtures.player()
         serviceClient.addPlayers(player)
@@ -99,7 +99,7 @@ class PlayerTest {
     @Test
     fun `can pause playback`() {
         val track = ServerMediaItemFixtures.track()
-        serviceClient.addToLibrary(track)
+        serviceClient.addItems(track)
 
         val player = ServerPlayerFixtures.player()
         serviceClient.addPlayers(player)

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/PlaylistTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/PlaylistTest.kt
@@ -40,8 +40,9 @@ class PlaylistTest {
         val track1 = ServerMediaItemFixtures.track()
         val track2 = ServerMediaItemFixtures.track()
         val track3 = ServerMediaItemFixtures.track()
-        serviceClient.addToLibrary(playlist, track1, track2, track3)
+        serviceClient.addItems(playlist, track1, track2, track3)
         serviceClient.setPlaylist(playlist, track1, track2, track3)
+        serviceClient.addToLibrary(playlist)
 
         val player = ServerPlayerFixtures.player()
         serviceClient.addPlayers(player)
@@ -61,8 +62,9 @@ class PlaylistTest {
         val track1 = ServerMediaItemFixtures.track()
         val track2 = ServerMediaItemFixtures.track()
         val track3 = ServerMediaItemFixtures.track()
-        serviceClient.addToLibrary(playlist, track1, track2, track3)
+        serviceClient.addItems(playlist, track1, track2, track3)
         serviceClient.setPlaylist(playlist, track1, track2, track3)
+        serviceClient.addToLibrary(playlist)
 
         val player = ServerPlayerFixtures.player()
         serviceClient.addPlayers(player)

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/QueueTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/QueueTest.kt
@@ -32,7 +32,7 @@ class QueueTest {
         val album = ServerMediaItemFixtures.album()
         val track1 = ServerMediaItemFixtures.track(album = album)
         val track2 = ServerMediaItemFixtures.track(album = album)
-        serviceClient.addToLibrary(track1, track2)
+        serviceClient.addItems(track1, track2)
 
         val player = ServerPlayerFixtures.player()
         serviceClient.addPlayers(player)
@@ -49,7 +49,7 @@ class QueueTest {
     fun `can clear current player queue`() {
         val album = ServerMediaItemFixtures.album()
         val track = ServerMediaItemFixtures.track(album = album)
-        serviceClient.addToLibrary(track)
+        serviceClient.addItems(track)
 
         val player = ServerPlayerFixtures.player()
         serviceClient.addPlayers(player)
@@ -65,7 +65,7 @@ class QueueTest {
     fun `can transfer queue to another player`() {
         val album = ServerMediaItemFixtures.album()
         val track = ServerMediaItemFixtures.track(album = album)
-        serviceClient.addToLibrary(track)
+        serviceClient.addItems(track)
 
         val player1 = ServerPlayerFixtures.player()
         val player2 = ServerPlayerFixtures.player()

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/SearchTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/SearchTest.kt
@@ -9,6 +9,8 @@ import io.music_assistant.client.support.ServerMediaItemFixtures
 import io.music_assistant.client.support.get
 import io.music_assistant.client.support.launchLoggedInApp
 import io.music_assistant.client.support.pages.ItemPage
+import io.music_assistant.client.support.pages.assertMediaDisplayed
+import io.music_assistant.client.support.pages.assertMediaNotDisplayed
 import io.music_assistant.client.support.pages.clickHome
 import io.music_assistant.client.support.pages.clickSearch
 import io.music_assistant.client.support.pages.enableFilter
@@ -43,7 +45,7 @@ class SearchTest {
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickSearch()
             .search("onion")
-            .assertResult(album.name)
+            .assertMediaDisplayed(album)
             .clickOnMedia(album)
     }
 
@@ -56,13 +58,13 @@ class SearchTest {
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickSearch()
             .search("onion")
-            .assertResult(album.name)
-            .assertResult(track.name)
+            .assertMediaDisplayed(album)
+            .assertMediaDisplayed(track)
             .enableFilter {
                 it.enableChip(Res.string.media_type_albums.get())
             }
-            .assertResult(album.name)
-            .assertNoResult(track.name)
+            .assertMediaDisplayed(album)
+            .assertMediaNotDisplayed(track)
             .clickOnMedia(album)
     }
 
@@ -81,8 +83,8 @@ class SearchTest {
             .enableFilter {
                 it.enableSwitch(Res.string.search_in_library_only.get())
             }
-            .assertResult(libraryAlbum.name)
-            .assertNoResult(globalAlbum.name)
+            .assertMediaDisplayed(libraryAlbum)
+            .assertMediaNotDisplayed(globalAlbum)
     }
 
     @Test

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/SearchTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/SearchTest.kt
@@ -3,6 +3,7 @@ package io.music_assistant.client.feature
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.music_assistant.client.api.ServiceClient
+import io.music_assistant.client.data.model.server.ServerMediaItem
 import io.music_assistant.client.support.FakeServiceClient
 import io.music_assistant.client.support.Qualifiers
 import io.music_assistant.client.support.ServerMediaItemFixtures
@@ -83,7 +84,7 @@ class SearchTest {
             .enableFilter {
                 it.enableSwitch(Res.string.search_in_library_only.get())
             }
-            .assertMediaDisplayed(libraryAlbum)
+            .assertMediaDisplayed(libraryAlbum, provider = ServerMediaItem.LIBRARY_PROVIDER)
             .assertMediaNotDisplayed(globalAlbum)
     }
 

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/SearchTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/SearchTest.kt
@@ -38,7 +38,7 @@ class SearchTest {
     @Test
     fun `can navigate to items via search`() {
         val album = ServerMediaItemFixtures.album(name = "The Exploding Onion Conspiracy")
-        serviceClient.addToLibrary(album)
+        serviceClient.addItems(album)
 
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickSearch()
@@ -51,7 +51,7 @@ class SearchTest {
     fun `can filter search results by media type`() {
         val album = ServerMediaItemFixtures.album(name = "The Exploding Onion Conspiracy")
         val track = ServerMediaItemFixtures.track(name = "Onion Dip")
-        serviceClient.addToLibrary(album, track)
+        serviceClient.addItems(album, track)
 
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickSearch()
@@ -69,9 +69,11 @@ class SearchTest {
     @Test
     fun `can filter search results to library only`() {
         val libraryAlbum = ServerMediaItemFixtures.album(name = "The Exploding Onion Conspiracy")
-        val globalAlbum = ServerMediaItemFixtures.album(name = "A Tale of Onions")
+        val globalAlbum =
+            ServerMediaItemFixtures.album(name = "A Tale of Onions")
+        serviceClient.addItems(libraryAlbum)
         serviceClient.addToLibrary(libraryAlbum)
-        serviceClient.addToGlobalItems(globalAlbum)
+        serviceClient.addItems(globalAlbum)
 
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickSearch()
@@ -86,7 +88,7 @@ class SearchTest {
     @Test
     fun `clicking clear clears results`() {
         val album = ServerMediaItemFixtures.album(name = "Blast from Dastardly Past")
-        serviceClient.addToLibrary(album)
+        serviceClient.addItems(album)
 
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickSearch()
@@ -99,7 +101,7 @@ class SearchTest {
     fun `search has its own backstack`() {
         val album1 = ServerMediaItemFixtures.album()
         val album2 = ServerMediaItemFixtures.album()
-        serviceClient.addToLibrary(album1, album2)
+        serviceClient.addItems(album1, album2)
 
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickOnMedia(album1)

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ShortcutsTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ShortcutsTest.kt
@@ -66,7 +66,7 @@ class ShortcutsTest {
         serviceClient.addItems(album)
 
         launchLoggedInApp(composeTestRule, serviceClient)
-            .assertMediaDisplayed(album.name)
+            .assertMediaDisplayed(album)
     }
 
     @Test

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ShortcutsTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ShortcutsTest.kt
@@ -37,7 +37,7 @@ class ShortcutsTest {
     @Test
     fun `can navigate to shortcut items`() {
         val album = ServerMediaItemFixtures.album()
-        serviceClient.addToLibrary(album)
+        serviceClient.addItems(album)
         serviceClient.addShortcut(album)
 
         launchLoggedInApp(composeTestRule, serviceClient)
@@ -47,7 +47,7 @@ class ShortcutsTest {
     @Test
     fun `can play shortcut items`() {
         val track = ServerMediaItemFixtures.track()
-        serviceClient.addToLibrary(track)
+        serviceClient.addItems(track)
         serviceClient.addShortcut(track)
 
         val player = ServerPlayerFixtures.player()
@@ -63,7 +63,7 @@ class ShortcutsTest {
         serviceClient.setLegacyVersion(LegacyVersion.V2_8)
 
         val album = ServerMediaItemFixtures.album()
-        serviceClient.addToLibrary(album)
+        serviceClient.addItems(album)
 
         launchLoggedInApp(composeTestRule, serviceClient)
             .assertMediaDisplayed(album.name)

--- a/androidApp/src/test/kotlin/io/music_assistant/client/regression/AndroidBackGestureTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/regression/AndroidBackGestureTest.kt
@@ -34,7 +34,7 @@ class AndroidBackGestureTest {
     fun `using back while on expanded player closes the player instead of popping nav stack`() {
         val album = ServerMediaItemFixtures.album()
         val track = ServerMediaItemFixtures.track(album = album)
-        serviceClient.addToLibrary(track)
+        serviceClient.addItems(track)
 
         val player = ServerPlayerFixtures.player()
         serviceClient.addPlayers(player)
@@ -53,7 +53,7 @@ class AndroidBackGestureTest {
     fun `using back while on expanded player doesn't close app`() {
         val album = ServerMediaItemFixtures.album()
         val track = ServerMediaItemFixtures.track(album = album)
-        serviceClient.addToLibrary(track)
+        serviceClient.addItems(track)
 
         val player = ServerPlayerFixtures.player()
         serviceClient.addPlayers(player)

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeMediaItemStore.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeMediaItemStore.kt
@@ -1,0 +1,156 @@
+package io.music_assistant.client.support
+
+import io.music_assistant.client.data.model.client.MediaType
+import io.music_assistant.client.data.model.server.ServerMediaItem
+import io.music_assistant.client.utils.UniqueIdGenerator
+
+internal class FakeMediaItemStore {
+    private val uniqueIdGenerator = UniqueIdGenerator()
+    private val mediaItems = mutableSetOf<ServerMediaItem>()
+    private val libraryIds = mutableMapOf<Pair<String, String>, String>()
+    private val playlistItems = mutableMapOf<String, List<String>>()
+
+    fun query(
+        query: String? = null,
+        mediaType: MediaType? = null,
+        inLibraryOnly: Boolean = false,
+        favoritesOnly: Boolean = false,
+    ): List<ServerMediaItem> {
+        return mediaItems
+            .filter { mediaType == null || it.mediaType == mediaType.serverValue }
+            .filter { !inLibraryOnly || it.isInLibrary() }
+            .filter { !favoritesOnly || it.favorite ?: false }
+            .filter { query == null || it.name.contains(query, ignoreCase = true) }
+    }
+
+    fun getItem(itemId: String, provider: String): ServerMediaItem {
+        return if (provider == "library") {
+            val globalId = libraryIds.entries.first { it.value == itemId }.key
+            mediaItems.first { it.globalId() == globalId }
+        } else {
+            mediaItems
+                .filter { it.isInProvider(provider) }
+                .first { it.itemId == itemId }
+        }
+    }
+
+    fun getByUri(uri: String): ServerMediaItem? {
+        return mediaItems.find { it.uri == uri }
+    }
+
+    fun getAlbumsByArtist(artist: ServerMediaItem, provider: String): List<ServerMediaItem> {
+        return mediaItems
+            .filter { it.isInProvider(provider) }
+            .filter { it.mediaType == MediaType.ALBUM.serverValue }
+            .filter { it.artists?.contains(artist) ?: false }
+    }
+
+    fun getTracksByAlbum(album: ServerMediaItem): List<ServerMediaItem> {
+        return mediaItems
+            .filter { it.mediaType == MediaType.TRACK.serverValue }
+            .filter { it.album == album }
+    }
+
+    fun getTracksByPlaylist(playlist: ServerMediaItem): List<ServerMediaItem> {
+        return mediaItems
+            .filter { it.mediaType == MediaType.TRACK.serverValue }
+            .filter { playlistItems[playlist.itemId]?.contains(it.itemId) ?: false }
+    }
+
+    fun addItems(vararg items: ServerMediaItem) {
+        val itemsToAdd = items.toList()
+        itemsToAdd.forEach { item ->
+            item.artists?.let {
+                mediaItems.addAll(it)
+            }
+
+            item.album?.let {
+                mediaItems.add(it)
+            }
+        }
+
+        mediaItems.addAll(itemsToAdd)
+    }
+
+    fun addToLibrary(item: ServerMediaItem) {
+        libraryIds[item.globalId()] = uniqueIdGenerator.nextInt().toString()
+
+        when (MediaType.fromServer(item.mediaType)) {
+            MediaType.ALBUM -> {
+                mediaItems.filter { it.album == this }.forEach {
+                    addToLibrary(it)
+                }
+
+                item.artists?.forEach {
+                    addToLibrary(it)
+                }
+            }
+
+            MediaType.PLAYLIST -> Unit
+            MediaType.ARTIST -> Unit
+            MediaType.TRACK -> Unit
+            MediaType.RADIO -> Unit
+            MediaType.AUDIOBOOK -> Unit
+            MediaType.PODCAST -> Unit
+            MediaType.PODCAST_EPISODE -> Unit
+            MediaType.GENRE -> Unit
+            MediaType.FOLDER -> Unit
+            MediaType.FLOW_STREAM -> Unit
+            MediaType.ANNOUNCEMENT -> Unit
+            MediaType.UNKNOWN -> Unit
+            null -> Unit
+        }
+    }
+
+    fun matchItem(libraryItem: ServerMediaItem, providerItem: ServerMediaItem) {
+        val libraryId = libraryIds[libraryItem.globalId()]
+        require(libraryId != null) { "Can't add match for item not in library!" }
+        libraryIds[providerItem.globalId()] = libraryId
+    }
+
+    fun setPlaylist(playlist: ServerMediaItem, vararg tracks: ServerMediaItem) {
+        playlistItems[playlist.itemId] = tracks.map { it.itemId }
+    }
+
+    fun enrichLibraryItem(item: ServerMediaItem): ServerMediaItem {
+        val libraryId = libraryIds[item.globalId()]
+
+        return if (libraryId != null) {
+            val matchedItems = libraryIds.entries
+                .filter { it.value == libraryId }
+                .map { it.key }
+                .flatMap { globalId ->
+                    mediaItems.filter { it.globalId() == globalId }
+                }
+
+            val providerMappings = matchedItems.map { it.providerMappings!![0] }
+
+            item.copy(
+                itemId = libraryId,
+                provider = "library",
+                providerMappings = providerMappings,
+            )
+        } else {
+            item
+        }
+    }
+
+    private fun ServerMediaItem.isInProvider(provider: String): Boolean {
+        return if (provider == ServerMediaItem.LIBRARY_PROVIDER) {
+            isInLibrary()
+        } else {
+            this.providerMappings?.any { mapping ->
+                (mapping.providerInstance == provider || mapping.providerDomain == provider) && mapping.itemId == itemId
+            } ?: false
+        }
+    }
+
+    private fun ServerMediaItem.isInLibrary(): Boolean {
+        return libraryIds.containsKey(this.globalId())
+    }
+}
+
+private fun ServerMediaItem.globalId(): Pair<String, String> {
+    val providerMapping = this.providerMappings!![0]
+    return Pair(providerMapping.providerInstance, providerMapping.itemId)
+}

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -46,8 +46,6 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.encodeToJsonElement
-import kotlin.properties.ReadOnlyProperty
-import kotlin.reflect.KProperty
 
 class FakeServiceClient : ServiceClient {
     private var legacyVersion: LegacyVersion? = null
@@ -60,25 +58,8 @@ class FakeServiceClient : ServiceClient {
     private val playerAudioFormats = mutableMapOf<String, AudioFormat>()
     private val queues = mutableListOf<ServerQueue>()
     private val queueItems = mutableMapOf<String, List<ServerQueueItem>>()
-    private val items = mutableSetOf<ServerMediaItem>()
-    private val globalItems = mutableSetOf<ServerMediaItem>()
-
-    private val albums: List<ServerMediaItem> by items(items, MediaType.ALBUM)
-    private val artists: List<ServerMediaItem> by items(items, MediaType.ARTIST)
-    private val tracks: List<ServerMediaItem> by items(items, MediaType.TRACK)
-    private val playlists: List<ServerMediaItem> by items(items, MediaType.PLAYLIST)
-    private val audiobooks: List<ServerMediaItem> by items(items, MediaType.AUDIOBOOK)
-    private val podcasts: List<ServerMediaItem> by items(items, MediaType.PODCAST)
-    private val radios: List<ServerMediaItem> by items(items, MediaType.RADIO)
-    private val genres: List<ServerMediaItem> by items(items, MediaType.GENRE)
-    private val globalArtists: List<ServerMediaItem> by items(globalItems, MediaType.ARTIST)
-    private val globalAlbums: List<ServerMediaItem> by items(globalItems, MediaType.ALBUM)
-    private val globalTracks: List<ServerMediaItem> by items(globalItems, MediaType.TRACK)
-    private val globalPlaylists: List<ServerMediaItem> by items(globalItems, MediaType.PLAYLIST)
-    private val globalAudiobooks: List<ServerMediaItem> by items(globalItems, MediaType.AUDIOBOOK)
-    private val globalPodcasts: List<ServerMediaItem> by items(globalItems, MediaType.PODCAST)
-    private val globalRadios: List<ServerMediaItem> by items(globalItems, MediaType.RADIO)
-    private val globalGenres: List<ServerMediaItem> by items(globalItems, MediaType.GENRE)
+    private val mediaItems = mutableSetOf<ServerMediaItem>()
+    private val libraryIds = mutableMapOf<Pair<String, String>, String>()
 
     private val playlistItems = mutableMapOf<String, List<String>>()
     private val shortcuts = mutableListOf<String>()
@@ -145,7 +126,7 @@ class FakeServiceClient : ServiceClient {
             }
 
             APICommands.MUSIC_ITEM_BY_URI -> {
-                val item = items.find { it.uri == request.getArg("uri") }!!
+                val item = mediaItems.find { it.uri == request.getArg("uri") }!!
                 Result.success(answer(request = request, result = item))
             }
 
@@ -159,14 +140,18 @@ class FakeServiceClient : ServiceClient {
                                 provider = "library",
                                 name = "Recently added albums",
                                 mediaType = MediaType.FOLDER.serverValue,
-                                items = albums,
+                                items = mediaItems
+                                    .filter { it.mediaType == MediaType.ALBUM.serverValue }
+                                    .forResponse(),
                             ),
                             ServerMediaItem(
                                 itemId = "recently_added_tracks",
                                 provider = "library",
                                 name = "Recently added tracks",
                                 mediaType = MediaType.FOLDER.serverValue,
-                                items = tracks,
+                                items = mediaItems
+                                    .filter { it.mediaType == MediaType.TRACK.serverValue }
+                                    .forResponse(),
                             ),
                         ),
                     ),
@@ -174,158 +159,62 @@ class FakeServiceClient : ServiceClient {
             }
 
             APICommands.MUSIC_SEARCH -> {
-                val searchArg = "search_query"
                 val mediaTypes =
                     (request.args!!["media_types"] as JsonArray).map { (it as JsonPrimitive).content }
                 val libraryOnly = request.getArgOrNull("library_only") == "true"
 
-                if (mediaTypes.isEmpty()) {
-                    Result.success(
-                        answer(
-                            request = request,
-                            result = SearchResult(
-                                artists = searchItems(
-                                    request,
-                                    searchArg,
-                                    if (libraryOnly) artists else artists + globalArtists,
-                                ),
-                                albums = searchItems(
-                                    request,
-                                    searchArg,
-                                    if (libraryOnly) albums else albums + globalAlbums,
-                                ),
-                                tracks = searchItems(
-                                    request,
-                                    searchArg,
-                                    if (libraryOnly) tracks else tracks + globalTracks,
-                                ),
-                                playlists = searchItems(
-                                    request,
-                                    searchArg,
-                                    if (libraryOnly) playlists else playlists + globalPlaylists,
-                                ),
-                                podcasts = searchItems(
-                                    request,
-                                    searchArg,
-                                    if (libraryOnly) podcasts else podcasts + globalPodcasts,
-                                ),
-                                audiobooks = searchItems(
-                                    request,
-                                    searchArg,
-                                    if (libraryOnly) audiobooks else audiobooks + globalAudiobooks,
-                                ),
-                                radio = searchItems(
-                                    request,
-                                    searchArg,
-                                    if (libraryOnly) radios else radios + globalRadios,
-                                ),
-                                genres = searchItems(
-                                    request,
-                                    searchArg,
-                                    if (libraryOnly) genres else genres + globalGenres,
-                                ),
-                            ),
-                        ),
-                    )
+                val itemsToSearch = if (libraryOnly) {
+                    mediaItems.dropNotInLibrary()
                 } else {
-                    Result.success(
-                        answer(
-                            request = request,
-                            result = SearchResult(
-                                artists = if (mediaTypes.contains(MediaType.ARTIST.serverValue)) {
-                                    searchItems(
-                                        request,
-                                        searchArg,
-                                        if (libraryOnly) artists else artists + globalArtists,
-                                    )
-                                } else {
-                                    emptyList()
-                                },
-                                albums = if (mediaTypes.contains(MediaType.ALBUM.serverValue)) {
-                                    searchItems(
-                                        request,
-                                        searchArg,
-                                        if (libraryOnly) albums else albums + globalAlbums,
-                                    )
-                                } else {
-                                    emptyList()
-                                },
-                                tracks = if (mediaTypes.contains(MediaType.TRACK.serverValue)) {
-                                    searchItems(
-                                        request,
-                                        searchArg,
-                                        if (libraryOnly) tracks else tracks + globalTracks,
-                                    )
-                                } else {
-                                    emptyList()
-                                },
-                                playlists = if (mediaTypes.contains(MediaType.PLAYLIST.serverValue)) {
-                                    searchItems(
-                                        request,
-                                        searchArg,
-                                        if (libraryOnly) playlists else playlists + globalPlaylists,
-                                    )
-                                } else {
-                                    emptyList()
-                                },
-                                podcasts = if (mediaTypes.contains(MediaType.PODCAST.serverValue)) {
-                                    searchItems(
-                                        request,
-                                        searchArg,
-                                        if (libraryOnly) podcasts else podcasts + globalPodcasts,
-                                    )
-                                } else {
-                                    emptyList()
-                                },
-                                audiobooks = if (mediaTypes.contains(MediaType.AUDIOBOOK.serverValue)) {
-                                    searchItems(
-                                        request,
-                                        searchArg,
-                                        if (libraryOnly) audiobooks else audiobooks + globalAudiobooks,
-                                    )
-                                } else {
-                                    emptyList()
-                                },
-                                radio = if (mediaTypes.contains(MediaType.RADIO.serverValue)) {
-                                    searchItems(
-                                        request,
-                                        searchArg,
-                                        if (libraryOnly) radios else radios + globalRadios,
-                                    )
-                                } else {
-                                    emptyList()
-                                },
-                                genres = if (mediaTypes.contains(MediaType.GENRE.serverValue)) {
-                                    searchItems(
-                                        request,
-                                        searchArg,
-                                        if (libraryOnly) genres else genres + globalGenres,
-                                    )
-                                } else {
-                                    emptyList()
-                                },
-                            ),
-                        ),
-                    )
+                    mediaItems
                 }
+
+                val results = itemsToSearch.filter {
+                    it.name.contains(request.getArg("search_query"), ignoreCase = true)
+                }
+
+                val resultsForType: (MediaType) -> List<ServerMediaItem> = {
+                    val mediaTypeServerValue = it.serverValue
+                    if (mediaTypes.isEmpty() || mediaTypes.contains(mediaTypeServerValue)) {
+                        results.filter { it.mediaType == mediaTypeServerValue }.forResponse()
+                    } else {
+                        emptyList()
+                    }
+                }
+
+                Result.success(
+                    answer(
+                        request = request,
+                        result = SearchResult(
+                            artists = resultsForType(MediaType.ARTIST),
+                            albums = resultsForType(MediaType.ALBUM),
+                            tracks = resultsForType(MediaType.TRACK),
+                            playlists = resultsForType(MediaType.PLAYLIST),
+                            podcasts = resultsForType(MediaType.PODCAST),
+                            audiobooks = resultsForType(MediaType.AUDIOBOOK),
+                            radio = resultsForType(MediaType.RADIO),
+                            genres = resultsForType(MediaType.GENRE),
+                        ),
+                    ),
+                )
             }
 
             APICommands.musicGet(APICommands.KIND_ALBUMS) -> {
                 Result.success(
                     answer(
                         request = request,
-                        result = findItem(request, albums),
+                        result = findItem(request).forResponse(),
                     ),
                 )
             }
 
             APICommands.MUSIC_ALBUMS_ALBUM_TRACKS -> {
-                val album = findItem(request, albums)
+                val album = findItem(request)
 
                 Result.success(
                     answer(
                         request = request,
-                        result = tracks.filter { it.album == album },
+                        result = album.getAlbumTracks().forResponse(),
                     ),
                 )
             }
@@ -334,7 +223,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = searchItems(request, "search", albums),
+                        result = filterLibrary(request, MediaType.ALBUM).forResponse(),
                     ),
                 )
             }
@@ -343,7 +232,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = findItem(request, artists),
+                        result = findItem(request).forResponse(),
                     ),
                 )
             }
@@ -352,7 +241,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = searchItems(request, "search", artists),
+                        result = filterLibrary(request, MediaType.ARTIST).forResponse(),
                     ),
                 )
             }
@@ -361,7 +250,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = searchItems(request, "search", playlists),
+                        result = filterLibrary(request, MediaType.PLAYLIST).forResponse(),
                     ),
                 )
             }
@@ -370,18 +259,18 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = findItem(request, playlists),
+                        result = findItem(request).forResponse(),
                     ),
                 )
             }
 
             APICommands.MUSIC_PLAYLISTS_PLAYLIST_TRACKS -> {
-                val playlistId = request.getArg("item_id")
+                val playlist = findItem(request)
 
                 Result.success(
                     answer(
                         request = request,
-                        result = tracks.filter { playlistItems[playlistId]!!.contains(it.itemId) },
+                        result = playlist.getPlaylistTracks().forResponse(),
                     ),
                 )
             }
@@ -390,7 +279,12 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = tracks,
+                        result = mediaItems
+                            .dropNotInLibrary()
+                            .filter {
+                                it.mediaType == MediaType.TRACK.serverValue
+                            }
+                            .forResponse(),
                     ),
                 )
             }
@@ -399,7 +293,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = searchItems(request, "search", audiobooks),
+                        result = filterLibrary(request, MediaType.AUDIOBOOK).forResponse(),
                     ),
                 )
             }
@@ -408,7 +302,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = searchItems(request, "search", podcasts),
+                        result = filterLibrary(request, MediaType.PODCAST).forResponse(),
                     ),
                 )
             }
@@ -417,7 +311,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = searchItems(request, "search", radios),
+                        result = filterLibrary(request, MediaType.RADIO).forResponse(),
                     ),
                 )
             }
@@ -426,7 +320,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = searchItems(request, "search", genres),
+                        result = filterLibrary(request, MediaType.GENRE).forResponse(),
                     ),
                 )
             }
@@ -443,35 +337,35 @@ class FakeServiceClient : ServiceClient {
             APICommands.PLAYER_QUEUES_PLAY_MEDIA -> {
                 val mediaUri = ((request.args!!["media"] as JsonArray)[0] as JsonPrimitive).content
                 val startItemId = request.getArgOrNull("start_item")
-                val mediaTracks = items.find { it.uri == mediaUri }?.let { item ->
-                    when (MediaType.fromServer(item.mediaType)) {
-                        MediaType.ALBUM -> {
-                            val albumTracks = tracks.filter { it.album == item }
-                            val startIndex = if (startItemId != null) {
-                                albumTracks.indexOfFirst { it.itemId == startItemId }
-                            } else {
-                                0
+                val mediaTracks =
+                    mediaItems.find { it.uri == mediaUri }?.let { item ->
+                        when (MediaType.fromServer(item.mediaType)) {
+                            MediaType.ALBUM -> {
+                                val albumTracks = item.getAlbumTracks()
+                                val startIndex = if (startItemId != null) {
+                                    albumTracks.indexOfFirst { it.itemId == startItemId }
+                                } else {
+                                    0
+                                }
+
+                                albumTracks.drop(startIndex)
                             }
 
-                            albumTracks.drop(startIndex)
-                        }
+                            MediaType.TRACK -> listOf(item)
+                            MediaType.PLAYLIST -> {
+                                val playlistTracks = item.getPlaylistTracks()
+                                val startIndex = if (startItemId != null) {
+                                    playlistTracks.indexOfFirst { it.itemId == startItemId }
+                                } else {
+                                    0
+                                }
 
-                        MediaType.TRACK -> listOf(item)
-                        MediaType.PLAYLIST -> {
-                            val playlistTracks =
-                                tracks.filter { playlistItems[item.itemId]!!.contains(it.itemId) }
-                            val startIndex = if (startItemId != null) {
-                                playlistTracks.indexOfFirst { it.itemId == startItemId }
-                            } else {
-                                0
+                                playlistTracks.drop(startIndex)
                             }
 
-                            playlistTracks.drop(startIndex)
+                            else -> TODO()
                         }
-
-                        else -> TODO()
-                    }
-                } ?: emptyList()
+                    } ?: emptyList()
 
                 val queueId = request.getArg("queue_id")
                 updateQueue(
@@ -766,12 +660,71 @@ class FakeServiceClient : ServiceClient {
         _sessionState.update { SessionState.Disconnected.NoServerData }
     }
 
-    fun addToLibrary(vararg items: ServerMediaItem) {
-        addItems(items, this.items)
+    fun addItems(vararg items: ServerMediaItem) {
+        val itemsToAdd = items.toList()
+        itemsToAdd.forEach { item ->
+            item.artists?.let {
+                mediaItems.addAll(it)
+            }
+
+            item.album?.let {
+                mediaItems.add(it)
+            }
+        }
+
+        mediaItems.addAll(itemsToAdd)
     }
 
-    fun addToGlobalItems(vararg items: ServerMediaItem) {
-        addItems(items, globalItems)
+    fun addToLibrary(vararg items: ServerMediaItem) {
+        items.forEach { addToLibrary(it) }
+    }
+
+    fun addToLibrary(item: ServerMediaItem) {
+        libraryIds[item.globalId()] = uniqueIdGenerator.nextInt().toString()
+
+        when (MediaType.fromServer(item.mediaType)) {
+            MediaType.ALBUM -> {
+                item.getAlbumTracks().forEach {
+                    libraryIds[it.globalId()] = uniqueIdGenerator.nextInt().toString()
+                }
+            }
+
+            MediaType.PLAYLIST -> Unit
+            MediaType.ARTIST -> Unit
+            MediaType.TRACK -> Unit
+            MediaType.RADIO -> Unit
+            MediaType.AUDIOBOOK -> Unit
+            MediaType.PODCAST -> Unit
+            MediaType.PODCAST_EPISODE -> Unit
+            MediaType.GENRE -> Unit
+            MediaType.FOLDER -> Unit
+            MediaType.FLOW_STREAM -> Unit
+            MediaType.ANNOUNCEMENT -> Unit
+            MediaType.UNKNOWN -> Unit
+            null -> Unit
+        }
+    }
+
+    fun Set<ServerMediaItem>.dropNotInLibrary(): List<ServerMediaItem> {
+        return this.filter { libraryIds.containsKey(it.globalId()) }
+    }
+
+    fun ServerMediaItem.forResponse(): ServerMediaItem {
+        val libraryId = libraryIds[this.globalId()]
+        return if (libraryId != null) {
+            this.copy(
+                itemId = libraryId,
+                provider = "library",
+                album = album.let { it?.forResponse() },
+                artists = artists.let { it?.forResponse() },
+            )
+        } else {
+            this
+        }
+    }
+
+    fun Collection<ServerMediaItem>.forResponse(): List<ServerMediaItem> {
+        return this.map { it.forResponse() }
     }
 
     fun addPlayers(vararg players: ServerPlayer) {
@@ -802,30 +755,45 @@ class FakeServiceClient : ServiceClient {
         }
     }
 
-    private fun findItem(
-        request: Request,
-        items: List<ServerMediaItem>,
-    ): ServerMediaItem {
-        return items.find {
-            it.itemId == (request.args!!["item_id"]!! as JsonPrimitive).content
-        }!!
+    private fun findItem(request: Request): ServerMediaItem {
+        val itemId = request.getArg("item_id")
+        val provider = request.getArg("provider_instance_id_or_domain")
+
+        return if (provider == "library") {
+            val globalId = libraryIds.entries.first { it.value == itemId }.key
+            mediaItems.first { it.globalId() == globalId }
+        } else {
+            mediaItems.first {
+                it.providerMappings?.any { mapping ->
+                    (mapping.providerInstance == provider || mapping.providerDomain == provider) && mapping.itemId == itemId
+                } ?: false
+            }
+        }
     }
 
-    private fun searchItems(
+    private fun filterLibrary(
         request: Request,
-        requestArg: String,
-        items: Collection<ServerMediaItem>,
+        mediaType: MediaType,
     ): List<ServerMediaItem> {
-        return items.filter {
-            val nameMatches = it.name.contains(request.getArg(requestArg), ignoreCase = true)
-            val favoriteMatches = if (request.getArgOrNull("favorite") == "true") {
-                it.favorite ?: false
-            } else {
-                true
-            }
+        return mediaItems.dropNotInLibrary().filter { it.mediaType == mediaType.serverValue }
+            .filter {
+                val nameMatches = it.name.contains(request.getArg("search"), ignoreCase = true)
+                val favoriteMatches = if (request.getArgOrNull("favorite") == "true") {
+                    it.favorite ?: false
+                } else {
+                    true
+                }
 
-            nameMatches && favoriteMatches
-        }
+                nameMatches && favoriteMatches
+            }
+    }
+
+    fun ServerMediaItem.getAlbumTracks(): List<ServerMediaItem> {
+        return mediaItems.filter { it.album == this }
+    }
+
+    fun ServerMediaItem.getPlaylistTracks(): List<ServerMediaItem> {
+        return mediaItems.filter { playlistItems[this.itemId]?.contains(it.itemId) ?: false }
     }
 
     fun getQueueForPlayer(player: ServerPlayer): List<ServerMediaItem> {
@@ -915,23 +883,6 @@ class FakeServiceClient : ServiceClient {
         }
     }
 
-    private fun addItems(
-        itemsToAdd: Array<out ServerMediaItem>,
-        items: MutableSet<ServerMediaItem>,
-    ) {
-        items.addAll(itemsToAdd)
-        itemsToAdd.forEach { item ->
-            item.artists?.let {
-                items.addAll(it)
-            }
-        }
-        itemsToAdd.forEach { item ->
-            item.album?.let {
-                items.add(it)
-            }
-        }
-    }
-
     fun setPlayerAudioFormat(player: ServerPlayer, audioFormat: AudioFormat) {
         playerAudioFormats[player.playerId] = audioFormat
     }
@@ -965,16 +916,7 @@ private fun Request.getArgOrNull(arg: String): String? {
     return (args!![arg] as JsonPrimitive?)?.content
 }
 
-private class FilteredMediaTypeDelegate(
-    private val items: Set<ServerMediaItem>,
-    private val mediaType: MediaType,
-) : ReadOnlyProperty<Any?, List<ServerMediaItem>> {
-    override fun getValue(thisRef: Any?, property: KProperty<*>): List<ServerMediaItem> {
-        return items.filter { it.mediaType == mediaType.serverValue }
-    }
+private fun ServerMediaItem.globalId(): Pair<String, String> {
+    val providerMapping = this.providerMappings!![0]
+    return Pair(providerMapping.providerInstance, providerMapping.itemId)
 }
-
-private fun items(
-    items: Set<ServerMediaItem>,
-    mediaType: MediaType,
-): FilteredMediaTypeDelegate = FilteredMediaTypeDelegate(items, mediaType)

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -58,10 +58,7 @@ class FakeServiceClient : ServiceClient {
     private val playerAudioFormats = mutableMapOf<String, AudioFormat>()
     private val queues = mutableListOf<ServerQueue>()
     private val queueItems = mutableMapOf<String, List<ServerQueueItem>>()
-    private val mediaItems = mutableSetOf<ServerMediaItem>()
-    private val libraryIds = mutableMapOf<Pair<String, String>, String>()
-
-    private val playlistItems = mutableMapOf<String, List<String>>()
+    private val mediaItemStore = FakeMediaItemStore()
     private val shortcuts = mutableListOf<String>()
 
     val username = "user"
@@ -126,8 +123,8 @@ class FakeServiceClient : ServiceClient {
             }
 
             APICommands.MUSIC_ITEM_BY_URI -> {
-                val item = mediaItems.find { it.uri == request.getArg("uri") }!!
-                Result.success(answer(request = request, result = item.enrichLibraryItems()))
+                val item = mediaItemStore.getByUri(request.getArg("uri"))!!
+                Result.success(answer(request = request, result = item.enrichLibraryItem()))
             }
 
             APICommands.MUSIC_RECOMMENDATIONS -> {
@@ -140,24 +137,21 @@ class FakeServiceClient : ServiceClient {
                                 provider = "library",
                                 name = "Recently added albums",
                                 mediaType = MediaType.FOLDER.serverValue,
-                                items = mediaItems
-                                    .filter { it.mediaType == MediaType.ALBUM.serverValue },
+                                items = mediaItemStore.query(mediaType = MediaType.ALBUM),
                             ),
                             ServerMediaItem(
                                 itemId = "recently_added_tracks",
                                 provider = "library",
                                 name = "Recently added tracks",
                                 mediaType = MediaType.FOLDER.serverValue,
-                                items = mediaItems
-                                    .filter { it.mediaType == MediaType.TRACK.serverValue },
+                                items = mediaItemStore.query(mediaType = MediaType.TRACK),
                             ),
                             ServerMediaItem(
                                 itemId = "recently_added_artists",
                                 provider = "library",
                                 name = "Recently added artists",
                                 mediaType = MediaType.FOLDER.serverValue,
-                                items = mediaItems
-                                    .filter { it.mediaType == MediaType.ARTIST.serverValue },
+                                items = mediaItemStore.query(mediaType = MediaType.ARTIST),
                             ),
                         ),
                     ),
@@ -168,16 +162,10 @@ class FakeServiceClient : ServiceClient {
                 val mediaTypes =
                     (request.args!!["media_types"] as JsonArray).map { (it as JsonPrimitive).content }
                 val libraryOnly = request.getArgOrNull("library_only") == "true"
-
-                val itemsToSearch = if (libraryOnly) {
-                    mediaItems.dropNotInLibrary()
-                } else {
-                    mediaItems
-                }
-
-                val results = itemsToSearch.filter {
-                    it.name.contains(request.getArg("search_query"), ignoreCase = true)
-                }
+                val results = mediaItemStore.query(
+                    request.getArg("search_query"),
+                    inLibraryOnly = libraryOnly,
+                )
 
                 val resultsForType: (MediaType) -> List<ServerMediaItem> = {
                     val mediaTypeServerValue = it.serverValue
@@ -209,7 +197,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = findItem(request).enrichLibraryItems(),
+                        result = findItem(request).enrichLibraryItem(),
                     ),
                 )
             }
@@ -220,7 +208,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = album.getAlbumTracks(),
+                        result = mediaItemStore.getTracksByAlbum(album),
                     ),
                 )
             }
@@ -238,25 +226,20 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = findItem(request).enrichLibraryItems(),
+                        result = findItem(request).enrichLibraryItem(),
                     ),
                 )
             }
 
             APICommands.MUSIC_ARTISTS_ARTIST_ALBUMS -> {
                 val artist = findItem(request)
-
-                val albums = if (request.getArg("provider_instance_id_or_domain") == "library") {
-                    mediaItems.dropNotInLibrary()
-                } else {
-                    mediaItems
-                }.filter { it.mediaType == MediaType.ALBUM.serverValue }
-                    .filter { it.artists?.contains(artist) ?: false }
+                val provider = request.getArg("provider_instance_id_or_domain")
+                val albums = mediaItemStore.getAlbumsByArtist(artist, provider)
 
                 Result.success(
                     answer(
                         request = request,
-                        result = if (request.getArg("provider_instance_id_or_domain") == "library") {
+                        result = if (provider == ServerMediaItem.LIBRARY_PROVIDER) {
                             albums.enrichLibraryItems()
                         } else {
                             albums
@@ -287,7 +270,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = findItem(request).enrichLibraryItems(),
+                        result = findItem(request).enrichLibraryItem(),
                     ),
                 )
             }
@@ -298,7 +281,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = playlist.getPlaylistTracks(),
+                        result = mediaItemStore.getTracksByPlaylist(playlist),
                     ),
                 )
             }
@@ -307,12 +290,10 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = mediaItems
-                            .dropNotInLibrary()
-                            .filter {
-                                it.mediaType == MediaType.TRACK.serverValue
-                            }
-                            .enrichLibraryItems(),
+                        result = mediaItemStore.query(
+                            mediaType = MediaType.TRACK,
+                            inLibraryOnly = true,
+                        ).enrichLibraryItems(),
                     ),
                 )
             }
@@ -366,10 +347,10 @@ class FakeServiceClient : ServiceClient {
                 val mediaUri = ((request.args!!["media"] as JsonArray)[0] as JsonPrimitive).content
                 val startItemId = request.getArgOrNull("start_item")
                 val mediaTracks =
-                    mediaItems.find { it.uri == mediaUri }?.let { item ->
+                    mediaItemStore.getByUri(mediaUri)?.let { item ->
                         when (MediaType.fromServer(item.mediaType)) {
                             MediaType.ALBUM -> {
-                                val albumTracks = item.getAlbumTracks()
+                                val albumTracks = mediaItemStore.getTracksByAlbum(item)
                                 val startIndex = if (startItemId != null) {
                                     albumTracks.indexOfFirst { it.itemId == startItemId }
                                 } else {
@@ -381,7 +362,7 @@ class FakeServiceClient : ServiceClient {
 
                             MediaType.TRACK -> listOf(item)
                             MediaType.PLAYLIST -> {
-                                val playlistTracks = item.getPlaylistTracks()
+                                val playlistTracks = mediaItemStore.getTracksByPlaylist(item)
                                 val startIndex = if (startItemId != null) {
                                     playlistTracks.indexOfFirst { it.itemId == startItemId }
                                 } else {
@@ -689,18 +670,7 @@ class FakeServiceClient : ServiceClient {
     }
 
     fun addItems(vararg items: ServerMediaItem) {
-        val itemsToAdd = items.toList()
-        itemsToAdd.forEach { item ->
-            item.artists?.let {
-                mediaItems.addAll(it)
-            }
-
-            item.album?.let {
-                mediaItems.add(it)
-            }
-        }
-
-        mediaItems.addAll(itemsToAdd)
+        mediaItemStore.addItems(*items)
     }
 
     fun addToLibrary(vararg items: ServerMediaItem) {
@@ -708,70 +678,11 @@ class FakeServiceClient : ServiceClient {
     }
 
     fun addToLibrary(item: ServerMediaItem) {
-        libraryIds[item.globalId()] = uniqueIdGenerator.nextInt().toString()
-
-        when (MediaType.fromServer(item.mediaType)) {
-            MediaType.ALBUM -> {
-                item.getAlbumTracks().forEach {
-                    addToLibrary(it)
-                }
-
-                item.artists?.forEach {
-                    addToLibrary(it)
-                }
-            }
-
-            MediaType.PLAYLIST -> Unit
-            MediaType.ARTIST -> Unit
-            MediaType.TRACK -> Unit
-            MediaType.RADIO -> Unit
-            MediaType.AUDIOBOOK -> Unit
-            MediaType.PODCAST -> Unit
-            MediaType.PODCAST_EPISODE -> Unit
-            MediaType.GENRE -> Unit
-            MediaType.FOLDER -> Unit
-            MediaType.FLOW_STREAM -> Unit
-            MediaType.ANNOUNCEMENT -> Unit
-            MediaType.UNKNOWN -> Unit
-            null -> Unit
-        }
+        mediaItemStore.addToLibrary(item)
     }
 
     fun matchItem(libraryItem: ServerMediaItem, providerItem: ServerMediaItem) {
-        val libraryId = libraryIds[libraryItem.globalId()]
-        require(libraryId != null) { "Can't add match for item not in library!" }
-        libraryIds[providerItem.globalId()] = libraryId
-    }
-
-    fun Set<ServerMediaItem>.dropNotInLibrary(): List<ServerMediaItem> {
-        return this.filter { libraryIds.containsKey(it.globalId()) }
-    }
-
-    fun ServerMediaItem.enrichLibraryItems(): ServerMediaItem {
-        val libraryId = libraryIds[this.globalId()]
-
-        return if (libraryId != null) {
-            val matchedItems = libraryIds.entries
-                .filter { it.value == libraryId }
-                .map { it.key }
-                .flatMap { globalId ->
-                    mediaItems.filter { it.globalId() == globalId }
-                }
-
-            val providerMappings = matchedItems.map { it.providerMappings!![0] }
-
-            this.copy(
-                itemId = libraryId,
-                provider = "library",
-                providerMappings = providerMappings,
-            )
-        } else {
-            this
-        }
-    }
-
-    fun Collection<ServerMediaItem>.enrichLibraryItems(): List<ServerMediaItem> {
-        return this.map { it.enrichLibraryItems() }
+        mediaItemStore.matchItem(libraryItem, providerItem)
     }
 
     fun addPlayers(vararg players: ServerPlayer) {
@@ -805,42 +716,21 @@ class FakeServiceClient : ServiceClient {
     private fun findItem(request: Request): ServerMediaItem {
         val itemId = request.getArg("item_id")
         val provider = request.getArg("provider_instance_id_or_domain")
-
-        return if (provider == "library") {
-            val globalId = libraryIds.entries.first { it.value == itemId }.key
-            mediaItems.first { it.globalId() == globalId }
-        } else {
-            mediaItems.first {
-                it.providerMappings?.any { mapping ->
-                    (mapping.providerInstance == provider || mapping.providerDomain == provider) && mapping.itemId == itemId
-                } ?: false
-            }
-        }
+        return mediaItemStore.getItem(itemId, provider)
     }
 
     private fun filterLibrary(
         request: Request,
         mediaType: MediaType,
     ): List<ServerMediaItem> {
-        return mediaItems.dropNotInLibrary().filter { it.mediaType == mediaType.serverValue }
-            .filter {
-                val nameMatches = it.name.contains(request.getArg("search"), ignoreCase = true)
-                val favoriteMatches = if (request.getArgOrNull("favorite") == "true") {
-                    it.favorite ?: false
-                } else {
-                    true
-                }
-
-                nameMatches && favoriteMatches
-            }
-    }
-
-    fun ServerMediaItem.getAlbumTracks(): List<ServerMediaItem> {
-        return mediaItems.filter { it.album == this }
-    }
-
-    fun ServerMediaItem.getPlaylistTracks(): List<ServerMediaItem> {
-        return mediaItems.filter { playlistItems[this.itemId]?.contains(it.itemId) ?: false }
+        val query = request.getArgOrNull("search")
+        val favoritesOnly = request.getArgOrNull("favorite") == "true"
+        return mediaItemStore.query(
+            query = query,
+            mediaType = mediaType,
+            inLibraryOnly = true,
+            favoritesOnly = favoritesOnly,
+        )
     }
 
     fun getQueueForPlayer(player: ServerPlayer): List<ServerMediaItem> {
@@ -848,7 +738,7 @@ class FakeServiceClient : ServiceClient {
     }
 
     fun setPlaylist(playlist: ServerMediaItem, vararg tracks: ServerMediaItem) {
-        playlistItems[playlist.itemId] = tracks.map { it.itemId }
+        mediaItemStore.setPlaylist(playlist, *tracks)
     }
 
     fun setRequestErrors(reachable: Boolean) {
@@ -934,6 +824,14 @@ class FakeServiceClient : ServiceClient {
         playerAudioFormats[player.playerId] = audioFormat
     }
 
+    private fun ServerMediaItem.enrichLibraryItem(): ServerMediaItem {
+        return mediaItemStore.enrichLibraryItem(this)
+    }
+
+    private fun List<ServerMediaItem>.enrichLibraryItems(): List<ServerMediaItem> {
+        return this.map { mediaItemStore.enrichLibraryItem(it) }
+    }
+
     enum class LegacyVersion {
         V2_8,
         V2_9,
@@ -961,9 +859,4 @@ private fun Request.getArg(arg: String): String {
 
 private fun Request.getArgOrNull(arg: String): String? {
     return (args!![arg] as JsonPrimitive?)?.content
-}
-
-private fun ServerMediaItem.globalId(): Pair<String, String> {
-    val providerMapping = this.providerMappings!![0]
-    return Pair(providerMapping.providerInstance, providerMapping.itemId)
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -153,6 +153,15 @@ class FakeServiceClient : ServiceClient {
                                     .filter { it.mediaType == MediaType.TRACK.serverValue }
                                     .forResponse(),
                             ),
+                            ServerMediaItem(
+                                itemId = "recently_added_artists",
+                                provider = "library",
+                                name = "Recently added artists",
+                                mediaType = MediaType.FOLDER.serverValue,
+                                items = mediaItems
+                                    .filter { it.mediaType == MediaType.ARTIST.serverValue }
+                                    .forResponse(),
+                            ),
                         ),
                     ),
                 )
@@ -233,6 +242,20 @@ class FakeServiceClient : ServiceClient {
                     answer(
                         request = request,
                         result = findItem(request).forResponse(),
+                    ),
+                )
+            }
+
+            APICommands.MUSIC_ARTISTS_ARTIST_ALBUMS -> {
+                val artist = findItem(request)
+
+                Result.success(
+                    answer(
+                        request = request,
+                        result = mediaItems
+                            .filter { it.mediaType == MediaType.ALBUM.serverValue }
+                            .filter { it.artists?.contains(artist) ?: false }
+                            .forResponse(),
                     ),
                 )
             }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -246,15 +246,21 @@ class FakeServiceClient : ServiceClient {
             APICommands.MUSIC_ARTISTS_ARTIST_ALBUMS -> {
                 val artist = findItem(request)
 
+                val albums = if (request.getArg("provider_instance_id_or_domain") == "library") {
+                    mediaItems.dropNotInLibrary()
+                } else {
+                    mediaItems
+                }.filter { it.mediaType == MediaType.ALBUM.serverValue }
+                    .filter { it.artists?.contains(artist) ?: false }
+
                 Result.success(
                     answer(
                         request = request,
                         result = if (request.getArg("provider_instance_id_or_domain") == "library") {
-                            mediaItems.dropNotInLibrary().enrichLibraryItems()
+                            albums.enrichLibraryItems()
                         } else {
-                            mediaItems
-                        }.filter { it.mediaType == MediaType.ALBUM.serverValue }
-                            .filter { it.artists?.contains(artist) ?: false },
+                            albums
+                        },
                     ),
                 )
             }
@@ -741,8 +747,6 @@ class FakeServiceClient : ServiceClient {
             this.copy(
                 itemId = libraryId,
                 provider = "library",
-                album = album.let { it?.enrichLibraryItems() },
-                artists = artists.let { it?.enrichLibraryItems() },
             )
         } else {
             this

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -737,16 +737,33 @@ class FakeServiceClient : ServiceClient {
         }
     }
 
+    fun matchItem(libraryItem: ServerMediaItem, providerItem: ServerMediaItem) {
+        val libraryId = libraryIds[libraryItem.globalId()]
+        require(libraryId != null) { "Can't add match for item not in library!" }
+        libraryIds[providerItem.globalId()] = libraryId
+    }
+
     fun Set<ServerMediaItem>.dropNotInLibrary(): List<ServerMediaItem> {
         return this.filter { libraryIds.containsKey(it.globalId()) }
     }
 
     fun ServerMediaItem.enrichLibraryItems(): ServerMediaItem {
         val libraryId = libraryIds[this.globalId()]
+
         return if (libraryId != null) {
+            val matchedItems = libraryIds.entries
+                .filter { it.value == libraryId }
+                .map { it.key }
+                .flatMap { globalId ->
+                    mediaItems.filter { it.globalId() == globalId }
+                }
+
+            val providerMappings = matchedItems.map { it.providerMappings!![0] }
+
             this.copy(
                 itemId = libraryId,
                 provider = "library",
+                providerMappings = providerMappings,
             )
         } else {
             this

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -252,8 +252,11 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = mediaItems
-                            .filter { it.mediaType == MediaType.ALBUM.serverValue }
+                        result = if (request.getArg("provider_instance_id_or_domain") == "library") {
+                            mediaItems.dropNotInLibrary()
+                        } else {
+                            mediaItems
+                        }.filter { it.mediaType == MediaType.ALBUM.serverValue }
                             .filter { it.artists?.contains(artist) ?: false }
                             .forResponse(),
                     ),
@@ -708,7 +711,11 @@ class FakeServiceClient : ServiceClient {
         when (MediaType.fromServer(item.mediaType)) {
             MediaType.ALBUM -> {
                 item.getAlbumTracks().forEach {
-                    libraryIds[it.globalId()] = uniqueIdGenerator.nextInt().toString()
+                    addToLibrary(it)
+                }
+
+                item.artists?.forEach {
+                    addToLibrary(it)
                 }
             }
 

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -127,7 +127,7 @@ class FakeServiceClient : ServiceClient {
 
             APICommands.MUSIC_ITEM_BY_URI -> {
                 val item = mediaItems.find { it.uri == request.getArg("uri") }!!
-                Result.success(answer(request = request, result = item))
+                Result.success(answer(request = request, result = item.enrichLibraryItems()))
             }
 
             APICommands.MUSIC_RECOMMENDATIONS -> {
@@ -141,8 +141,7 @@ class FakeServiceClient : ServiceClient {
                                 name = "Recently added albums",
                                 mediaType = MediaType.FOLDER.serverValue,
                                 items = mediaItems
-                                    .filter { it.mediaType == MediaType.ALBUM.serverValue }
-                                    .forResponse(),
+                                    .filter { it.mediaType == MediaType.ALBUM.serverValue },
                             ),
                             ServerMediaItem(
                                 itemId = "recently_added_tracks",
@@ -150,8 +149,7 @@ class FakeServiceClient : ServiceClient {
                                 name = "Recently added tracks",
                                 mediaType = MediaType.FOLDER.serverValue,
                                 items = mediaItems
-                                    .filter { it.mediaType == MediaType.TRACK.serverValue }
-                                    .forResponse(),
+                                    .filter { it.mediaType == MediaType.TRACK.serverValue },
                             ),
                             ServerMediaItem(
                                 itemId = "recently_added_artists",
@@ -159,8 +157,7 @@ class FakeServiceClient : ServiceClient {
                                 name = "Recently added artists",
                                 mediaType = MediaType.FOLDER.serverValue,
                                 items = mediaItems
-                                    .filter { it.mediaType == MediaType.ARTIST.serverValue }
-                                    .forResponse(),
+                                    .filter { it.mediaType == MediaType.ARTIST.serverValue },
                             ),
                         ),
                     ),
@@ -185,7 +182,7 @@ class FakeServiceClient : ServiceClient {
                 val resultsForType: (MediaType) -> List<ServerMediaItem> = {
                     val mediaTypeServerValue = it.serverValue
                     if (mediaTypes.isEmpty() || mediaTypes.contains(mediaTypeServerValue)) {
-                        results.filter { it.mediaType == mediaTypeServerValue }.forResponse()
+                        results.filter { it.mediaType == mediaTypeServerValue }.enrichLibraryItems()
                     } else {
                         emptyList()
                     }
@@ -212,7 +209,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = findItem(request).forResponse(),
+                        result = findItem(request).enrichLibraryItems(),
                     ),
                 )
             }
@@ -223,7 +220,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = album.getAlbumTracks().forResponse(),
+                        result = album.getAlbumTracks(),
                     ),
                 )
             }
@@ -232,7 +229,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = filterLibrary(request, MediaType.ALBUM).forResponse(),
+                        result = filterLibrary(request, MediaType.ALBUM).enrichLibraryItems(),
                     ),
                 )
             }
@@ -241,7 +238,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = findItem(request).forResponse(),
+                        result = findItem(request).enrichLibraryItems(),
                     ),
                 )
             }
@@ -253,12 +250,11 @@ class FakeServiceClient : ServiceClient {
                     answer(
                         request = request,
                         result = if (request.getArg("provider_instance_id_or_domain") == "library") {
-                            mediaItems.dropNotInLibrary()
+                            mediaItems.dropNotInLibrary().enrichLibraryItems()
                         } else {
                             mediaItems
                         }.filter { it.mediaType == MediaType.ALBUM.serverValue }
-                            .filter { it.artists?.contains(artist) ?: false }
-                            .forResponse(),
+                            .filter { it.artists?.contains(artist) ?: false },
                     ),
                 )
             }
@@ -267,7 +263,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = filterLibrary(request, MediaType.ARTIST).forResponse(),
+                        result = filterLibrary(request, MediaType.ARTIST).enrichLibraryItems(),
                     ),
                 )
             }
@@ -276,7 +272,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = filterLibrary(request, MediaType.PLAYLIST).forResponse(),
+                        result = filterLibrary(request, MediaType.PLAYLIST).enrichLibraryItems(),
                     ),
                 )
             }
@@ -285,7 +281,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = findItem(request).forResponse(),
+                        result = findItem(request).enrichLibraryItems(),
                     ),
                 )
             }
@@ -296,7 +292,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = playlist.getPlaylistTracks().forResponse(),
+                        result = playlist.getPlaylistTracks(),
                     ),
                 )
             }
@@ -310,7 +306,7 @@ class FakeServiceClient : ServiceClient {
                             .filter {
                                 it.mediaType == MediaType.TRACK.serverValue
                             }
-                            .forResponse(),
+                            .enrichLibraryItems(),
                     ),
                 )
             }
@@ -319,7 +315,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = filterLibrary(request, MediaType.AUDIOBOOK).forResponse(),
+                        result = filterLibrary(request, MediaType.AUDIOBOOK).enrichLibraryItems(),
                     ),
                 )
             }
@@ -328,7 +324,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = filterLibrary(request, MediaType.PODCAST).forResponse(),
+                        result = filterLibrary(request, MediaType.PODCAST).enrichLibraryItems(),
                     ),
                 )
             }
@@ -337,7 +333,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = filterLibrary(request, MediaType.RADIO).forResponse(),
+                        result = filterLibrary(request, MediaType.RADIO).enrichLibraryItems(),
                     ),
                 )
             }
@@ -346,7 +342,7 @@ class FakeServiceClient : ServiceClient {
                 Result.success(
                     answer(
                         request = request,
-                        result = filterLibrary(request, MediaType.GENRE).forResponse(),
+                        result = filterLibrary(request, MediaType.GENRE).enrichLibraryItems(),
                     ),
                 )
             }
@@ -739,22 +735,22 @@ class FakeServiceClient : ServiceClient {
         return this.filter { libraryIds.containsKey(it.globalId()) }
     }
 
-    fun ServerMediaItem.forResponse(): ServerMediaItem {
+    fun ServerMediaItem.enrichLibraryItems(): ServerMediaItem {
         val libraryId = libraryIds[this.globalId()]
         return if (libraryId != null) {
             this.copy(
                 itemId = libraryId,
                 provider = "library",
-                album = album.let { it?.forResponse() },
-                artists = artists.let { it?.forResponse() },
+                album = album.let { it?.enrichLibraryItems() },
+                artists = artists.let { it?.enrichLibraryItems() },
             )
         } else {
             this
         }
     }
 
-    fun Collection<ServerMediaItem>.forResponse(): List<ServerMediaItem> {
-        return this.map { it.forResponse() }
+    fun Collection<ServerMediaItem>.enrichLibraryItems(): List<ServerMediaItem> {
+        return this.map { it.enrichLibraryItems() }
     }
 
     fun addPlayers(vararg players: ServerPlayer) {

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/ServerMediaItemFixtures.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/ServerMediaItemFixtures.kt
@@ -36,17 +36,18 @@ object ServerMediaItemFixtures {
     fun artist(
         itemId: String = uniqueIdGenerator.nextInt().toString(),
         name: String = "Artist $itemId",
+        provider: Pair<String, String> = Pair(DEFAULT_PROVIDER_DOMAIN, DEFAULT_PROVIDER_INSTANCE),
     ): ServerMediaItem {
         return ServerMediaItem(
             itemId = itemId,
-            provider = DEFAULT_PROVIDER_DOMAIN,
+            provider = provider.first,
             name = name,
             mediaType = MediaType.ARTIST.serverValue,
             providerMappings = listOf(
                 ProviderMapping(
                     itemId = itemId,
-                    providerDomain = DEFAULT_PROVIDER_DOMAIN,
-                    providerInstance = DEFAULT_PROVIDER_INSTANCE,
+                    providerDomain = provider.first,
+                    providerInstance = provider.second,
                 ),
             ),
         )

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/ServerMediaItemFixtures.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/ServerMediaItemFixtures.kt
@@ -1,6 +1,7 @@
 package io.music_assistant.client.support
 
 import io.music_assistant.client.data.model.client.MediaType
+import io.music_assistant.client.data.model.server.ProviderMapping
 import io.music_assistant.client.data.model.server.ServerMediaItem
 import io.music_assistant.client.utils.UniqueIdGenerator
 
@@ -15,13 +16,20 @@ object ServerMediaItemFixtures {
     ): ServerMediaItem {
         return ServerMediaItem(
             itemId = itemId,
-            provider = "blah",
+            provider = DEFAULT_PROVIDER_DOMAIN,
             name = name,
             mediaType = MediaType.ALBUM.serverValue,
             artists = listOf(artist),
             uri = "http://example.com/album/$itemId",
             isPlayable = true,
             favorite = favorite,
+            providerMappings = listOf(
+                ProviderMapping(
+                    itemId = itemId,
+                    providerDomain = DEFAULT_PROVIDER_DOMAIN,
+                    providerInstance = DEFAULT_PROVIDER_INSTANCE,
+                ),
+            ),
         )
     }
 
@@ -31,9 +39,16 @@ object ServerMediaItemFixtures {
     ): ServerMediaItem {
         return ServerMediaItem(
             itemId = itemId,
-            provider = "blah",
+            provider = DEFAULT_PROVIDER_DOMAIN,
             name = name,
             mediaType = MediaType.ARTIST.serverValue,
+            providerMappings = listOf(
+                ProviderMapping(
+                    itemId = itemId,
+                    providerDomain = DEFAULT_PROVIDER_DOMAIN,
+                    providerInstance = DEFAULT_PROVIDER_INSTANCE,
+                ),
+            ),
         )
     }
 
@@ -45,13 +60,20 @@ object ServerMediaItemFixtures {
     ): ServerMediaItem {
         return ServerMediaItem(
             itemId = itemId,
-            provider = "blah",
+            provider = DEFAULT_PROVIDER_DOMAIN,
             name = name,
             mediaType = MediaType.TRACK.serverValue,
             artists = artists,
             album = album,
             uri = "http://example.com/track/$itemId",
             isPlayable = true,
+            providerMappings = listOf(
+                ProviderMapping(
+                    itemId = itemId,
+                    providerDomain = DEFAULT_PROVIDER_DOMAIN,
+                    providerInstance = DEFAULT_PROVIDER_INSTANCE,
+                ),
+            ),
         )
     }
 
@@ -61,11 +83,18 @@ object ServerMediaItemFixtures {
     ): ServerMediaItem {
         return ServerMediaItem(
             itemId = itemId,
-            provider = "blah",
+            provider = DEFAULT_PROVIDER_DOMAIN,
             name = name,
             mediaType = MediaType.PLAYLIST.serverValue,
             isPlayable = true,
             uri = "http://example.com/playlist/$itemId",
+            providerMappings = listOf(
+                ProviderMapping(
+                    itemId = itemId,
+                    providerDomain = DEFAULT_PROVIDER_DOMAIN,
+                    providerInstance = DEFAULT_PROVIDER_INSTANCE,
+                ),
+            ),
         )
     }
 
@@ -75,10 +104,17 @@ object ServerMediaItemFixtures {
     ): ServerMediaItem {
         return ServerMediaItem(
             itemId = itemId,
-            provider = "blah",
+            provider = DEFAULT_PROVIDER_DOMAIN,
             name = name,
             mediaType = MediaType.AUDIOBOOK.serverValue,
             isPlayable = true,
+            providerMappings = listOf(
+                ProviderMapping(
+                    itemId = itemId,
+                    providerDomain = DEFAULT_PROVIDER_DOMAIN,
+                    providerInstance = DEFAULT_PROVIDER_INSTANCE,
+                ),
+            ),
         )
     }
 
@@ -88,10 +124,17 @@ object ServerMediaItemFixtures {
     ): ServerMediaItem {
         return ServerMediaItem(
             itemId = itemId,
-            provider = "blah",
+            provider = DEFAULT_PROVIDER_DOMAIN,
             name = name,
             mediaType = MediaType.PODCAST.serverValue,
             isPlayable = true,
+            providerMappings = listOf(
+                ProviderMapping(
+                    itemId = itemId,
+                    providerDomain = DEFAULT_PROVIDER_DOMAIN,
+                    providerInstance = DEFAULT_PROVIDER_INSTANCE,
+                ),
+            ),
         )
     }
 
@@ -101,10 +144,17 @@ object ServerMediaItemFixtures {
     ): ServerMediaItem {
         return ServerMediaItem(
             itemId = itemId,
-            provider = "blah",
+            provider = DEFAULT_PROVIDER_DOMAIN,
             name = name,
             mediaType = MediaType.RADIO.serverValue,
             isPlayable = true,
+            providerMappings = listOf(
+                ProviderMapping(
+                    itemId = itemId,
+                    providerDomain = DEFAULT_PROVIDER_DOMAIN,
+                    providerInstance = DEFAULT_PROVIDER_INSTANCE,
+                ),
+            ),
         )
     }
 
@@ -114,9 +164,19 @@ object ServerMediaItemFixtures {
     ): ServerMediaItem {
         return ServerMediaItem(
             itemId = itemId,
-            provider = "blah",
+            provider = DEFAULT_PROVIDER_DOMAIN,
             name = name,
             mediaType = MediaType.GENRE.serverValue,
+            providerMappings = listOf(
+                ProviderMapping(
+                    itemId = itemId,
+                    providerDomain = DEFAULT_PROVIDER_DOMAIN,
+                    providerInstance = DEFAULT_PROVIDER_INSTANCE,
+                ),
+            ),
         )
     }
+
+    private const val DEFAULT_PROVIDER_DOMAIN = "test-domain"
+    private const val DEFAULT_PROVIDER_INSTANCE = "test-instance"
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/ServerMediaItemFixtures.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/ServerMediaItemFixtures.kt
@@ -13,10 +13,11 @@ object ServerMediaItemFixtures {
         name: String = "Album $itemId",
         artist: ServerMediaItem = artist(),
         favorite: Boolean? = null,
+        provider: Pair<String, String> = Pair(DEFAULT_PROVIDER_DOMAIN, DEFAULT_PROVIDER_INSTANCE),
     ): ServerMediaItem {
         return ServerMediaItem(
             itemId = itemId,
-            provider = DEFAULT_PROVIDER_DOMAIN,
+            provider = provider.first,
             name = name,
             mediaType = MediaType.ALBUM.serverValue,
             artists = listOf(artist),
@@ -26,8 +27,8 @@ object ServerMediaItemFixtures {
             providerMappings = listOf(
                 ProviderMapping(
                     itemId = itemId,
-                    providerDomain = DEFAULT_PROVIDER_DOMAIN,
-                    providerInstance = DEFAULT_PROVIDER_INSTANCE,
+                    providerDomain = provider.first,
+                    providerInstance = provider.second,
                 ),
             ),
         )
@@ -176,6 +177,13 @@ object ServerMediaItemFixtures {
                 ),
             ),
         )
+    }
+
+    fun provider(
+        domain: String = DEFAULT_PROVIDER_DOMAIN,
+        instance: String = DEFAULT_PROVIDER_INSTANCE,
+    ): Pair<String, String> {
+        return Pair(domain, instance)
     }
 
     private const val DEFAULT_PROVIDER_DOMAIN = "test-domain"

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/HomePage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/HomePage.kt
@@ -52,7 +52,7 @@ class HomePage(composeTestRule: ComposeTestRule) : ComposePage(composeTestRule) 
     }
 
     fun assertShortcutDisplayed(item: ServerMediaItem): HomePage {
-        assertMediaDisplayed(item.name, withinTag = HomeScreenSemantics.SHORTCUTS_ROW_TAG)
+        assertMediaDisplayed(item, withinTag = HomeScreenSemantics.SHORTCUTS_ROW_TAG)
         return this
     }
 

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/HomePage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/HomePage.kt
@@ -29,8 +29,8 @@ class HomePage(composeTestRule: ComposeTestRule) : ComposePage(composeTestRule) 
         )
     }
 
-    fun clickOnMedia(item: ServerMediaItem): ItemPage {
-        return clickOnMedia(item, Res.string.nav_home.get())
+    fun clickOnMedia(item: ServerMediaItem, withinTag: String? = null): ItemPage {
+        return clickOnMedia(item, Res.string.nav_home.get(), withinTag)
     }
 
     fun refresh(): HomePage {

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ItemPage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ItemPage.kt
@@ -12,6 +12,7 @@ import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.server.ServerMediaItem
 import io.music_assistant.client.support.get
 import io.music_assistant.client.support.isTab
+import io.music_assistant.client.ui.compose.item.ItemDetailsScreenSemantics
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.action_go_to_artist
 import musicassistantclient.composeapp.generated.resources.action_play_now
@@ -100,5 +101,9 @@ class ItemPage(
     fun clickPlay(): ItemPage {
         composeTestRule.onNodeWithText(Res.string.action_play_now.get()).performClick()
         return this
+    }
+
+    fun assertMediaDisplayed(item: ServerMediaItem): ItemPage {
+        return assertMediaDisplayed(item, inScrollable = ItemDetailsScreenSemantics.LIST_TAG)
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ItemPage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ItemPage.kt
@@ -75,6 +75,7 @@ class ItemPage(
                 composeTestRule.onNode(isTab(Res.string.media_type_tracks.get()))
                     .assertIsDisplayed()
             }
+
             MediaType.RADIO -> TODO()
             MediaType.AUDIOBOOK -> TODO()
             MediaType.PODCAST -> TODO()
@@ -103,7 +104,11 @@ class ItemPage(
         return this
     }
 
-    fun assertMediaDisplayed(item: ServerMediaItem): ItemPage {
-        return assertMediaDisplayed(item, inScrollable = ItemDetailsScreenSemantics.LIST_TAG)
+    fun assertMediaDisplayed(item: ServerMediaItem, provider: String? = null): ItemPage {
+        return assertMediaDisplayed(
+            item,
+            inScrollable = ItemDetailsScreenSemantics.LIST_TAG,
+            provider = provider,
+        )
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ItemPage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ItemPage.kt
@@ -3,6 +3,7 @@ package io.music_assistant.client.support.pages
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.hasTextExactly
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -40,7 +41,7 @@ class ItemPage(
     )
 
     override fun assert() {
-        composeTestRule.onNodeWithText(name).assertIsDisplayed()
+        composeTestRule.onNode(hasTextExactly(name)).assertIsDisplayed()
         composeTestRule.onNodeWithText(Res.string.action_play_now.get()).assertIsDisplayed()
             .assertHasClickAction()
         assertNavBar(

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/LibraryListPage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/LibraryListPage.kt
@@ -21,7 +21,7 @@ import musicassistantclient.composeapp.generated.resources.nav_search
 import musicassistantclient.composeapp.generated.resources.nav_settings
 import musicassistantclient.composeapp.generated.resources.search_query_label
 
-class ItemListPage(private val type: String, composeTestRule: ComposeTestRule) :
+class LibraryListPage(private val type: String, composeTestRule: ComposeTestRule) :
     ComposePage(composeTestRule) {
     override fun assert() {
         composeTestRule.onAllNodesWithText(type).onFirst().assertIsDisplayed()
@@ -37,10 +37,14 @@ class ItemListPage(private val type: String, composeTestRule: ComposeTestRule) :
     }
 
     fun clickOnMedia(item: ServerMediaItem): ItemPage {
-        return clickOnMedia(item, Res.string.nav_library.get())
+        return clickOnMedia(
+            item,
+            Res.string.nav_library.get(),
+            provider = ServerMediaItem.LIBRARY_PROVIDER,
+        )
     }
 
-    fun search(query: String): ItemListPage {
+    fun search(query: String): LibraryListPage {
         composeTestRule.onNodeWithText(Res.string.search_query_label.get())
             .assertIsDisplayed()
             .performTextInput(query)
@@ -50,12 +54,13 @@ class ItemListPage(private val type: String, composeTestRule: ComposeTestRule) :
         return this
     }
 
-    fun openSearch(): ItemListPage {
-        composeTestRule.onNodeWithContentDescription(Res.string.library_quick_search.get()).performClick()
+    fun openSearch(): LibraryListPage {
+        composeTestRule.onNodeWithContentDescription(Res.string.library_quick_search.get())
+            .performClick()
         return this
     }
 
-    fun assertNoItems(): ItemListPage {
+    fun assertNoItems(): LibraryListPage {
         composeTestRule.onNodeWithText(Res.string.library_empty.get()).assertIsDisplayed()
         return this
     }
@@ -65,5 +70,13 @@ class ItemListPage(private val type: String, composeTestRule: ComposeTestRule) :
             .assertIsDisplayed()
             .performClick()
         return SearchPage(composeTestRule, query = query).assertOnPage()
+    }
+
+    fun assertMediaNotDisplayed(item: ServerMediaItem): LibraryListPage {
+        return assertMediaNotDisplayed(item, provider = ServerMediaItem.LIBRARY_PROVIDER)
+    }
+
+    fun assertMediaDisplayed(item: ServerMediaItem): LibraryListPage {
+        return assertMediaDisplayed(item, provider = ServerMediaItem.LIBRARY_PROVIDER)
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/LibraryPage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/LibraryPage.kt
@@ -34,42 +34,42 @@ class LibraryPage(composeTestRule: ComposeTestRule) :
         )
     }
 
-    fun clickAlbums(): ItemListPage {
+    fun clickAlbums(): LibraryListPage {
         return clickType(Res.string.media_type_albums.get())
     }
 
-    fun clickArtists(): ItemListPage {
+    fun clickArtists(): LibraryListPage {
         return clickType(Res.string.media_type_artists.get())
     }
 
-    fun clickPlaylists(): ItemListPage {
+    fun clickPlaylists(): LibraryListPage {
         return clickType(Res.string.media_type_playlists.get())
     }
 
-    fun clickTracks(): ItemListPage {
+    fun clickTracks(): LibraryListPage {
         return clickType(Res.string.media_type_tracks.get())
     }
 
-    fun clickAudiobooks(): ItemListPage {
+    fun clickAudiobooks(): LibraryListPage {
         return clickType(Res.string.media_type_audiobooks.get())
     }
 
-    fun clickPodcasts(): ItemListPage {
+    fun clickPodcasts(): LibraryListPage {
         return clickType(Res.string.media_type_podcasts.get())
     }
 
-    fun clickRadio(): ItemListPage {
+    fun clickRadio(): LibraryListPage {
         return clickType(Res.string.media_type_radio.get())
     }
 
-    fun clickGenres(): ItemListPage {
+    fun clickGenres(): LibraryListPage {
         val type = Res.string.media_type_genres.get()
         composeTestRule.onNodeWithText(type).onParent().performScrollToIndex(7)
         return clickType(type)
     }
 
-    private fun clickType(type: String): ItemListPage {
+    private fun clickType(type: String): LibraryListPage {
         composeTestRule.onNodeWithText(type).performClick()
-        return ItemListPage(type, composeTestRule).assertOnPage()
+        return LibraryListPage(type, composeTestRule).assertOnPage()
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SearchPage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SearchPage.kt
@@ -1,7 +1,6 @@
 package io.music_assistant.client.support.pages
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -46,16 +45,6 @@ class SearchPage(composeTestRule: ComposeTestRule, val query: String? = null) : 
         composeTestRule.onNodeWithText(query)
             .performImeAction()
 
-        return this
-    }
-
-    fun assertResult(result: String): SearchPage {
-        composeTestRule.onNodeWithText(result).assertIsDisplayed()
-        return this
-    }
-
-    fun assertNoResult(result: String): SearchPage {
-        composeTestRule.onNodeWithText(result).assertIsNotDisplayed()
         return this
     }
 

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
@@ -39,28 +39,15 @@ fun ComposePage.clickOnMedia(
     navigationItem: String,
     withinTag: String? = null,
 ): ItemPage {
-    return clickOnMedia(
-        serverMediaItem.name,
-        MediaType.fromServer(serverMediaItem.mediaType) ?: MediaType.UNKNOWN,
-        navigationItem,
-        withinTag,
-    )
-}
-
-fun ComposePage.clickOnMedia(
-    name: String,
-    type: MediaType,
-    navigationItem: String,
-    withinTag: String? = null,
-): ItemPage {
     val matcher = if (withinTag != null) {
-        withinTag(withinTag).and(hasText(name))
+        withinTag(withinTag).and(hasText(serverMediaItem.name))
     } else {
-        hasText(name)
+        hasText(serverMediaItem.name)
     }
 
     composeTestRule.onNode(matcher).assertIsDisplayed().performClick()
-    return ItemPage(name, type, navigationItem, composeTestRule).assertOnPage()
+    val type = MediaType.fromServer(serverMediaItem.mediaType) ?: MediaType.UNKNOWN
+    return ItemPage(serverMediaItem.name, type, navigationItem, composeTestRule).assertOnPage()
 }
 
 fun <T : ComposePage> T.clickItemOption(serverMediaItem: ServerMediaItem, action: String): T {

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.assertIsSelected
-import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -25,6 +25,7 @@ import musicassistantclient.composeapp.generated.resources.action_pause
 import musicassistantclient.composeapp.generated.resources.action_play
 import musicassistantclient.composeapp.generated.resources.banner_no_network
 import musicassistantclient.composeapp.generated.resources.banner_reconnecting
+import musicassistantclient.composeapp.generated.resources.cd_album_item
 import musicassistantclient.composeapp.generated.resources.cd_current_player
 import musicassistantclient.composeapp.generated.resources.cd_filter
 import musicassistantclient.composeapp.generated.resources.cd_playing
@@ -49,7 +50,7 @@ fun ComposePage.clickOnMedia(
 }
 
 fun <T : ComposePage> T.clickItemOption(serverMediaItem: ServerMediaItem, action: String): T {
-    composeTestRule.onNodeWithText(serverMediaItem.name).performTouchInput { longClick() }
+    composeTestRule.onNode(mediaItemMatcher(serverMediaItem)).performTouchInput { longClick() }
     composeTestRule.onNodeWithText(action).performClick()
     return this
 }
@@ -109,13 +110,7 @@ fun <T : ComposePage> T.assertMediaNotDisplayed(serverMediaItem: ServerMediaItem
 }
 
 fun <T : ComposePage> T.playMedia(item: ServerMediaItem, withinTag: String? = null): T {
-    val matcher = if (withinTag != null) {
-        withinTag(withinTag).and(hasText(item.name))
-    } else {
-        hasText(item.name)
-    }
-
-    composeTestRule.onNode(matcher).performClick()
+    composeTestRule.onNode(mediaItemMatcher(item, withinTag)).performClick()
     return this
 }
 
@@ -202,9 +197,15 @@ fun <T : ComposePage> T.enableFilter(action: (FilterSheetPage) -> Unit): T {
 }
 
 private fun mediaItemMatcher(item: ServerMediaItem, withinTag: String? = null): SemanticsMatcher {
-    return if (withinTag != null) {
-        withinTag(withinTag).and(hasText(item.name))
+    val matcher = if (MediaType.fromServer(item.mediaType) == MediaType.ALBUM) {
+        hasContentDescription(Res.string.cd_album_item.get(item.name))
     } else {
-        hasText(item.name)
+        hasContentDescription(item.name)
+    }
+
+    return if (withinTag != null) {
+        withinTag(withinTag).and(matcher)
+    } else {
+        matcher
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
@@ -41,8 +41,9 @@ fun ComposePage.clickOnMedia(
     serverMediaItem: ServerMediaItem,
     navigationItem: String,
     withinTag: String? = null,
+    provider: String? = null,
 ): ItemPage {
-    composeTestRule.onNode(mediaItemMatcher(serverMediaItem, withinTag))
+    composeTestRule.onNode(mediaItemMatcher(serverMediaItem, withinTag, provider))
         .assertIsDisplayed()
         .performClick()
 
@@ -104,8 +105,9 @@ fun <T : ComposePage> T.assertMediaDisplayed(
     serverMediaItem: ServerMediaItem,
     withinTag: String? = null,
     inScrollable: String? = null,
+    provider: String? = null,
 ): T {
-    val matcher = mediaItemMatcher(serverMediaItem, withinTag)
+    val matcher = mediaItemMatcher(serverMediaItem, withinTag, provider)
     if (inScrollable != null) {
         composeTestRule.inScrollable(inScrollable) { onNode(matcher).assertIsDisplayed() }
     } else {
@@ -115,8 +117,12 @@ fun <T : ComposePage> T.assertMediaDisplayed(
     return this
 }
 
-fun <T : ComposePage> T.assertMediaNotDisplayed(serverMediaItem: ServerMediaItem): T {
-    composeTestRule.onNodeWithText(serverMediaItem.name).assertIsNotDisplayed()
+fun <T : ComposePage> T.assertMediaNotDisplayed(
+    serverMediaItem: ServerMediaItem,
+    provider: String? = null,
+): T {
+    composeTestRule.onNode(mediaItemMatcher(serverMediaItem, provider = provider))
+        .assertIsNotDisplayed()
     return this
 }
 
@@ -207,9 +213,17 @@ fun <T : ComposePage> T.enableFilter(action: (FilterSheetPage) -> Unit): T {
     return this
 }
 
-private fun mediaItemMatcher(item: ServerMediaItem, withinTag: String? = null): SemanticsMatcher {
+private fun mediaItemMatcher(
+    item: ServerMediaItem,
+    withinTag: String? = null,
+    provider: String? = null,
+): SemanticsMatcher {
     val matcher = if (MediaType.fromServer(item.mediaType) == MediaType.ALBUM) {
-        hasContentDescription(Res.string.cd_album_item.get(item.name))
+        if (provider != null) {
+            hasContentDescription(Res.string.cd_album_item.get(item.name, provider))
+        } else {
+            hasContentDescription(Res.string.cd_album_item.get(item.name, item.provider))
+        }
     } else {
         hasContentDescription(item.name)
     }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
@@ -113,6 +113,10 @@ fun ComposePage.clickSettings(): SettingsPage {
     return SettingsPage(composeTestRule).assertOnPage()
 }
 
+fun <T : ComposePage> T.assertMediaDisplayed(serverMediaItem: ServerMediaItem, withinTag: String? = null): T {
+    return assertMediaDisplayed(serverMediaItem.name, withinTag)
+}
+
 fun <T : ComposePage> T.assertMediaDisplayed(name: String, withinTag: String? = null): T {
     val matcher = if (withinTag != null) {
         withinTag(withinTag).and(hasText(name))

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
@@ -20,6 +20,7 @@ import io.music_assistant.client.support.get
 import io.music_assistant.client.support.isTab
 import io.music_assistant.client.support.withinTag
 import io.music_assistant.client.ui.compose.home.FloatingBarSemantics
+import io.music_assistant.client.ui.compose.support.inScrollable
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.action_pause
 import musicassistantclient.composeapp.generated.resources.action_play
@@ -99,8 +100,18 @@ fun ComposePage.clickSettings(): SettingsPage {
     return SettingsPage(composeTestRule).assertOnPage()
 }
 
-fun <T : ComposePage> T.assertMediaDisplayed(serverMediaItem: ServerMediaItem, withinTag: String? = null): T {
-    composeTestRule.onNode(mediaItemMatcher(serverMediaItem, withinTag)).assertIsDisplayed()
+fun <T : ComposePage> T.assertMediaDisplayed(
+    serverMediaItem: ServerMediaItem,
+    withinTag: String? = null,
+    inScrollable: String? = null,
+): T {
+    val matcher = mediaItemMatcher(serverMediaItem, withinTag)
+    if (inScrollable != null) {
+        composeTestRule.inScrollable(inScrollable) { onNode(matcher).assertIsDisplayed() }
+    } else {
+        composeTestRule.onNode(matcher).assertIsDisplayed()
+    }
+
     return this
 }
 

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
@@ -114,22 +114,18 @@ fun ComposePage.clickSettings(): SettingsPage {
 }
 
 fun <T : ComposePage> T.assertMediaDisplayed(serverMediaItem: ServerMediaItem, withinTag: String? = null): T {
-    return assertMediaDisplayed(serverMediaItem.name, withinTag)
-}
-
-fun <T : ComposePage> T.assertMediaDisplayed(name: String, withinTag: String? = null): T {
     val matcher = if (withinTag != null) {
-        withinTag(withinTag).and(hasText(name))
+        withinTag(withinTag).and(hasText(serverMediaItem.name))
     } else {
-        hasText(name)
+        hasText(serverMediaItem.name)
     }
 
     composeTestRule.onNode(matcher).assertIsDisplayed()
     return this
 }
 
-fun <T : ComposePage> T.assertMediaNotDisplayed(name: String): T {
-    composeTestRule.onNodeWithText(name).assertIsNotDisplayed()
+fun <T : ComposePage> T.assertMediaNotDisplayed(serverMediaItem: ServerMediaItem): T {
+    composeTestRule.onNodeWithText(serverMediaItem.name).assertIsNotDisplayed()
     return this
 }
 

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
@@ -1,5 +1,6 @@
 package io.music_assistant.client.support.pages
 
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
@@ -39,13 +40,10 @@ fun ComposePage.clickOnMedia(
     navigationItem: String,
     withinTag: String? = null,
 ): ItemPage {
-    val matcher = if (withinTag != null) {
-        withinTag(withinTag).and(hasText(serverMediaItem.name))
-    } else {
-        hasText(serverMediaItem.name)
-    }
+    composeTestRule.onNode(mediaItemMatcher(serverMediaItem, withinTag))
+        .assertIsDisplayed()
+        .performClick()
 
-    composeTestRule.onNode(matcher).assertIsDisplayed().performClick()
     val type = MediaType.fromServer(serverMediaItem.mediaType) ?: MediaType.UNKNOWN
     return ItemPage(serverMediaItem.name, type, navigationItem, composeTestRule).assertOnPage()
 }
@@ -101,13 +99,7 @@ fun ComposePage.clickSettings(): SettingsPage {
 }
 
 fun <T : ComposePage> T.assertMediaDisplayed(serverMediaItem: ServerMediaItem, withinTag: String? = null): T {
-    val matcher = if (withinTag != null) {
-        withinTag(withinTag).and(hasText(serverMediaItem.name))
-    } else {
-        hasText(serverMediaItem.name)
-    }
-
-    composeTestRule.onNode(matcher).assertIsDisplayed()
+    composeTestRule.onNode(mediaItemMatcher(serverMediaItem, withinTag)).assertIsDisplayed()
     return this
 }
 
@@ -207,4 +199,12 @@ fun <T : ComposePage> T.enableFilter(action: (FilterSheetPage) -> Unit): T {
     composeTestRule.onNodeWithContentDescription(Res.string.cd_filter.get()).assertIsOn()
 
     return this
+}
+
+private fun mediaItemMatcher(item: ServerMediaItem, withinTag: String? = null): SemanticsMatcher {
+    return if (withinTag != null) {
+        withinTag(withinTag).and(hasText(item.name))
+    } else {
+        hasText(item.name)
+    }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTest.kt
@@ -78,8 +78,23 @@ class ItemDetailsTest {
 
         composeTestRule.onAllNodes(hasText(artist.displayName)).onFirst().assertIsDisplayed()
         composeTestRule.inScrollable("LazyVerticalGrid") {
-            onNode(hasContentDescription(Res.string.cd_album_item.get(albums[0].displayName))).assertIsDisplayed()
-            onNode(hasContentDescription(Res.string.cd_album_item.get(albums[1].displayName))).assertIsDisplayed()
+            onNode(
+                hasContentDescription(
+                    Res.string.cd_album_item.get(
+                        albums[0].displayName,
+                        albums[0].provider,
+                    ),
+                ),
+            ).assertIsDisplayed()
+
+            onNode(
+                hasContentDescription(
+                    Res.string.cd_album_item.get(
+                        albums[1].displayName,
+                        albums[1].provider,
+                    ),
+                ),
+            ).assertIsDisplayed()
         }
     }
 

--- a/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTest.kt
@@ -26,6 +26,7 @@ import io.music_assistant.client.utils.support.MockFunction0
 import io.music_assistant.client.utils.support.MockFunction2
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.action_go_to_artist
+import musicassistantclient.composeapp.generated.resources.cd_album_item
 import musicassistantclient.composeapp.generated.resources.cd_more
 import org.junit.Rule
 import org.junit.Test
@@ -77,8 +78,8 @@ class ItemDetailsTest {
 
         composeTestRule.onAllNodes(hasText(artist.displayName)).onFirst().assertIsDisplayed()
         composeTestRule.inScrollable("LazyVerticalGrid") {
-            onNode(hasText(albums[0].displayName)).assertIsDisplayed()
-            onNode(hasText(albums[1].displayName)).assertIsDisplayed()
+            onNode(hasContentDescription(Res.string.cd_album_item.get(albums[0].displayName))).assertIsDisplayed()
+            onNode(hasContentDescription(Res.string.cd_album_item.get(albums[1].displayName))).assertIsDisplayed()
         }
     }
 
@@ -103,8 +104,8 @@ class ItemDetailsTest {
         composeTestRule.onAllNodes(hasText(album.displayName)).onFirst().assertIsDisplayed()
         composeTestRule.onAllNodes(hasText(artist.displayName)).onFirst().assertIsDisplayed()
         composeTestRule.inScrollable("LazyVerticalGrid") {
-            onNode(hasText(tracks[0].displayName)).assertIsDisplayed()
-            onNode(hasText(tracks[1].displayName)).assertIsDisplayed()
+            onNode(hasContentDescription(tracks[0].displayName)).assertIsDisplayed()
+            onNode(hasContentDescription(tracks[1].displayName)).assertIsDisplayed()
         }
     }
 
@@ -167,10 +168,8 @@ class ItemDetailsTest {
 
         composeTestRule.onAllNodes(hasText(playlist.displayName)).onFirst().assertIsDisplayed()
         composeTestRule.inScrollable("LazyVerticalGrid") {
-            onNode(hasText(tracks[0].displayName)).assertIsDisplayed()
-            onNode(hasText(tracks[0].artists[0].displayName)).assertIsDisplayed()
-            onNode(hasText(tracks[1].displayName)).assertIsDisplayed()
-            onNode(hasText(tracks[1].artists[0].displayName)).assertIsDisplayed()
+            onNode(hasContentDescription(tracks[0].displayName)).assertIsDisplayed()
+            onNode(hasContentDescription(tracks[1].displayName)).assertIsDisplayed()
         }
     }
 
@@ -194,8 +193,8 @@ class ItemDetailsTest {
 
         composeTestRule.onAllNodes(hasText(podcast.displayName)).onFirst().assertIsDisplayed()
         composeTestRule.inScrollable("LazyVerticalGrid") {
-            onNode(hasText(episodes[0].displayName)).assertIsDisplayed()
-            onNode(hasText(episodes[1].displayName)).assertIsDisplayed()
+            onNode(hasContentDescription(episodes[0].displayName)).assertIsDisplayed()
+            onNode(hasContentDescription(episodes[1].displayName)).assertIsDisplayed()
         }
     }
 

--- a/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/support/Scrollable.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/support/Scrollable.kt
@@ -3,7 +3,6 @@ package io.music_assistant.client.ui.compose.support
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.junit4.ComposeTestRule
-import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performScrollToNode
 
@@ -14,6 +13,6 @@ fun ComposeTestRule.inScrollable(scrollableTag: String, block: ScrollableScope.(
 class ScrollableScope(private val composeTestRule: ComposeTestRule, private val scrollableTag: String) {
     fun onNode(matcher: SemanticsMatcher): SemanticsNodeInteraction {
         composeTestRule.onNodeWithTag(scrollableTag).performScrollToNode(matcher)
-        return composeTestRule.onAllNodes(matcher).onFirst()
+        return composeTestRule.onNode(matcher)
     }
 }

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -100,6 +100,7 @@
   <string name="cd_toggle_view_mode">Toggle view mode</string>
   <string name="cd_unmute">Unmute</string>
   <string name="cd_vinyl_record">Vinyl Record</string>
+  <string name="cd_album_item">Album "%1$s"</string>
   <string name="clickctx_album">Album</string>
   <string name="clickctx_artist">Artist</string>
   <string name="clickctx_browse">Browse</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -100,7 +100,7 @@
   <string name="cd_toggle_view_mode">Toggle view mode</string>
   <string name="cd_unmute">Unmute</string>
   <string name="cd_vinyl_record">Vinyl Record</string>
-  <string name="cd_album_item">Album "%1$s"</string>
+  <string name="cd_album_item">Album "%1$s" from %2$s</string>
   <string name="clickctx_album">Album</string>
   <string name="clickctx_artist">Artist</string>
   <string name="clickctx_browse">Browse</string>

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerMediaItem.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerMediaItem.kt
@@ -66,7 +66,11 @@ data class ServerMediaItem(
     @SerialName("items") val items: List<ServerMediaItem>? = null,
     // BrowseFolder only: the server browse path to descend into (distinct from `uri`).
     @SerialName("path") val path: String? = null,
-)
+) {
+    companion object {
+        const val LIBRARY_PROVIDER = "library"
+    }
+}
 
 @Serializable
 data class ServerMetadata(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/MediaItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/MediaItems.kt
@@ -44,6 +44,8 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -78,6 +80,7 @@ import io.music_assistant.client.ui.theme.favoriteTint
 import io.music_assistant.client.utils.gridItemMinSize
 import io.music_assistant.client.utils.rowImageSize
 import musicassistantclient.composeapp.generated.resources.Res
+import musicassistantclient.composeapp.generated.resources.cd_album_item
 import musicassistantclient.composeapp.generated.resources.cd_favorite
 import musicassistantclient.composeapp.generated.resources.cd_fully_played
 import musicassistantclient.composeapp.generated.resources.cd_in_progress
@@ -103,6 +106,7 @@ fun ArtistGridItem(
 ) {
     GridItem(
         modifier = modifier,
+        description = contentDescription(item),
         onClick = { onClick(item) },
         onLongClick = { onLongClick(item) },
     ) {
@@ -167,6 +171,7 @@ fun AlbumGridItem(
 ) {
     GridItem(
         modifier = modifier,
+        description = contentDescription(item),
         onClick = { onClick(item) },
         onLongClick = { onLongClick(item) },
     ) {
@@ -241,6 +246,7 @@ fun PlaylistGridItem(
 ) {
     GridItem(
         modifier = modifier,
+        description = contentDescription(item),
         onClick = { onClick(item) },
         onLongClick = { onLongClick(item) },
     ) {
@@ -337,6 +343,7 @@ fun PodcastGridItem(
 ) {
     GridItem(
         modifier = modifier,
+        description = contentDescription(item),
         onClick = { onClick(item) },
         onLongClick = { onLongClick(item) },
     ) {
@@ -433,6 +440,7 @@ internal fun TrackGridItem(
 ) {
     GridItem(
         modifier = modifier,
+        description = contentDescription(item),
         onClick = { onClick(item) },
         onLongClick = { onLongClick(item) },
     ) {
@@ -500,6 +508,7 @@ internal fun PodcastEpisodeGridItem(
 ) {
     GridItem(
         modifier = modifier,
+        description = contentDescription(item),
         onClick = { onClick(item) },
         onLongClick = { onLongClick(item) },
     ) {
@@ -587,6 +596,7 @@ internal fun RadioGridItem(
 ) {
     GridItem(
         modifier = modifier,
+        description = contentDescription(item),
         onClick = { onClick(item) },
         onLongClick = { onLongClick(item) },
     ) {
@@ -647,6 +657,7 @@ internal fun AudiobookGridItem(
 ) {
     GridItem(
         modifier = modifier,
+        description = contentDescription(item),
         onClick = { onClick(item) },
         onLongClick = { onLongClick(item) },
     ) {
@@ -741,11 +752,16 @@ private fun GridPlayableItemLabels(item: PlayableItem) {
 @Composable
 private fun GridItem(
     modifier: Modifier = Modifier,
+    description: String,
     onClick: () -> Unit,
     onLongClick: () -> Unit,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    BoxWithConstraints {
+    BoxWithConstraints(
+        modifier = Modifier.clearAndSetSemantics {
+        contentDescription = description
+    },
+    ) {
         val cellWidthModifier = if (constraints.hasBoundedWidth) {
             Modifier.fillMaxWidth()
         } else {
@@ -857,6 +873,7 @@ internal fun TrackRowItem(
         modifier = modifier,
         name = item.displayName,
         subtitle = item.localizedSubtitle(),
+        description = contentDescription(item),
         prefixContent = if (showTrackNumber) {
             item.trackNumber?.toString()?.let { trackNumber ->
                 {
@@ -894,6 +911,7 @@ internal fun AlbumRowItem(
         modifier = modifier,
         name = item.displayName,
         subtitle = item.localizedSubtitle(),
+        description = contentDescription(item),
         prefixContent = {
             AlbumImage(item)
             Badges(
@@ -918,6 +936,7 @@ internal fun ArtistRowItem(
         modifier = modifier,
         name = item.displayName,
         subtitle = item.localizedSubtitle(),
+        description = contentDescription(item),
         prefixContent = {
             ArtistImage(item)
             Badges(
@@ -942,6 +961,7 @@ internal fun PlaylistRowItem(
         modifier = modifier,
         name = item.displayName,
         subtitle = item.localizedSubtitle(),
+        description = contentDescription(item),
         prefixContent = {
             PlaylistImage(item)
             Badges(
@@ -966,6 +986,7 @@ internal fun PodcastRowItem(
         modifier = modifier,
         name = item.displayName,
         subtitle = item.localizedSubtitle(),
+        description = contentDescription(item),
         prefixContent = {
             PodcastImage(item)
             Badges(
@@ -990,6 +1011,7 @@ internal fun PodcastEpisodeRowItem(
         modifier = modifier,
         name = item.displayName,
         subtitle = item.localizedSubtitle(),
+        description = contentDescription(item),
         prefixContent = {
             PodcastEpisodeImage(item)
             Badges(
@@ -1018,6 +1040,7 @@ internal fun RadioRowItem(
         modifier = modifier,
         name = item.displayName,
         subtitle = item.localizedSubtitle(),
+        description = contentDescription(item),
         prefixContent = {
             RadioImage(item)
             Badges(
@@ -1040,6 +1063,7 @@ fun GenreGridItem(
 ) {
     GridItem(
         modifier = modifier,
+        description = contentDescription(item),
         onClick = { onClick(item) },
         onLongClick = { onLongClick(item) },
     ) {
@@ -1100,6 +1124,7 @@ internal fun GenreRowItem(
         modifier = modifier,
         name = item.displayName,
         subtitle = item.localizedSubtitle(),
+        description = contentDescription(item),
         prefixContent = {
             GenreImage(item)
             Badges(
@@ -1128,11 +1153,14 @@ fun FolderCell(
             modifier = Modifier.fillMaxWidth(),
             name = item.displayName,
             subtitle = null,
+            description = contentDescription(item),
             prefixContent = { FolderImage(item) },
             onClick = { onNavigateClick(item) },
             onLongClick = {},
         )
+
         ViewMode.GRID -> GridItem(
+            description = contentDescription(item),
             onClick = { onNavigateClick(item) },
             onLongClick = {},
         ) {
@@ -1186,6 +1214,7 @@ internal fun AudiobookRowItem(
         modifier = modifier,
         name = item.displayName,
         subtitle = item.localizedSubtitle(),
+        description = contentDescription(item),
         prefixContent = {
             AudiobookImage(item)
             Badges(
@@ -1245,6 +1274,7 @@ private fun RowItem(
     modifier: Modifier = Modifier,
     name: String,
     subtitle: String?,
+    description: String,
     prefixContent: @Composable (BoxScope.() -> Unit)?,
     onClick: () -> Unit,
     onLongClick: () -> Unit,
@@ -1254,7 +1284,10 @@ private fun RowItem(
             .fillMaxWidth()
             .clip(RoundedCornerShape(8.dp))
             .combinedClickable(onClick = onClick, onLongClick = onLongClick)
-            .padding(horizontal = 8.dp, vertical = 4.dp),
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+            .clearAndSetSemantics {
+                contentDescription = description
+            },
         verticalAlignment = Alignment.CenterVertically,
     ) {
         prefixContent?.let {
@@ -1271,5 +1304,14 @@ private fun RowItem(
                 titleMaxLines = 2,
             )
         }
+    }
+}
+
+@Composable
+private fun contentDescription(appMediaItem: AppMediaItem): String {
+    return if (appMediaItem is Album) {
+        stringResource(Res.string.cd_album_item, appMediaItem.displayName)
+    } else {
+        appMediaItem.displayName
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/MediaItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/MediaItems.kt
@@ -1310,7 +1310,7 @@ private fun RowItem(
 @Composable
 private fun contentDescription(appMediaItem: AppMediaItem): String {
     return if (appMediaItem is Album) {
-        stringResource(Res.string.cd_album_item, appMediaItem.displayName)
+        stringResource(Res.string.cd_album_item, appMediaItem.displayName, appMediaItem.provider)
     } else {
         appMediaItem.displayName
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -270,6 +270,7 @@ private fun getCategories(
                     title = it.displayName.toDisplayString(),
                     items = it.items.orEmpty(),
                     lazyListKey = it.lazyListKey(),
+                    tag = HomeScreenSemantics.rowTag(it.itemId),
                 )
             }
 
@@ -352,6 +353,7 @@ class HomeScreenState(
 }
 
 object HomeScreenSemantics {
+    fun rowTag(categoryId: String): String = "Row:$categoryId"
     const val SHORTCUTS_ROW_TAG = "ShortcutsRow"
     const val LIST_TAG = "List"
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -749,7 +749,7 @@ private fun DetailGrid(
     CompositionLocalProvider(LocalOverscrollFactory provides null) {
         LazyVerticalGrid(
             state = gridState,
-            modifier = Modifier.fillMaxSize().testTag("LazyVerticalGrid"),
+            modifier = Modifier.fillMaxSize().testTag(ItemDetailsScreenSemantics.LIST_TAG),
             columns = GridCells.Adaptive(minSize = gridItemMinSize()),
             contentPadding = gridPadding,
             horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -1169,6 +1169,10 @@ private fun ChapterRow(
             )
         }
     }
+}
+
+object ItemDetailsScreenSemantics {
+    const val LIST_TAG = "LazyVerticalGrid"
 }
 
 @Preview


### PR DESCRIPTION
Work towards #801

## Is there anything about the code changes here that should be highlighted?

The big change here to get these tests in a good place was to improve `FakeServiceClient` so that it handles the MA server concepts of the library and providers more like the real thing. With that, comes the ability to write tests that make better assertions about media items (identifying multiple on a screen, checking their provider domain etc).

## Before submitting this PR, make sure you have:
- [x] Given this PR a readable name that can be used in the app's changelog
- [x] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

