### PR TITLE
Fix WebRTC message reassembly

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/WebRTCTransport.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/WebRTCTransport.kt
@@ -26,9 +26,87 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlin.io.encoding.Base64
 
 private const val HTTP_PROXY_TYPE_SCAN_WINDOW = 256
 private const val HTTP_PROXY_TYPE_TOKEN = "\"type\":\"http-proxy-response\""
+private const val CHUNK_TYPE_TOKEN = "\"__chunk__\""
+private const val MAX_CHUNK_COUNT = 256
+internal const val MAX_PENDING_CHUNK_GROUPS = 16
+private const val MAX_REASSEMBLED_BYTES = 16 * 1024 * 1024
+
+/** Reassembles server-side `__chunk__` envelopes while passing legacy whole messages through. */
+internal class WebRTCChunkReassembler {
+    private class PendingGroup(
+        val count: Int,
+        val parts: Array<ByteArray?>,
+        var received: Int = 0,
+        var totalBytes: Int = 0,
+    )
+
+    // Insertion order lets us evict the oldest incomplete group if a buggy peer continuously
+    // starts groups without finishing them. The instance is confined to one listener coroutine.
+    private val groups = linkedMapOf<Int, PendingGroup>()
+
+    fun accept(message: String): String? {
+        // The server always emits `type` first. Bound the fast scan so legacy multi-MB responses
+        // do not incur another full payload pass before the existing bounded proxy-type scan.
+        val scanEnd = minOf(HTTP_PROXY_TYPE_SCAN_WINDOW, message.length)
+        if (message.indexOf(CHUNK_TYPE_TOKEN) !in 0 until scanEnd) return message
+
+        val frame = runCatching { myJson.decodeFromString<JsonObject>(message) }.getOrNull()
+            ?: return message
+        if (frame.string("type") != "__chunk__") return message
+
+        // Once identified as a chunk envelope, malformed frames are consumed rather than leaked
+        // into the normal API dispatcher. A later valid frame/group can still be processed.
+        val id = frame.int("id") ?: return null
+        val seq = frame.int("seq") ?: return null
+        val count = frame.int("count") ?: return null
+        val encoded = frame.string("b64") ?: return null
+        if (count !in 1..MAX_CHUNK_COUNT || seq !in 0 until count) return null
+
+        val existing = groups[id]
+        if (existing != null && existing.count != count) return null
+        val bytes = runCatching { Base64.decode(encoded) }.getOrNull() ?: return null
+        val pending = existing ?: registerGroup(id, count)
+        val previous = pending.parts[seq]
+        val newTotal = pending.totalBytes - (previous?.size ?: 0) + bytes.size
+        if (newTotal > MAX_REASSEMBLED_BYTES) {
+            groups.remove(id)
+            return null
+        }
+        if (previous == null) pending.received++
+        pending.parts[seq] = bytes
+        pending.totalBytes = newTotal
+        if (pending.received < pending.count) return null
+
+        val assembled = ByteArray(pending.totalBytes)
+        var offset = 0
+        // received == count guarantees every valid sequence slot has been populated.
+        for (part in pending.parts) {
+            val bytes = checkNotNull(part)
+            bytes.copyInto(assembled, destinationOffset = offset)
+            offset += bytes.size
+        }
+        groups.remove(id)
+        return runCatching { assembled.decodeToString(throwOnInvalidSequence = true) }.getOrNull()
+    }
+
+    private fun registerGroup(id: Int, count: Int): PendingGroup {
+        if (groups.size >= MAX_PENDING_CHUNK_GROUPS) {
+            groups.remove(groups.keys.first())
+        }
+        return PendingGroup(count, arrayOfNulls(count)).also { groups[id] = it }
+    }
+}
+
+private fun JsonObject.int(name: String): Int? = (this[name] as? JsonPrimitive)?.intOrNull
+
+private fun JsonObject.string(name: String): String? = (this[name] as? JsonPrimitive)?.contentOrNull
 
 private fun isHttpProxyResponse(jsonString: String): Boolean {
     val end = minOf(HTTP_PROXY_TYPE_SCAN_WINDOW, jsonString.length)
@@ -180,9 +258,15 @@ class WebRTCTransport(
     private fun startMessageListener(mgr: WebRTCConnectionManager) {
         messageListenerJob?.cancel()
         messageListenerJob = scope.launch {
+            // Listener-local ownership avoids mutable reassembly state racing lifecycle teardown.
+            val chunkReassembler = WebRTCChunkReassembler()
             try {
-                mgr.incomingMessages.collect { jsonString ->
+                mgr.incomingMessages.collect { wireMessage ->
                     try {
+                        // New servers chunk messages that exceed libdatachannel's 256 KiB limit.
+                        // Legacy servers still send whole messages, which pass through unchanged.
+                        val jsonString = chunkReassembler.accept(wireMessage) ?: return@collect
+
                         // CHEAP peek: avoid full JSON parse for multi-MB http-proxy-response frames.
                         // The full parse would block the listener (single coroutine), queueing every
                         // subsequent control-plane message behind each image body for hundreds of ms.
@@ -194,7 +278,9 @@ class WebRTCTransport(
                             _messages.emit(jsonObject)
                         }
                     } catch (e: Exception) {
-                        logger.e(e) { "Failed to parse incoming WebRTC message: ${jsonString.take(200)}" }
+                        // For chunked traffic wireMessage is only the final envelope, not the
+                        // reassembled payload, so identify the stage without mislabeling the frame.
+                        logger.e(e) { "Failed to dispatch incoming WebRTC frame: ${wireMessage.take(200)}" }
                     }
                 }
             } catch (e: Exception) {

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/api/WebRTCChunkReassemblerTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/api/WebRTCChunkReassemblerTest.kt
@@ -1,0 +1,113 @@
+package io.music_assistant.client.api
+
+import kotlin.io.encoding.Base64
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class WebRTCChunkReassemblerTest {
+    private fun chunks(text: String, id: Int, pieceSize: Int): List<String> {
+        val pieces = text.encodeToByteArray().asList().chunked(pieceSize)
+        return pieces.mapIndexed { seq, piece ->
+            chunkFrame(id, seq, pieces.size, Base64.encode(piece.toByteArray()))
+        }
+    }
+
+    private fun chunkFrame(id: Int, seq: Int, count: Int, b64: String): String =
+        """{"type":"__chunk__","id":$id,"seq":$seq,"count":$count,"b64":"$b64"}"""
+
+    @Test
+    fun passesLegacyWholeMessagesThroughUnchanged() {
+        val message = """{"event":"player_updated"}"""
+        assertEquals(message, WebRTCChunkReassembler().accept(message))
+    }
+
+    @Test
+    fun boundedProbeDoesNotMisclassifyTokenLateInNormalMessage() {
+        val message = """{"data":"${"x".repeat(300)}__chunk__"}"""
+        assertEquals(message, WebRTCChunkReassembler().accept(message))
+    }
+
+    @Test
+    fun reassemblesOrderedChunks() {
+        val message = """{"message_id":"1","result":[1,2,3]}"""
+        val results = chunks(message, id = 42, pieceSize = 8).map(WebRTCChunkReassembler()::accept)
+        assertTrue(results.dropLast(1).all { it == null })
+        assertEquals(message, results.last())
+    }
+
+    @Test
+    fun reassemblesOutOfOrderMultibyteChunksByByteSequence() {
+        val message = """{"name":"${"音楽ライブラリ".repeat(5)}"}"""
+        val results = chunks(message, id = 7, pieceSize = 5).reversed()
+            .map(WebRTCChunkReassembler()::accept)
+        assertTrue(results.dropLast(1).all { it == null })
+        assertEquals(message, results.last())
+    }
+
+    @Test
+    fun reassemblesInterleavedGroupsIndependently() {
+        val first = chunks("""{"event":"first"}""", id = 1, pieceSize = 5)
+        val second = chunks("""{"event":"second"}""", id = 2, pieceSize = 5)
+        val reassembler = WebRTCChunkReassembler()
+        val results = buildList {
+            repeat(maxOf(first.size, second.size)) { index ->
+                first.getOrNull(index)?.let { add(reassembler.accept(it)) }
+                second.getOrNull(index)?.let { add(reassembler.accept(it)) }
+            }
+        }.filterNotNull()
+        assertEquals(listOf("""{"event":"first"}""", """{"event":"second"}"""), results)
+    }
+
+    @Test
+    fun duplicateChunkDoesNotCompleteGroupEarly() {
+        val message = """{"event":"queue_updated","data":"abcdefgh"}"""
+        val frames = chunks(message, id = 9, pieceSize = 10)
+        val reassembler = WebRTCChunkReassembler()
+        assertNull(reassembler.accept(frames.first()))
+        assertNull(reassembler.accept(frames.first()))
+        assertEquals(message, frames.drop(1).map(reassembler::accept).last())
+    }
+
+    @Test
+    fun rejectsOversizedCountWithoutAllocating() {
+        val frame = chunkFrame(id = 1, seq = 0, count = Int.MAX_VALUE, b64 = "eA==")
+        assertNull(WebRTCChunkReassembler().accept(frame))
+    }
+
+    @Test
+    fun countMismatchDoesNotDiscardOriginalGroup() {
+        val message = """{"event":"healthy"}"""
+        val frames = chunks(message, id = 3, pieceSize = 10)
+        val reassembler = WebRTCChunkReassembler()
+        assertNull(reassembler.accept(frames.first()))
+        assertNull(reassembler.accept(chunkFrame(id = 3, seq = 0, count = frames.size + 1, b64 = "eA==")))
+        assertEquals(message, frames.drop(1).map(reassembler::accept).last())
+    }
+
+    @Test
+    fun malformedChunkIsConsumedAndSubsequentGroupStillWorks() {
+        val reassembler = WebRTCChunkReassembler()
+        assertNull(reassembler.accept(chunkFrame(id = 1, seq = 99, count = 2, b64 = "eA==")))
+        val message = """{"event":"healthy"}"""
+        assertEquals(message, chunks(message, id = 2, pieceSize = 100).single().let(reassembler::accept))
+    }
+
+    @Test
+    fun invalidUtf8IsConsumedWithoutThrowing() {
+        val invalidUtf8 = Base64.encode(byteArrayOf(0xC3.toByte(), 0x28))
+        assertNull(WebRTCChunkReassembler().accept(chunkFrame(id = 4, seq = 0, count = 1, b64 = invalidUtf8)))
+    }
+
+    @Test
+    fun oldestIncompleteGroupIsEvictedAtCapacity() {
+        val reassembler = WebRTCChunkReassembler()
+        val first = chunks("""{"event":"first"}""", id = 0, pieceSize = 5)
+        assertNull(reassembler.accept(first.first()))
+        repeat(MAX_PENDING_CHUNK_GROUPS) { id ->
+            assertNull(reassembler.accept(chunkFrame(id = id + 1, seq = 0, count = 2, b64 = "eA==")))
+        }
+        assertTrue(first.drop(1).map(reassembler::accept).all { it == null })
+    }
+}


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

Reassemble chunked MA API frames before dispatch while preserving legacy whole-message handling. Bound incomplete groups and payload sizes, with coverage for malformed and interleaved chunks. Tested against both head of `dev` and on the stable 2.9.9 release.

## Are there any additional changes not related to the issue above?

N/A

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

