### PR TITLE
Fix iOS FLAC decoding crashes

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/audio/AudioStreamManager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/audio/AudioStreamManager.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
@@ -179,8 +180,11 @@ class AudioStreamManager(
         }
 
         try {
+            isStreaming = false
+            playbackJob?.cancelAndJoin()
+            playbackJob = null
+
             streamConfig = config
-            isStreaming = true
             // Create and configure decoder atomically under lock
             val (outputCodec, outputBitDepth) = decoderLock.withLock {
                 audioDecoder?.release()
@@ -238,6 +242,7 @@ class AudioStreamManager(
                 currentSinkConfig = newSinkConfig
             }
 
+            isStreaming = true
             queueLock.withLock {
                 queue.clear()
                 lastConsumedTs = Long.MIN_VALUE
@@ -429,7 +434,7 @@ class AudioStreamManager(
         logger.i { "Stopping stream" }
         isStreaming = false
         _isStarved.value = false
-        playbackJob?.cancel()
+        playbackJob?.cancelAndJoin()
         playbackJob = null
 
         queueLock.withLock {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/audio/AudioStreamManager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/audio/AudioStreamManager.kt
@@ -256,8 +256,7 @@ class AudioStreamManager(
             // armed guard with no running consumer would leave us silent. Also stop any consumer
             // this call managed to launch on the detached playback scope.
             streamConfig = null
-            playbackJob?.cancel()
-            playbackJob = null
+            stopPlaybackThread(join = false)
             throw e
         }
     }
@@ -307,9 +306,13 @@ class AudioStreamManager(
      * Consumer: decode the oldest frame from sorted queue and write PCM to AudioTrack.
      * Runs on high-priority [audioDispatcher]. Paced by blocking AudioTrack.write().
      */
-    private suspend fun stopPlaybackThread() {
+    private suspend fun stopPlaybackThread(join: Boolean = true) {
         isStreaming = false
-        playbackJob?.cancelAndJoin()
+        if (join) {
+            playbackJob?.cancelAndJoin()
+        } else {
+            playbackJob?.cancel()
+        }
         playbackJob = null
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/audio/AudioStreamManager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/audio/AudioStreamManager.kt
@@ -180,9 +180,7 @@ class AudioStreamManager(
         }
 
         try {
-            isStreaming = false
-            playbackJob?.cancelAndJoin()
-            playbackJob = null
+            stopPlaybackThread()
 
             streamConfig = config
             // Create and configure decoder atomically under lock
@@ -309,6 +307,12 @@ class AudioStreamManager(
      * Consumer: decode the oldest frame from sorted queue and write PCM to AudioTrack.
      * Runs on high-priority [audioDispatcher]. Paced by blocking AudioTrack.write().
      */
+    private suspend fun stopPlaybackThread() {
+        isStreaming = false
+        playbackJob?.cancelAndJoin()
+        playbackJob = null
+    }
+
     private fun startPlaybackThread() {
         playbackJob?.cancel()
         playbackJob = CoroutineScope(audioDispatcher + SupervisorJob()).launch {
@@ -432,10 +436,8 @@ class AudioStreamManager(
 
     override suspend fun stopStream() = streamLifecycleLock.withLock {
         logger.i { "Stopping stream" }
-        isStreaming = false
         _isStarved.value = false
-        playbackJob?.cancelAndJoin()
-        playbackJob = null
+        stopPlaybackThread()
 
         queueLock.withLock {
             queue.clear()

--- a/iosApp/AudioDecoders.swift
+++ b/iosApp/AudioDecoders.swift
@@ -160,6 +160,7 @@ class OpusLibDecoder: NativeAudioDecoder {
 /// FLAC decoder using libFLAC C library
 class FLACLibDecoder: NativeAudioDecoder {
     private var decoder: UnsafeMutablePointer<FLAC__StreamDecoder>?
+    private let decodeLock = NSLock()
     private let sampleRate: Int
     private let channels: Int
     private let bitDepth: Int
@@ -244,6 +245,9 @@ class FLACLibDecoder: NativeAudioDecoder {
     private let maxPendingSize = 1_048_576
 
     func decode(_ data: Data) throws -> Data {
+        decodeLock.lock()
+        defer { decodeLock.unlock() }
+
         // Append new data to pending buffer
         pendingData.append(data)
 

--- a/iosApp/NativeAudioController.swift
+++ b/iosApp/NativeAudioController.swift
@@ -20,6 +20,7 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
 
     // MARK: - Decoder
     private var decoder: NativeAudioDecoder?
+    private let decoderLock = NSLock()
     private var listener: MediaPlayerListener?
 
     // MARK: - Stream Configuration
@@ -177,13 +178,16 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
 
         // Create decoder for codec
         do {
-            decoder = try AudioDecoderFactory.create(
+            let newDecoder = try AudioDecoderFactory.create(
                 codec: currentCodec,
                 sampleRate: Int(sampleRate),
                 channels: Int(channels),
                 bitDepth: Int(bitDepth),
                 codecHeader: self.codecHeader
             )
+            decoderLock.lock()
+            decoder = newDecoder
+            decoderLock.unlock()
             logInfo("Created decoder for \(codec)")
         } catch {
             logError("Failed to create decoder: \(error)")
@@ -223,6 +227,9 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
             NowPlayingCoordinator.shared.activatePlayback()
             startAudioQueue()
         }
+
+        decoderLock.lock()
+        defer { decoderLock.unlock() }
 
         guard let decoder = decoder else {
             logDebug("No decoder available — dropping packet")
@@ -296,7 +303,9 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
         // The Now Playing surface is cleared by the track channel going null
         // (pipeline teardown removes the current item); no direct clear here.
         stopAudioQueue()
+        decoderLock.lock()
         decoder = nil
+        decoderLock.unlock()
     }
 
     // MARK: - AudioQueue Management


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

Serialize access to the stateful native FLAC decoder to prevent concurrent mutation of its pending data. Wait for the previous playback consumer to fully stop before resetting or replacing the decoder.

## Are there any additional changes not related to the issue above?

Got a few crash reports through iOS Test Flight, all from long-running (like, overnight) sessions, all from concurrent FLAC data mutation.

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

