### PR TITLE
Stabilize queue transfer UI test

### DIFF
--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/QueueTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/QueueTest.kt
@@ -75,6 +75,10 @@ class QueueTest {
             .clickOnMedia(album)
             .clickPlay()
             .expandPlayer(player1.displayName, playing = true, item = track.name)
-            .transferQueue(player2.displayName)
+            .transferQueue(player2.displayName) {
+                composeTestRule.waitUntil {
+                    serviceClient.getCurrentlyPlaying(player2.playerId) == track
+                }
+            }
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ExpandedPlayerPage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ExpandedPlayerPage.kt
@@ -71,10 +71,14 @@ class ExpandedPlayerPage(
             .performClick()
     }
 
-    fun transferQueue(player: String): ExpandedPlayerPage {
+    fun transferQueue(
+        player: String,
+        awaitTransfer: () -> Unit = {},
+    ): ExpandedPlayerPage {
         clickMore()
         composeTestRule.onNodeWithText(Res.string.queue_transfer.get()).performClick()
         composeTestRule.onNodeWithText(player).performClick()
+        awaitTransfer()
         return ExpandedPlayerPage(player, true, item, composeTestRule).assertOnPage()
     }
 


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

Wait for the fake server to complete the asynchronous queue transfer before asserting the destination player's rendered state.

## Are there any additional changes not related to the issue above?

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

