### PR TITLE
Add view mode toggle to artist "View all" screens

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/di/SharedModule.kt
@@ -33,6 +33,7 @@ import io.music_assistant.client.ui.compose.home.HomeScreenViewModel
 import io.music_assistant.client.ui.compose.home.players.DspSettingsViewModel
 import io.music_assistant.client.ui.compose.item.ItemDetailsViewModel
 import io.music_assistant.client.ui.compose.item.ItemListViewModel
+import io.music_assistant.client.ui.compose.item.ViewModeViewModel
 import io.music_assistant.client.ui.compose.library.BrowseViewModel
 import io.music_assistant.client.ui.compose.library.LibraryCategoriesViewModel
 import io.music_assistant.client.ui.compose.library.LibraryListViewModel
@@ -118,6 +119,7 @@ fun sharedModule(
                 params[2],
             )
         }
+        factory { ViewModeViewModel(get()) }
         factory { params -> ItemListViewModel(params[0], get()) }
         factory { DspSettingsViewModel(get()) }
         factory { HomeScreenViewModel(get(), get(), get(), get()) }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -109,6 +109,7 @@ import kotlin.uuid.Uuid
 fun MainNavigationRoot(
     homeScreenViewModel: HomeScreenViewModel = koinViewModel(),
     actionsViewModel: ActionsViewModel = koinViewModel(),
+    viewModeViewModel: ViewModeViewModel = koinViewModel(),
     dspSettingsViewModel: DspSettingsViewModel = koinViewModel(),
     goToSettings: () -> Unit,
 ) {
@@ -312,6 +313,7 @@ fun MainNavigationRoot(
                                 multiBackStack,
                                 homeScreenViewModel,
                                 actionsViewModel,
+                                viewModeViewModel,
                                 homeScreenState,
                                 libraryScreenState,
                                 searchScreenState,
@@ -335,6 +337,7 @@ private fun mainNavEntryProvider(
     multiBackStack: MultiBackStack<NavKey>,
     homeScreenViewModel: HomeScreenViewModel,
     actionsViewModel: ActionsViewModel,
+    viewModeViewModel: ViewModeViewModel,
     homeScreenState: MutableState<HomeScreenState?>,
     libraryScreenState: MutableState<LibraryScreenState?>,
     searchScreenState: MutableState<SearchScreenState?>,
@@ -405,11 +408,9 @@ private fun mainNavEntryProvider(
                 parametersOf(it.mediaType)
             }
 
-            val viewModelViewModel = koinViewModel<ViewModeViewModel>()
-
             LibraryListScreen(
                 libraryListViewModel = libraryListViewModel,
-                viewModeViewModel = viewModelViewModel,
+                viewModeViewModel = viewModeViewModel,
                 contentPadding = contentPadding,
                 actionsViewModel = actionsViewModel,
                 onBack = { multiBackStack.removeLastOrNull() },
@@ -493,7 +494,9 @@ private fun mainNavEntryProvider(
 
             ItemListScreen(
                 title = it.title,
+                mediaType = it.itemList.mediaType,
                 itemListViewModel = itemListViewModel,
+                viewModeViewModel = viewModeViewModel,
                 actionsViewModel = actionsViewModel,
                 onNavigateClick = { item ->
                     when (item) {
@@ -526,8 +529,6 @@ private fun mainNavEntryProvider(
             val itemDetailsViewModel = koinViewModel<ItemDetailsViewModel> {
                 parametersOf(it.itemId, it.mediaType, it.providerId)
             }
-
-            val viewModeViewModel = koinViewModel<ViewModeViewModel>()
 
             ItemDetailsScreen(
                 itemDetailsViewModel = itemDetailsViewModel,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -65,6 +65,7 @@ import io.music_assistant.client.ui.compose.item.ItemDetailsScreen
 import io.music_assistant.client.ui.compose.item.ItemDetailsViewModel
 import io.music_assistant.client.ui.compose.item.ItemListScreen
 import io.music_assistant.client.ui.compose.item.ItemListViewModel
+import io.music_assistant.client.ui.compose.item.ViewModeViewModel
 import io.music_assistant.client.ui.compose.library.BrowseScreen
 import io.music_assistant.client.ui.compose.library.BrowseViewModel
 import io.music_assistant.client.ui.compose.library.LibraryCategoriesViewModel
@@ -404,8 +405,11 @@ private fun mainNavEntryProvider(
                 parametersOf(it.mediaType)
             }
 
+            val viewModelViewModel = koinViewModel<ViewModeViewModel>()
+
             LibraryListScreen(
                 libraryListViewModel = libraryListViewModel,
+                viewModeViewModel = viewModelViewModel,
                 contentPadding = contentPadding,
                 actionsViewModel = actionsViewModel,
                 onBack = { multiBackStack.removeLastOrNull() },
@@ -523,8 +527,11 @@ private fun mainNavEntryProvider(
                 parametersOf(it.itemId, it.mediaType, it.providerId)
             }
 
+            val viewModeViewModel = koinViewModel<ViewModeViewModel>()
+
             ItemDetailsScreen(
                 itemDetailsViewModel = itemDetailsViewModel,
+                viewModeViewModel = viewModeViewModel,
                 actionsViewModel = actionsViewModel,
                 onBack = { multiBackStack.removeLastOrNull() },
                 onNavigateToItem = { itemId, mediaType, providerId ->

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -22,13 +22,8 @@ import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ViewList
-import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PrimaryScrollableTabRow
 import androidx.compose.material3.Scaffold
@@ -113,7 +108,6 @@ import musicassistantclient.composeapp.generated.resources.artist_section_all
 import musicassistantclient.composeapp.generated.resources.artist_section_in_library
 import musicassistantclient.composeapp.generated.resources.artist_section_top
 import musicassistantclient.composeapp.generated.resources.cd_provider_filter
-import musicassistantclient.composeapp.generated.resources.cd_toggle_view_mode
 import musicassistantclient.composeapp.generated.resources.item_error
 import musicassistantclient.composeapp.generated.resources.item_no_data
 import musicassistantclient.composeapp.generated.resources.library_empty
@@ -126,6 +120,7 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun ItemDetailsScreen(
     itemDetailsViewModel: ItemDetailsViewModel,
+    viewModeViewModel: ViewModeViewModel,
     actionsViewModel: ActionsViewModel,
     onBack: () -> Unit,
     onNavigateToItem: (String, MediaType, String) -> Unit,
@@ -139,9 +134,9 @@ fun ItemDetailsScreen(
         state = state,
         onBack = onBack,
         viewModeProvider = { type ->
-            itemDetailsViewModel.viewMode(type).collectAsStateWithLifecycle().value
+            viewModeViewModel.viewModeFor(type).collectAsStateWithLifecycle().value
         },
-        onToggleViewMode = itemDetailsViewModel::toggleViewMode,
+        onToggleViewMode = viewModeViewModel::toggleFor,
         onNavigateToItem = onNavigateToItem,
         onNavigateToList = onNavigateToList,
         geEditablePlaylists = actionsViewModel::getEditablePlaylists,
@@ -553,15 +548,10 @@ private fun TabsBar(
         }
 
         currentTab.viewMediaType?.let { viewMediaType ->
-            IconButton(onClick = { onToggleViewMode(viewMediaType) }) {
-                Icon(
-                    imageVector = when (viewModeProvider(viewMediaType)) {
-                        ViewMode.LIST -> Icons.Default.GridView
-                        ViewMode.GRID -> Icons.AutoMirrored.Filled.ViewList
-                    },
-                    contentDescription = stringResource(Res.string.cd_toggle_view_mode),
-                )
-            }
+            ViewModeToggle(
+                viewMode = viewModeProvider(viewMediaType),
+                onToggleViewMode = { onToggleViewMode(viewMediaType) },
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -82,13 +82,6 @@ class ItemDetailsViewModel(
     private var rawAlbums: List<Album> = emptyList()
     private var rawPlayableItems: List<PlayableItem> = emptyList()
 
-    fun viewMode(mediaType: MediaType) = settingsRepository.viewMode(mediaType)
-
-    fun toggleViewMode(mediaType: MediaType) {
-        val current = settingsRepository.viewMode(mediaType).value
-        settingsRepository.setViewMode(mediaType, current.toggled())
-    }
-
     fun onTabSelected(tab: ItemDetailsTab) {
         _state.update { it.copy(userSelectedTab = tab) }
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListScreen.kt
@@ -6,16 +6,17 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.music_assistant.client.data.model.client.ClickContext
+import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.settings.ViewMode
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.library.ItemList
 import io.music_assistant.client.ui.compose.nav.TopBarLayout
+import io.music_assistant.client.ui.compose.nav.TwoRowTopAppBar
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.common_back
 import org.jetbrains.compose.resources.stringResource
@@ -23,7 +24,9 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun ItemListScreen(
     title: String,
+    mediaType: MediaType,
     itemListViewModel: ItemListViewModel,
+    viewModeViewModel: ViewModeViewModel,
     actionsViewModel: ActionsViewModel,
     onNavigateClick: (AppMediaItem) -> Unit,
     onBack: () -> Unit,
@@ -31,10 +34,11 @@ fun ItemListScreen(
     clickContext: ClickContext,
 ) {
     val state by itemListViewModel.state.collectAsStateWithLifecycle()
+    val viewMode by viewModeViewModel.viewModeFor(mediaType).collectAsStateWithLifecycle()
 
     TopBarLayout(
         topBar = {
-            TopAppBar(
+            TwoRowTopAppBar(
                 title = { Text(title) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
@@ -43,6 +47,12 @@ fun ItemListScreen(
                             stringResource(Res.string.common_back),
                         )
                     }
+                },
+                secondRow = {
+                    ViewModeToggle(
+                        viewMode = viewMode,
+                        onToggleViewMode = { viewModeViewModel.toggleFor(mediaType) },
+                    )
                 },
             )
         },

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListScreen.kt
@@ -12,7 +12,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.music_assistant.client.data.model.client.ClickContext
 import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.items.AppMediaItem
-import io.music_assistant.client.settings.ViewMode
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.library.ItemList
 import io.music_assistant.client.ui.compose.nav.TopBarLayout
@@ -67,7 +66,7 @@ fun ItemListScreen(
             libraryActions = actionsViewModel,
             progressActions = actionsViewModel,
             contentPadding = contentPadding,
-            viewMode = ViewMode.GRID,
+            viewMode = viewMode,
             clickContext = clickContext,
         )
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListViewModel.kt
@@ -3,6 +3,7 @@ package io.music_assistant.client.ui.compose.item
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.music_assistant.client.api.Request
+import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.server.ServerMediaItem
 import io.music_assistant.client.data.repository.MediaItemRepository
@@ -54,12 +55,20 @@ class ItemListViewModel(
 
 @Serializable
 sealed interface ItemList {
-    @Serializable
-    data class ArtistAlbums(val providerInstance: String, val artistId: String) : ItemList
+    val mediaType: MediaType
 
     @Serializable
-    data class ArtistTopTracks(val providerInstance: String, val artistId: String) : ItemList
+    data class ArtistAlbums(val providerInstance: String, val artistId: String) : ItemList {
+        override val mediaType: MediaType = MediaType.ALBUM
+    }
 
     @Serializable
-    data class ArtistLibrary(val artistId: String) : ItemList
+    data class ArtistTopTracks(val providerInstance: String, val artistId: String) : ItemList {
+        override val mediaType: MediaType = MediaType.TRACK
+    }
+
+    @Serializable
+    data class ArtistLibrary(val artistId: String) : ItemList {
+        override val mediaType: MediaType = MediaType.ALBUM
+    }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ViewModeMediator.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ViewModeMediator.kt
@@ -1,0 +1,17 @@
+package io.music_assistant.client.ui.compose.item
+
+import io.music_assistant.client.data.model.client.MediaType
+import io.music_assistant.client.settings.SettingsRepository
+import io.music_assistant.client.settings.ViewMode
+import kotlinx.coroutines.flow.StateFlow
+
+class ViewModeMediator(private val settingsRepository: SettingsRepository) {
+    fun viewModeFor(mediaType: MediaType): StateFlow<ViewMode> {
+        return settingsRepository.viewMode(mediaType)
+    }
+
+    fun toggleFor(mediaType: MediaType) {
+        val current = settingsRepository.viewMode(mediaType).value
+        settingsRepository.setViewMode(mediaType, current.toggled())
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ViewModeToggle.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ViewModeToggle.kt
@@ -1,0 +1,25 @@
+package io.music_assistant.client.ui.compose.item
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ViewList
+import androidx.compose.material.icons.filled.GridView
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import io.music_assistant.client.settings.ViewMode
+import musicassistantclient.composeapp.generated.resources.Res
+import musicassistantclient.composeapp.generated.resources.cd_toggle_view_mode
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun ViewModeToggle(viewMode: ViewMode, onToggleViewMode: () -> Unit) {
+    IconButton(onClick = onToggleViewMode) {
+        Icon(
+            imageVector = when (viewMode) {
+                ViewMode.LIST -> Icons.Default.GridView
+                ViewMode.GRID -> Icons.AutoMirrored.Filled.ViewList
+            },
+            contentDescription = stringResource(Res.string.cd_toggle_view_mode),
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ViewModeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ViewModeViewModel.kt
@@ -1,11 +1,12 @@
 package io.music_assistant.client.ui.compose.item
 
+import androidx.lifecycle.ViewModel
 import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.settings.ViewMode
 import kotlinx.coroutines.flow.StateFlow
 
-class ViewModeMediator(private val settingsRepository: SettingsRepository) {
+class ViewModeViewModel(private val settingsRepository: SettingsRepository) : ViewModel() {
     fun viewModeFor(mediaType: MediaType): StateFlow<ViewMode> {
         return settingsRepository.viewMode(mediaType)
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListScreen.kt
@@ -41,6 +41,7 @@ import io.music_assistant.client.ui.compose.common.ToastHost
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.item.ViewModeToggle
+import io.music_assistant.client.ui.compose.item.ViewModeViewModel
 import io.music_assistant.client.ui.compose.nav.TopBarLayout
 import io.music_assistant.client.ui.compose.nav.TwoRowTopAppBar
 import io.music_assistant.client.ui.compose.search.SearchInput
@@ -60,6 +61,7 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun LibraryListScreen(
     libraryListViewModel: LibraryListViewModel,
+    viewModeViewModel: ViewModeViewModel,
     contentPadding: PaddingValues,
     actionsViewModel: ActionsViewModel,
     onNavigateClick: (AppMediaItem) -> Unit,
@@ -82,13 +84,14 @@ fun LibraryListScreen(
     val state by libraryListViewModel.state.collectAsStateWithLifecycle()
     val providerOptions by libraryListViewModel.providerOptions.collectAsStateWithLifecycle()
     val genreOptions by libraryListViewModel.genreOptions.collectAsStateWithLifecycle()
+    val viewMode by viewModeViewModel.viewModeFor(state.mediaType).collectAsStateWithLifecycle()
 
     TopBarLayout(
         topBar = {
             LibraryListTopBar(
                 onBack = onBack,
-                onToggleViewMode = libraryListViewModel::toggleViewMode,
-                viewMode = state.viewMode,
+                onToggleViewMode = { viewModeViewModel.toggleFor(state.mediaType) },
+                viewMode = viewMode,
                 searchQuery = state.searchQuery,
                 onSearchQueryChanged = libraryListViewModel::onSearchQueryChanged,
                 onSearch = libraryListViewModel::onSearch,
@@ -114,7 +117,7 @@ fun LibraryListScreen(
             libraryActions = actionsViewModel,
             progressActions = actionsViewModel,
             contentPadding = contentPadding,
-            viewMode = state.viewMode,
+            viewMode = viewMode,
             hasMore = state.hasMore,
             isLoadingMore = state.isLoadingMore,
             onLoadMore = libraryListViewModel::loadMore,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListScreen.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.ViewList
-import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.SearchOff
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -42,11 +40,11 @@ import io.music_assistant.client.ui.compose.common.SortChip
 import io.music_assistant.client.ui.compose.common.ToastHost
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
+import io.music_assistant.client.ui.compose.item.ViewModeToggle
 import io.music_assistant.client.ui.compose.nav.TopBarLayout
 import io.music_assistant.client.ui.compose.nav.TwoRowTopAppBar
 import io.music_assistant.client.ui.compose.search.SearchInput
 import musicassistantclient.composeapp.generated.resources.Res
-import musicassistantclient.composeapp.generated.resources.cd_toggle_view_mode
 import musicassistantclient.composeapp.generated.resources.common_back
 import musicassistantclient.composeapp.generated.resources.library_quick_search
 import musicassistantclient.composeapp.generated.resources.media_type_albums
@@ -252,15 +250,10 @@ private fun LibraryListTopBar(
                         onSortChanged = { onSortChanged(it) },
                     )
 
-                    IconButton(onClick = onToggleViewMode) {
-                        Icon(
-                            imageVector = when (viewMode) {
-                                ViewMode.LIST -> Icons.Default.GridView
-                                ViewMode.GRID -> Icons.AutoMirrored.Filled.ViewList
-                            },
-                            contentDescription = stringResource(Res.string.cd_toggle_view_mode),
-                        )
-                    }
+                    ViewModeToggle(
+                        viewMode = viewMode,
+                        onToggleViewMode = onToggleViewMode,
+                    )
                 }
             },
         )

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListScreen.kt
@@ -2,12 +2,9 @@
 
 package io.music_assistant.client.ui.compose.library
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -243,21 +240,16 @@ private fun LibraryListTopBar(
                 }
             },
             secondRow = {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
-                ) {
-                    SortChip(
-                        currentSort = sortOption,
-                        availableFields = SortConfig.fieldsFor(mediaType),
-                        onSortChanged = { onSortChanged(it) },
-                    )
+                SortChip(
+                    currentSort = sortOption,
+                    availableFields = SortConfig.fieldsFor(mediaType),
+                    onSortChanged = { onSortChanged(it) },
+                )
 
-                    ViewModeToggle(
-                        viewMode = viewMode,
-                        onToggleViewMode = onToggleViewMode,
-                    )
-                }
+                ViewModeToggle(
+                    viewMode = viewMode,
+                    onToggleViewMode = onToggleViewMode,
+                )
             },
         )
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListViewModel.kt
@@ -17,11 +17,9 @@ import io.music_assistant.client.data.model.server.ServerProviderInstance
 import io.music_assistant.client.data.repository.MediaItemChange
 import io.music_assistant.client.data.repository.MediaItemRepository
 import io.music_assistant.client.settings.SettingsRepository
-import io.music_assistant.client.settings.ViewMode
 import io.music_assistant.client.ui.Timings
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.SelectOption
-import io.music_assistant.client.ui.compose.item.ViewModeMediator
 import io.music_assistant.client.utils.resultAs
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -66,8 +64,6 @@ class LibraryListViewModel(
     val genreOptions = _genreOptions.asStateFlow()
     private var optionsRequested = false
 
-    private val viewModeMediator = ViewModeMediator(settingsRepository)
-
     init {
         viewModelScope.launch {
             searchTrigger
@@ -75,12 +71,6 @@ class LibraryListViewModel(
                 .collect {
                     loadFirstPage()
                 }
-        }
-
-        viewModelScope.launch {
-            viewModeMediator.viewModeFor(mediaType).collect { mode ->
-                _state.update { it.copy(viewMode = mode) }
-            }
         }
 
         // Settings are the source of truth for filters; fold emissions into state
@@ -145,10 +135,6 @@ class LibraryListViewModel(
     private fun AppMediaItem.matchesIdentityOf(other: AppMediaItem): Boolean =
         (mediaType == other.mediaType && provider == other.provider && itemId == other.itemId) ||
             hasAnyMappingFrom(other)
-
-    fun toggleViewMode() {
-        viewModeMediator.toggleFor(mediaType)
-    }
 
     // Persistence is the source of truth (like view mode); the settings flow
     // collector folds the new value back into state and triggers a refetch.
@@ -479,7 +465,6 @@ class LibraryListViewModel(
         val hasMore: Boolean = true,
         val searchQuery: String = "",
         val sortOption: SortOption = SortConfig.defaultFor(mediaType),
-        val viewMode: ViewMode = ViewMode.GRID,
         val offset: Int = 0,
         // Per-type filter set; only the fields applicable to [mediaType] are surfaced.
         val filters: LibraryFilters = LibraryFilters.DEFAULT,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListViewModel.kt
@@ -21,6 +21,7 @@ import io.music_assistant.client.settings.ViewMode
 import io.music_assistant.client.ui.Timings
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.SelectOption
+import io.music_assistant.client.ui.compose.item.ViewModeMediator
 import io.music_assistant.client.utils.resultAs
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -65,6 +66,8 @@ class LibraryListViewModel(
     val genreOptions = _genreOptions.asStateFlow()
     private var optionsRequested = false
 
+    private val viewModeMediator = ViewModeMediator(settingsRepository)
+
     init {
         viewModelScope.launch {
             searchTrigger
@@ -75,7 +78,7 @@ class LibraryListViewModel(
         }
 
         viewModelScope.launch {
-            settingsRepository.viewMode(mediaType).collect { mode ->
+            viewModeMediator.viewModeFor(mediaType).collect { mode ->
                 _state.update { it.copy(viewMode = mode) }
             }
         }
@@ -144,8 +147,7 @@ class LibraryListViewModel(
             hasAnyMappingFrom(other)
 
     fun toggleViewMode() {
-        val current = settingsRepository.viewMode(mediaType).value
-        settingsRepository.setViewMode(mediaType, current.toggled())
+        viewModeMediator.toggleFor(mediaType)
     }
 
     // Persistence is the source of truth (like view mode); the settings flow

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/TwoRowTopAppBar.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/nav/TwoRowTopAppBar.kt
@@ -1,5 +1,6 @@
 package io.music_assistant.client.ui.compose.nav
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
@@ -22,6 +23,7 @@ fun TwoRowTopAppBar(
     navigationIcon: @Composable () -> Unit = {},
     actions: @Composable RowScope.() -> Unit = {},
     secondRow: @Composable RowScope.() -> Unit = {},
+    secondRowArrangement: Arrangement.Horizontal = Arrangement.End,
 ) {
     Column {
         TopAppBar(
@@ -34,6 +36,7 @@ fun TwoRowTopAppBar(
             title = {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = secondRowArrangement,
                 ) {
                     secondRow()
                 }


### PR DESCRIPTION
Work towards #801
Follow up for #834 (more on the way)

## Is there anything about the code changes here that should be highlighted?

I've extracted the repeated view mode `ViewModel` logic to its own `ViewModel` as well as creating a specific component for the toggle to make it as easy as possible to add this to new/existing screens when needed.

## Before submitting this PR, make sure you have:
- [x] Given this PR a readable name that can be used in the app's changelog
- [x] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

