### PR TITLE
Ignore normal WebRTC coroutine cancellation

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/webrtc/PeerConnectionWrapper.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/webrtc/PeerConnectionWrapper.kt
@@ -10,6 +10,7 @@ import io.music_assistant.client.webrtc.model.IceCandidateData
 import io.music_assistant.client.webrtc.model.IceServer
 import io.music_assistant.client.webrtc.model.PeerConnectionStateValue
 import io.music_assistant.client.webrtc.model.SessionDescription
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -88,6 +89,8 @@ class PeerConnectionWrapper : KoinComponent {
                             ),
                         )
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     logger.e(e) { "ICE candidate flow failed" }
                 }
@@ -104,6 +107,8 @@ class PeerConnectionWrapper : KoinComponent {
                             }
                         }
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     logger.e(e) { "Data channel events flow failed" }
                 }
@@ -116,6 +121,8 @@ class PeerConnectionWrapper : KoinComponent {
                         logger.d { "Connection state: $state -> $mapped" }
                         _connectionState.value = mapped
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     logger.e(e) { "Connection state flow failed" }
                 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/webrtc/SignalingClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/webrtc/SignalingClient.kt
@@ -8,6 +8,7 @@ import io.ktor.websocket.Frame
 import io.ktor.websocket.close
 import io.ktor.websocket.readText
 import io.music_assistant.client.webrtc.model.SignalingMessage
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
@@ -197,6 +198,8 @@ class SignalingClient(
 
             _connectionState.value = SignalingState.Disconnected
             logger.i { "Disconnected from signaling server" }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             logger.e(e) { "Error during disconnect" }
         }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/webrtc/WebRTCConnectionManager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/webrtc/WebRTCConnectionManager.kt
@@ -9,6 +9,7 @@ import io.music_assistant.client.webrtc.model.RemoteId
 import io.music_assistant.client.webrtc.model.SignalingMessage
 import io.music_assistant.client.webrtc.model.WebRTCConnectionState
 import io.music_assistant.client.webrtc.model.WebRTCError
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -245,6 +246,8 @@ class WebRTCConnectionManager(
                             ),
                         )
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     logger.e(e) { "Error collecting ICE candidates" }
                 }
@@ -261,6 +264,8 @@ class WebRTCConnectionManager(
                             setupDataChannel(channel, message.sessionId.orEmpty(), remoteId)
                         }
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     logger.e(e) { "Error collecting data channels" }
                 }
@@ -331,6 +336,8 @@ class WebRTCConnectionManager(
                             }
                         }
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     logger.e(e) { "Error collecting connection state" }
                 }
@@ -477,6 +484,8 @@ class WebRTCConnectionManager(
                 channel.messages.collect { msg ->
                     _incomingMessages.emit(msg)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 logger.e(e) { "Error receiving messages from data channel" }
             }
@@ -493,6 +502,8 @@ class WebRTCConnectionManager(
                         )
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 logger.e(e) { "Error monitoring data channel state" }
             }
@@ -524,6 +535,8 @@ class WebRTCConnectionManager(
                         logger.i { "Sendspin data channel ready for use" }
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 logger.e(e) { "Error monitoring sendspin data channel state" }
             }


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

Another log-perusing catch, I found a *bunch* of these, every time WebRTC disconnected / connected (which is pretty common with WebRTC):
```
785009997380 Info/WebRTCConnectionManager: Disconnecting WebRTC connection
1785009997380 Info/DataChannelWrapper: Closing data channel ma-api
1785009997393 Info/DataChannelWrapper: Closing data channel sendspin
1785009997395 Info/PeerConnectionWrapper: Closing peer connection
1785009997462 Info/SignalingClient: Disconnecting from signaling server
1785009997471 Info/SignalingClient: Disconnected from signaling server
1785009997381 Error/WebRTCConnectionManager: Error collecting data channels
kotlinx.coroutines.JobCancellationException: StandaloneCoroutine was cancelled; job=StandaloneCoroutine{Cancelling}@128b0960
_snip very long exception log_
```

## Are there any additional changes not related to the issue above?

I could shorten it up a bit to something like:
```
catch (e: Exception) {
    if (e is CancellationException) throw e
    logger.e(e) { "Actual failure" }
}
```
if you like, but we had this longer version already in a few places and I was trying to match code-style.

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

