### PR TITLE
fix: send available field in client/state per spec

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/model/Messages.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/model/Messages.kt
@@ -162,6 +162,7 @@ data class ClientStateMessage(
 @Serializable
 data class ClientStatePayload(
     val player: PlayerStateObject? = null,
+    val available: Boolean? = null,
 )
 
 @Serializable

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/protocol/MessageDispatcher.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/protocol/MessageDispatcher.kt
@@ -249,7 +249,7 @@ class MessageDispatcher(
 
     suspend fun sendState(state: PlayerStateObject) {
         val message = ClientStateMessage(
-            payload = ClientStatePayload(player = state),
+            payload = ClientStatePayload(player = state, available = true),
         )
         val json = myJson.encodeToString(message)
         if (state.state != lastLoggedState) {


### PR DESCRIPTION
Add the required 'available' boolean to ClientStatePayload and pass it as true when sending client/state. This brings the mobile app in line with the sendspin spec, eliminating non-compliant client warnings from the server.

Backwards compatible: old servers that don't have the field ignore the extra JSON key; new servers use it as the primary availability signal.

## Is there anything about the code changes here that should be highlighted?

Forward compat with sendspin spec.

## Are there any additional changes not related to the issue above?

No

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

