### PR TITLE
Allow provider manifests without icons

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ProviderManifest.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ProviderManifest.kt
@@ -8,7 +8,7 @@ data class ProviderManifest(
     @SerialName("type") val type: String,
     @SerialName("domain") val domain: String,
     @SerialName("name") val name: String,
-    @SerialName("icon") val icon: String?,
-    @SerialName("icon_svg") val iconSvg: String?,
-    @SerialName("icon_svg_dark") val iconSvgDark: String?,
+    @SerialName("icon") val icon: String? = null,
+    @SerialName("icon_svg") val iconSvg: String? = null,
+    @SerialName("icon_svg_dark") val iconSvgDark: String? = null,
 )

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/ServerQueueItemSerializationTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/ServerQueueItemSerializationTest.kt
@@ -4,6 +4,7 @@ import io.music_assistant.client.utils.myJson
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class ServerQueueItemSerializationTest {
     /**
@@ -67,5 +68,25 @@ class ServerQueueItemSerializationTest {
         assertEquals(48_000, outputFormat.sampleRate)
         assertEquals(16, outputFormat.bitDepth)
         assertEquals(2, outputFormat.channels)
+    }
+
+    @Test
+    fun deserializesProviderManifestWithoutOptionalIcons() {
+        val json = """
+            {
+              "type": "player",
+              "domain": "bose_soundtouch",
+              "name": "Bose SoundTouch"
+            }
+        """.trimIndent()
+
+        val manifest = myJson.decodeFromString<ProviderManifest>(json)
+
+        assertEquals("player", manifest.type)
+        assertEquals("bose_soundtouch", manifest.domain)
+        assertEquals("Bose SoundTouch", manifest.name)
+        assertNull(manifest.icon)
+        assertNull(manifest.iconSvg)
+        assertNull(manifest.iconSvgDark)
     }
 }


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

While perusing logs today, I found a bunch of errors about deserializing provider manifests being broken.

```
1785009941477 Warn/Answer: Failed to decode RPC result as List: [{"type":"player","domain":"bose_soundtouch","name":"Bose SoundTouch","description":"Control Bose SoundTouch speakers and map their physical preset buttons to Music Assistant content.","codeowners":["@Odn0"],"stage":"alpha","requirements":["defusedxml==0.7.1"],"documentation":"[REDACTED_URL]
kotlinx.serialization.MissingFieldException: Fields [icon_svg, icon_svg_dark] are required for type with serial name 'io.music_assistant.client.data.model.server.ProviderManifest', but they were missing
_snip very long exception output_
```

## Are there any additional changes not related to the issue above?

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

