### PR TITLE
Fix home page on Music Assistant Server 2.10 Beta

### DIFF
--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/HomeTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/HomeTest.kt
@@ -27,6 +27,19 @@ class HomeTest {
 
     val serviceClient: FakeServiceClient by inject(ServiceClient::class.java)
 
+    // The default FakeServiceClient serves item-less rows resolved per row;
+    // legacy versions embed the items in the rows response.
+    @Test
+    fun `loads home recommendations from servers that embed row items`() {
+        serviceClient.setLegacyVersion(FakeServiceClient.LegacyVersion.V2_9)
+
+        val album = ServerMediaItemFixtures.album()
+        serviceClient.addItems(album)
+
+        launchLoggedInApp(composeTestRule, serviceClient)
+            .assertMediaDisplayed(album)
+    }
+
     @Test
     fun `can refresh home recommendations`() {
         val album1 = ServerMediaItemFixtures.album()

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -128,34 +128,41 @@ class FakeServiceClient : ServiceClient {
             }
 
             APICommands.MUSIC_RECOMMENDATIONS -> {
+                // Legacy servers embed each row's items; current servers return
+                // item-less rows resolved via MUSIC_RECOMMENDATIONS_ITEMS.
+                val embedItems = legacyVersion != null
                 Result.success(
                     answer(
                         request = request,
-                        result = listOf(
+                        result = recommendationRowIds.map { (itemId, name) ->
                             ServerMediaItem(
-                                itemId = "recently_added_albums",
+                                itemId = itemId,
                                 provider = "library",
-                                name = "Recently added albums",
+                                name = name,
                                 mediaType = MediaType.FOLDER.serverValue,
-                                items = mediaItemStore.query(mediaType = MediaType.ALBUM),
-                            ),
-                            ServerMediaItem(
-                                itemId = "recently_added_tracks",
-                                provider = "library",
-                                name = "Recently added tracks",
-                                mediaType = MediaType.FOLDER.serverValue,
-                                items = mediaItemStore.query(mediaType = MediaType.TRACK),
-                            ),
-                            ServerMediaItem(
-                                itemId = "recently_added_artists",
-                                provider = "library",
-                                name = "Recently added artists",
-                                mediaType = MediaType.FOLDER.serverValue,
-                                items = mediaItemStore.query(mediaType = MediaType.ARTIST),
-                            ),
-                        ),
+                                items = if (embedItems) {
+                                    recommendationRowItems(itemId)
+                                } else {
+                                    emptyList()
+                                },
+                            )
+                        },
                     ),
                 )
+            }
+
+            APICommands.MUSIC_RECOMMENDATIONS_ITEMS -> {
+                if (legacyVersion != null) {
+                    // Command doesn't exist on legacy servers.
+                    Result.failure(UnsupportedOperationException())
+                } else {
+                    Result.success(
+                        answer(
+                            request = request,
+                            result = recommendationRowItems(request.getArg("item_id")),
+                        ),
+                    )
+                }
             }
 
             APICommands.MUSIC_SEARCH -> {
@@ -724,6 +731,20 @@ class FakeServiceClient : ServiceClient {
             null
         }
     }
+
+    private val recommendationRowIds = listOf(
+        "recently_added_albums" to "Recently added albums",
+        "recently_added_tracks" to "Recently added tracks",
+        "recently_added_artists" to "Recently added artists",
+    )
+
+    private fun recommendationRowItems(itemId: String): List<ServerMediaItem> =
+        when (itemId) {
+            "recently_added_albums" -> mediaItemStore.query(mediaType = MediaType.ALBUM)
+            "recently_added_tracks" -> mediaItemStore.query(mediaType = MediaType.TRACK)
+            "recently_added_artists" -> mediaItemStore.query(mediaType = MediaType.ARTIST)
+            else -> emptyList()
+        }
 
     private fun findItem(request: Request): ServerMediaItem {
         val itemId = request.getArg("item_id")

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -649,7 +649,10 @@ class FakeServiceClient : ServiceClient {
                     serverInfo = ServerInfo(
                         serverId = serverId,
                         serverVersion = "fake",
-                        schemaVersion = -1,
+                        // Schema 39+ moved recommendation row items behind
+                        // MUSIC_RECOMMENDATIONS_ITEMS; this fake serves that
+                        // shape unless a legacy version is set.
+                        schemaVersion = if (legacyVersion != null) -1 else 39,
                         baseUrl = "http://homeassistant.example",
                     ),
                 )

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/APICommands.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/APICommands.kt
@@ -84,6 +84,10 @@ object APICommands {
     // Search and recommendations
     const val MUSIC_SEARCH = "music/search"
     const val MUSIC_RECOMMENDATIONS = "music/recommendations"
+
+    // Contents of a single recommendation row. Exists on servers (2.10+) whose
+    // MUSIC_RECOMMENDATIONS response returns rows without embedded items
+    const val MUSIC_RECOMMENDATIONS_ITEMS = "music/recommendations/items"
     const val PROVIDERS_MANIFESTS = "providers/manifests"
     const val PROVIDERS = "providers"
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Request.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Request.kt
@@ -729,6 +729,17 @@ data class Request @OptIn(ExperimentalUuidApi::class) constructor(
 
         fun recommendations() = Request(command = APICommands.MUSIC_RECOMMENDATIONS)
 
+        /**
+         * Items of a single recommendation row. Only exists on servers (2.10+)
+         */
+        fun recommendationItems(provider: String, itemId: String) = Request(
+            command = APICommands.MUSIC_RECOMMENDATIONS_ITEMS,
+            args = buildJsonObject {
+                put("provider", JsonPrimitive(provider))
+                put("item_id", JsonPrimitive(itemId))
+            },
+        )
+
         fun providersManifests() = Request(command = APICommands.PROVIDERS_MANIFESTS)
 
         /** Loaded provider instances (music/player/…); filter client-side by type. */

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Request.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Request.kt
@@ -730,7 +730,8 @@ data class Request @OptIn(ExperimentalUuidApi::class) constructor(
         fun recommendations() = Request(command = APICommands.MUSIC_RECOMMENDATIONS)
 
         /**
-         * Items of a single recommendation row. Only exists on servers (2.10+)
+         * Items of a single recommendation row. Only exists on servers that
+         * return [recommendations] rows without embedded items.
          */
         fun recommendationItems(provider: String, itemId: String) = Request(
             command = APICommands.MUSIC_RECOMMENDATIONS_ITEMS,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerInfo.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerInfo.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** Highest server schema_version this client is built and tested against. */
-const val LOCAL_SCHEMA_VERSION = 31
+const val LOCAL_SCHEMA_VERSION = 39
 
 @Serializable
 data class ServerInfo(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/repository/MediaItemRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/repository/MediaItemRepository.kt
@@ -11,9 +11,11 @@ import io.music_assistant.client.data.model.server.ServerMediaItem
 import io.music_assistant.client.data.model.server.events.MediaItemAddedEvent
 import io.music_assistant.client.data.model.server.events.MediaItemDeletedEvent
 import io.music_assistant.client.data.model.server.events.MediaItemUpdatedEvent
+import io.music_assistant.client.utils.HasConnectionData
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -25,6 +27,7 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.withContext
 
 /**
  * Single seam between RPC + DTO land and the UI's typed `AppMediaItem` world.
@@ -69,42 +72,50 @@ class MediaItemRepository(
 
     /**
      * The home-page recommendation rows as the server returned them, with or
-     * without embedded items (see [needPerRowItemFetch]).
+     * without embedded items (see [supportsRecommendationRowItems]).
      */
     suspend fun fetchRecommendationRows(): Result<List<RecommendationFolder>> =
-        fetchMediaItems(Request.Library.recommendations())
-            .map { items -> items.filterIsInstance<RecommendationFolder>() }
+        withContext(Dispatchers.IO) {
+            fetchMediaItems(Request.Library.recommendations())
+                .map { items -> items.filterIsInstance<RecommendationFolder>() }
+        }
+
+    /**
+     * Whether the connected server strips the items from `music/recommendations`
+     * rows and serves each row's contents via `music/recommendations/items`
+     * instead. This can be simplified once v2.10 is our minimum supported server
+     * version.
+     */
+    fun supportsRecommendationRowItems(): Boolean =
+        (apiClient.sessionState.value as? HasConnectionData)?.serverInfo?.schemaVersion
+            ?.let { it >= RECOMMENDATION_ITEMS_SCHEMA } == true
 
     /**
      * One-shot, fully-resolved recommendation rows for consumers without a
-     * progressive UI (e.g. CarPlay lists). The first row is probed alone —
-     * see [needPerRowItemFetch].
+     * progressive UI (e.g. CarPlay lists).
      */
     suspend fun fetchRecommendationFolders(): Result<List<RecommendationFolder>> {
         val folders = fetchRecommendationRows().getOrElse { error ->
             if (error is CancellationException) throw error
             return Result.failure(error)
         }
-        if (!folders.needPerRowItemFetch()) return Result.success(folders)
+        if (!supportsRecommendationRowItems()) return Result.success(folders)
 
-        val firstRowItems = fetchRecommendationRowItems(folders.first())
-            ?: return Result.success(folders)
-        val remaining = coroutineScope {
-            folders.drop(1).map { folder ->
-                async {
-                    folder.copy(items = fetchRecommendationRowItems(folder).orEmpty())
-                }
-            }.awaitAll()
-        }
         return Result.success(
-            listOf(folders.first().copy(items = firstRowItems)) + remaining,
+            coroutineScope {
+                folders.map { folder ->
+                    async {
+                        folder.copy(items = fetchRecommendationRowItems(folder).orEmpty())
+                    }
+                }.awaitAll()
+            },
         )
     }
 
     /** Items of one recommendation row, or null when the fetch failed (logged). */
     suspend fun fetchRecommendationRowItems(
         folder: RecommendationFolder,
-    ): List<AppMediaItem>? =
+    ): List<AppMediaItem>? = withContext(Dispatchers.IO) {
         fetchMediaItems(
             Request.Library.recommendationItems(folder.provider, folder.itemId),
         ).getOrElse { error ->
@@ -115,6 +126,7 @@ class MediaItemRepository(
             )
             null
         }
+    }
 
     /**
      * Issue [request] and decode its payload as a single client media item.
@@ -189,14 +201,5 @@ class MediaItemRepository(
 private fun <T : AppMediaItem> List<T>.replacing(changed: T): List<T> =
     map { if (it.itemId == changed.itemId) changed else it }
 
-/**
- * True when a `music/recommendations` response is the item-less shape (2.10+):
- * every row arrived without items, so each row's contents must be fetched via
- * [MediaItemRepository.fetchRecommendationRowItems]. A server that embeds items
- * always populates at least the rows worth showing. Callers should probe the
- * first row alone before fanning out: a pre-2.10 server that legitimately
- * returned only empty rows lacks the items command, and every failing call
- * there surfaces a user-visible error toast.
- */
-fun List<RecommendationFolder>.needPerRowItemFetch(): Boolean =
-    isNotEmpty() && all { it.items.isNullOrEmpty() }
+/** Server schema version that split `music/recommendations` into rows + per-row items. */
+private const val RECOMMENDATION_ITEMS_SCHEMA = 39

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/repository/MediaItemRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/repository/MediaItemRepository.kt
@@ -15,20 +15,16 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.flow.last
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.shareIn
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 
 /**
  * Single seam between RPC + DTO land and the UI's typed `AppMediaItem` world.
@@ -72,68 +68,41 @@ class MediaItemRepository(
     }
 
     /**
-     * Stream the home-page recommendation rows as snapshots, bridging the two
-     * response shapes `music/recommendations` can have:
-     * - rows with their items embedded (servers before 2.10): a single snapshot,
-     *   no row is ever [RecommendationRow.itemsLoading];
-     * - rows without items (2.10+), whose contents come from a per-row
-     *   `music/recommendations/items` call: an immediate snapshot with every row
-     *   loading, then one snapshot per row as its items resolve.
+     * The home-page recommendation rows as the server returned them, with or
+     * without embedded items (see [needPerRowItemFetch]).
      */
-    fun recommendationRows(): Flow<List<RecommendationRow>> = channelFlow {
-        val folders = fetchMediaItems(Request.Library.recommendations())
-            .getOrThrow()
-            .filterIsInstance<RecommendationFolder>()
-        val itemLess = folders.isNotEmpty() && folders.all { it.items.isNullOrEmpty() }
-        if (!itemLess) {
-            send(folders.map { RecommendationRow(it, itemsLoading = false) })
-            return@channelFlow
-        }
-
-        val rows = MutableList(folders.size) { RecommendationRow(folders[it], itemsLoading = true) }
-        val lock = Mutex()
-        suspend fun resolve(index: Int, items: List<AppMediaItem>?) = lock.withLock {
-            val folder = rows[index].folder
-            rows[index] = RecommendationRow(
-                folder = if (items == null) folder else folder.copy(items = items),
-                itemsLoading = false,
-            )
-            send(rows.toList())
-        }
-
-        send(rows.toList())
-        val probeItems = fetchRecommendationRowItems(folders.first())
-        if (probeItems == null) {
-            lock.withLock {
-                for (index in rows.indices) {
-                    rows[index] = rows[index].copy(itemsLoading = false)
-                }
-                send(rows.toList())
-            }
-            return@channelFlow
-        }
-        resolve(0, probeItems)
-        coroutineScope {
-            for (index in 1 until folders.size) {
-                launch { resolve(index, fetchRecommendationRowItems(folders[index])) }
-            }
-        }
-    }
+    suspend fun fetchRecommendationRows(): Result<List<RecommendationFolder>> =
+        fetchMediaItems(Request.Library.recommendations())
+            .map { items -> items.filterIsInstance<RecommendationFolder>() }
 
     /**
-     * One-shot, fully-resolved variant of [recommendationRows] for consumers
-     * without progressive UI (e.g. CarPlay lists).
+     * One-shot, fully-resolved recommendation rows for consumers without a
+     * progressive UI (e.g. CarPlay lists). The first row is probed alone —
+     * see [needPerRowItemFetch].
      */
-    suspend fun fetchRecommendationFolders(): Result<List<RecommendationFolder>> = try {
-        Result.success(recommendationRows().last().map { it.folder })
-    } catch (e: CancellationException) {
-        throw e
-    } catch (e: Exception) {
-        Result.failure(e)
+    suspend fun fetchRecommendationFolders(): Result<List<RecommendationFolder>> {
+        val folders = fetchRecommendationRows().getOrElse { error ->
+            if (error is CancellationException) throw error
+            return Result.failure(error)
+        }
+        if (!folders.needPerRowItemFetch()) return Result.success(folders)
+
+        val firstRowItems = fetchRecommendationRowItems(folders.first())
+            ?: return Result.success(folders)
+        val remaining = coroutineScope {
+            folders.drop(1).map { folder ->
+                async {
+                    folder.copy(items = fetchRecommendationRowItems(folder).orEmpty())
+                }
+            }.awaitAll()
+        }
+        return Result.success(
+            listOf(folders.first().copy(items = firstRowItems)) + remaining,
+        )
     }
 
     /** Items of one recommendation row, or null when the fetch failed (logged). */
-    private suspend fun fetchRecommendationRowItems(
+    suspend fun fetchRecommendationRowItems(
         folder: RecommendationFolder,
     ): List<AppMediaItem>? =
         fetchMediaItems(
@@ -221,11 +190,13 @@ private fun <T : AppMediaItem> List<T>.replacing(changed: T): List<T> =
     map { if (it.itemId == changed.itemId) changed else it }
 
 /**
- * One home-page recommendation row snapshot: the folder (with whatever items are
- * known so far) plus whether its items are still being fetched. Rows from a
- * server that embeds items are never [itemsLoading].
+ * True when a `music/recommendations` response is the item-less shape (2.10+):
+ * every row arrived without items, so each row's contents must be fetched via
+ * [MediaItemRepository.fetchRecommendationRowItems]. A server that embeds items
+ * always populates at least the rows worth showing. Callers should probe the
+ * first row alone before fanning out: a pre-2.10 server that legitimately
+ * returned only empty rows lacks the items command, and every failing call
+ * there surfaces a user-visible error toast.
  */
-data class RecommendationRow(
-    val folder: RecommendationFolder,
-    val itemsLoading: Boolean,
-)
+fun List<RecommendationFolder>.needPerRowItemFetch(): Boolean =
+    isNotEmpty() && all { it.items.isNullOrEmpty() }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/repository/MediaItemRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/repository/MediaItemRepository.kt
@@ -1,24 +1,34 @@
 package io.music_assistant.client.data.repository
 
+import co.touchlab.kermit.Logger
 import io.music_assistant.client.api.Request
 import io.music_assistant.client.api.ServiceClient
 import io.music_assistant.client.data.factory.MediaItemFactory
 import io.music_assistant.client.data.model.client.items.AppMediaItem
+import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.data.model.server.SearchResult
 import io.music_assistant.client.data.model.server.ServerMediaItem
 import io.music_assistant.client.data.model.server.events.MediaItemAddedEvent
 import io.music_assistant.client.data.model.server.events.MediaItemDeletedEvent
 import io.music_assistant.client.data.model.server.events.MediaItemUpdatedEvent
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.last
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 /**
  * Single seam between RPC + DTO land and the UI's typed `AppMediaItem` world.
@@ -60,6 +70,82 @@ class MediaItemRepository(
                 .collect { observer(it) }
         }
     }
+
+    /**
+     * Stream the home-page recommendation rows as snapshots, bridging the two
+     * response shapes `music/recommendations` can have:
+     * - rows with their items embedded (servers before 2.10): a single snapshot,
+     *   no row is ever [RecommendationRow.itemsLoading];
+     * - rows without items (2.10+), whose contents come from a per-row
+     *   `music/recommendations/items` call: an immediate snapshot with every row
+     *   loading, then one snapshot per row as its items resolve.
+     */
+    fun recommendationRows(): Flow<List<RecommendationRow>> = channelFlow {
+        val folders = fetchMediaItems(Request.Library.recommendations())
+            .getOrThrow()
+            .filterIsInstance<RecommendationFolder>()
+        val itemLess = folders.isNotEmpty() && folders.all { it.items.isNullOrEmpty() }
+        if (!itemLess) {
+            send(folders.map { RecommendationRow(it, itemsLoading = false) })
+            return@channelFlow
+        }
+
+        val rows = MutableList(folders.size) { RecommendationRow(folders[it], itemsLoading = true) }
+        val lock = Mutex()
+        suspend fun resolve(index: Int, items: List<AppMediaItem>?) = lock.withLock {
+            val folder = rows[index].folder
+            rows[index] = RecommendationRow(
+                folder = if (items == null) folder else folder.copy(items = items),
+                itemsLoading = false,
+            )
+            send(rows.toList())
+        }
+
+        send(rows.toList())
+        val probeItems = fetchRecommendationRowItems(folders.first())
+        if (probeItems == null) {
+            lock.withLock {
+                for (index in rows.indices) {
+                    rows[index] = rows[index].copy(itemsLoading = false)
+                }
+                send(rows.toList())
+            }
+            return@channelFlow
+        }
+        resolve(0, probeItems)
+        coroutineScope {
+            for (index in 1 until folders.size) {
+                launch { resolve(index, fetchRecommendationRowItems(folders[index])) }
+            }
+        }
+    }
+
+    /**
+     * One-shot, fully-resolved variant of [recommendationRows] for consumers
+     * without progressive UI (e.g. CarPlay lists).
+     */
+    suspend fun fetchRecommendationFolders(): Result<List<RecommendationFolder>> = try {
+        Result.success(recommendationRows().last().map { it.folder })
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    /** Items of one recommendation row, or null when the fetch failed (logged). */
+    private suspend fun fetchRecommendationRowItems(
+        folder: RecommendationFolder,
+    ): List<AppMediaItem>? =
+        fetchMediaItems(
+            Request.Library.recommendationItems(folder.provider, folder.itemId),
+        ).getOrElse { error ->
+            if (error is CancellationException) throw error
+            Logger.w(
+                "Failed fetching recommendation items for " +
+                        "${folder.provider}/${folder.itemId}: $error",
+            )
+            null
+        }
 
     /**
      * Issue [request] and decode its payload as a single client media item.
@@ -133,3 +219,13 @@ class MediaItemRepository(
 
 private fun <T : AppMediaItem> List<T>.replacing(changed: T): List<T> =
     map { if (it.itemId == changed.itemId) changed else it }
+
+/**
+ * One home-page recommendation row snapshot: the folder (with whatever items are
+ * known so far) plus whether its items are still being fetched. Rows from a
+ * server that embeds items are never [itemsLoading].
+ */
+data class RecommendationRow(
+    val folder: RecommendationFolder,
+    val itemsLoading: Boolean,
+)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeRowsConfig.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeRowsConfig.kt
@@ -1,14 +1,13 @@
 package io.music_assistant.client.ui.compose.home
 
 import io.music_assistant.client.settings.SettingsRepository.HomeRowPref
-import io.music_assistant.client.ui.compose.common.items.ItemCategory
 
 /**
  * Reconciles the live server rows against the stored [config] into an
  * ordered, enabled-flagged working list.
  *
  * Rules:
- * - A row's enabled state is taken from [config] by `itemId`; rows new to the
+ * - A row's enabled state is taken from [config] by [id]; rows new to the
  *   client (absent from config) default to enabled (visible).
  * - Enabled rows come first, then disabled rows — the enabled block stays
  *   contiguous at the top so the reorderable drag constraint (index < enabledCount)
@@ -17,24 +16,25 @@ import io.music_assistant.client.ui.compose.common.items.ItemCategory
  *   from config keep server order and sort after the known ones (stable sort).
  * - Stored ids no longer present on the server are ignored.
  */
-internal fun reconcileHomeRows(
-    categories: List<ItemCategory<*>>,
+internal fun <T> reconcileHomeRows(
+    rows: List<T>,
     config: List<HomeRowPref>,
     onTop: String? = null,
-): List<Pair<ItemCategory<*>, Boolean>> {
+    id: (T) -> String,
+): List<Pair<T, Boolean>> {
     val enabledById = config.associate { it.id to it.enabled }
     val orderById = config.withIndex().associate { (index, pref) -> pref.id to index }
-    val sortedCategories = categories
-        .map { category -> category to (enabledById[category.id] ?: true) }
+    val sortedRows = rows
+        .map { row -> row to (enabledById[id(row)] ?: true) }
         .sortedWith(
-            compareByDescending<Pair<ItemCategory<*>, Boolean>> { it.second }
-                .thenBy { orderById[it.first.id] ?: Int.MAX_VALUE },
+            compareByDescending<Pair<T, Boolean>> { it.second }
+                .thenBy { orderById[id(it.first)] ?: Int.MAX_VALUE },
         )
 
     return if (onTop != null && config.any { it.id == onTop }) {
-        sortedCategories
+        sortedRows
     } else {
-        sortedCategories.filter { it.first.id == onTop } +
-                sortedCategories.filter { it.first.id != onTop }
+        sortedRows.filter { id(it.first) == onTop } +
+                sortedRows.filter { id(it.first) != onTop }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeRowsConfig.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeRowsConfig.kt
@@ -2,13 +2,18 @@ package io.music_assistant.client.ui.compose.home
 
 import io.music_assistant.client.settings.SettingsRepository.HomeRowPref
 
+/** A row that can be reconciled against stored [HomeRowPref]s by stable id. */
+internal interface IdProvider {
+    val id: String
+}
+
 /**
  * Reconciles the live server rows against the stored [config] into an
  * ordered, enabled-flagged working list.
  *
  * Rules:
- * - A row's enabled state is taken from [config] by [id]; rows new to the
- *   client (absent from config) default to enabled (visible).
+ * - A row's enabled state is taken from [config] by [IdProvider.id]; rows new
+ *   to the client (absent from config) default to enabled (visible).
  * - Enabled rows come first, then disabled rows — the enabled block stays
  *   contiguous at the top so the reorderable drag constraint (index < enabledCount)
  *   holds.
@@ -16,25 +21,24 @@ import io.music_assistant.client.settings.SettingsRepository.HomeRowPref
  *   from config keep server order and sort after the known ones (stable sort).
  * - Stored ids no longer present on the server are ignored.
  */
-internal fun <T> reconcileHomeRows(
+internal fun <T : IdProvider> reconcileHomeRows(
     rows: List<T>,
     config: List<HomeRowPref>,
     onTop: String? = null,
-    id: (T) -> String,
 ): List<Pair<T, Boolean>> {
     val enabledById = config.associate { it.id to it.enabled }
     val orderById = config.withIndex().associate { (index, pref) -> pref.id to index }
     val sortedRows = rows
-        .map { row -> row to (enabledById[id(row)] ?: true) }
+        .map { row -> row to (enabledById[row.id] ?: true) }
         .sortedWith(
             compareByDescending<Pair<T, Boolean>> { it.second }
-                .thenBy { orderById[id(it.first)] ?: Int.MAX_VALUE },
+                .thenBy { orderById[it.first.id] ?: Int.MAX_VALUE },
         )
 
     return if (onTop != null && config.any { it.id == onTop }) {
         sortedRows
     } else {
-        sortedRows.filter { id(it.first) == onTop } +
-                sortedRows.filter { id(it.first) != onTop }
+        sortedRows.filter { it.first.id == onTop } +
+                sortedRows.filter { it.first.id != onTop }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -55,8 +55,8 @@ import io.music_assistant.client.data.model.client.items.Playlist
 import io.music_assistant.client.data.model.client.items.Podcast
 import io.music_assistant.client.data.model.client.items.PodcastEpisode
 import io.music_assistant.client.data.model.client.items.RadioStation
-import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.data.model.client.items.Track
+import io.music_assistant.client.data.repository.RecommendationRow
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.compose.common.CenteredProgress
 import io.music_assistant.client.ui.compose.common.CenteredText
@@ -107,7 +107,8 @@ fun HomeScreen(
     // snapshotted fresh on entering edit mode.
     var items by remember { mutableStateOf(working) }
     val enabledCount = items.count { it.second }
-    val enabledByKey = remember(items) { items.associate { it.first.lazyListKey to it.second } }
+    val enabledByKey =
+        remember(items) { items.associate { it.first.category.lazyListKey to it.second } }
 
     var editMode by remember { mutableStateOf(false) }
     val displayedData =
@@ -131,7 +132,7 @@ fun HomeScreen(
                         homeScreenViewModel.saveHomeRows(
                             items.map {
                                 SettingsRepository.HomeRowPref(
-                                    it.first.id,
+                                    it.first.category.id,
                                     it.second,
                                 )
                             },
@@ -154,9 +155,10 @@ fun HomeScreen(
                 color = MaterialTheme.colorScheme.error,
             )
         } else {
-            val rowContent: @Composable (ItemCategory<*>) -> Unit = {
+            val rowContent: @Composable (HomeRow) -> Unit = { row ->
                 CategoryRow(
-                    itemCategory = it,
+                    data = if (row.loading) DataState.Loading() else DataState.Data(row.category),
+                    itemCategoryProvider = { it },
                     onNavigateClick = onNavigateClick,
                     onPlayClick = { item, option, radio, _ ->
                         homeScreenViewModel.onPlayClick(item, option, radio)
@@ -177,13 +179,13 @@ fun HomeScreen(
                 ) {
                     items(
                         items = displayedData,
-                        key = { it.lazyListKey },
-                    ) { itemCategory ->
+                        key = { it.category.lazyListKey },
+                    ) { homeRow ->
                         if (editMode) {
-                            val enabled = enabledByKey[itemCategory.lazyListKey] ?: true
-                            ReorderableItem(reorderableState, key = itemCategory.lazyListKey) {
+                            val enabled = enabledByKey[homeRow.category.lazyListKey] ?: true
+                            ReorderableItem(reorderableState, key = homeRow.category.lazyListKey) {
                                 Box(modifier = Modifier.fillMaxWidth()) {
-                                    rowContent(itemCategory)
+                                    rowContent(homeRow)
                                     Box(
                                         modifier = Modifier
                                             .matchParentSize()
@@ -213,7 +215,7 @@ fun HomeScreen(
                                                 items =
                                                     moveToEnabledBoundary(
                                                         items,
-                                                        itemCategory,
+                                                        homeRow,
                                                         newEnabled,
                                                     )
                                             },
@@ -234,7 +236,7 @@ fun HomeScreen(
                                 }
                             }
                         } else {
-                            rowContent(itemCategory)
+                            rowContent(homeRow)
                         }
                     }
                 }
@@ -243,15 +245,29 @@ fun HomeScreen(
     }
 }
 
-private fun getCategories(
-    recommendationsState: DataState<List<RecommendationFolder>>,
+/**
+ * One reconciled home row: its display/reorder identity ([category], valid before
+ * the row's items resolve) plus whether those items are still loading, which
+ * [CategoryRow]'s [DataState] overload renders as a placeholder.
+ */
+internal data class HomeRow(
+    val category: ItemCategory<Nothing>,
+    val loading: Boolean,
+)
+
+// Internal so HomeScreenCategoriesTest can pin the row visibility rules: loading
+// rows stay, resolved-empty rows are hidden.
+internal fun getCategories(
+    recommendationsState: DataState<List<RecommendationRow>>,
     shortcutsState: DataState<List<Shortcut>>,
     homeRowsConfig: List<SettingsRepository.HomeRowPref>,
-): List<Pair<ItemCategory<*>, Boolean>> {
+): List<Pair<HomeRow, Boolean>> {
     val baseList = if (recommendationsState is DataState.Data) {
         val recommendations = recommendationsState.data
-            .filter {
-                it.items?.any { item ->
+            // A still-loading row stays visible as a placeholder; a resolved row
+            // must contain something the home page can render.
+            .filter { row ->
+                row.itemsLoading || row.folder.items?.any { item ->
                     item is Track ||
                             item is Artist ||
                             item is Album ||
@@ -263,28 +279,34 @@ private fun getCategories(
                             item is Genre
                 } == true
             }
-            .distinctBy { it.lazyListKey() }
-            .map {
-                ItemCategory<Nothing>(
-                    id = it.itemId,
-                    title = it.displayName.toDisplayString(),
-                    items = it.items.orEmpty(),
-                    lazyListKey = it.lazyListKey(),
-                    tag = HomeScreenSemantics.rowTag(it.itemId),
+            .distinctBy { it.folder.lazyListKey() }
+            .map { row ->
+                HomeRow(
+                    category = ItemCategory(
+                        id = row.folder.itemId,
+                        title = row.folder.displayName.toDisplayString(),
+                        items = row.folder.items.orEmpty(),
+                        lazyListKey = row.folder.lazyListKey(),
+                        tag = HomeScreenSemantics.rowTag(row.folder.itemId),
+                    ),
+                    loading = row.itemsLoading,
                 )
             }
 
         if (shortcutsState is DataState.Data && shortcutsState.data.isNotEmpty()) {
             val shortcuts = shortcutsState.data
-            val shortcutsCategory = ItemCategory<Nothing>(
-                id = SHORTCUTS_CATEGORY_ID,
-                title = Res.string.home_shortcuts.toDisplayString(),
-                items = shortcuts.map { it.item },
-                lazyListKey = SHORTCUTS_CATEGORY_ID,
-                tag = HomeScreenSemantics.SHORTCUTS_ROW_TAG,
+            val shortcutsRow = HomeRow(
+                category = ItemCategory(
+                    id = SHORTCUTS_CATEGORY_ID,
+                    title = Res.string.home_shortcuts.toDisplayString(),
+                    items = shortcuts.map { it.item },
+                    lazyListKey = SHORTCUTS_CATEGORY_ID,
+                    tag = HomeScreenSemantics.SHORTCUTS_ROW_TAG,
+                ),
+                loading = false,
             )
 
-            recommendations + shortcutsCategory
+            recommendations + shortcutsRow
         } else {
             recommendations
         }
@@ -292,7 +314,9 @@ private fun getCategories(
         emptyList()
     }
 
-    return reconcileHomeRows(baseList, homeRowsConfig, onTop = SHORTCUTS_CATEGORY_ID)
+    return reconcileHomeRows(baseList, homeRowsConfig, onTop = SHORTCUTS_CATEGORY_ID) {
+        it.category.id
+    }
 }
 
 private const val SHORTCUTS_CATEGORY_ID = "shortcuts"

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -56,7 +56,6 @@ import io.music_assistant.client.data.model.client.items.Podcast
 import io.music_assistant.client.data.model.client.items.PodcastEpisode
 import io.music_assistant.client.data.model.client.items.RadioStation
 import io.music_assistant.client.data.model.client.items.Track
-import io.music_assistant.client.data.repository.RecommendationRow
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.compose.common.CenteredProgress
 import io.music_assistant.client.ui.compose.common.CenteredText
@@ -260,7 +259,7 @@ internal data class HomeRow(
 // Internal so HomeScreenCategoriesTest can pin the row visibility rules: loading
 // rows stay, resolved-empty rows are hidden.
 internal fun getCategories(
-    recommendationsState: DataState<List<RecommendationRow>>,
+    recommendationsState: DataState<List<RecommendationRowState>>,
     shortcutsState: DataState<List<Shortcut>>,
     homeRowsConfig: List<SettingsRepository.HomeRowPref>,
 ): List<Pair<HomeRow, Boolean>> {
@@ -269,7 +268,7 @@ internal fun getCategories(
             // A still-loading row stays visible as a placeholder; a resolved row
             // must contain something the home page can render.
             .filter { row ->
-                row.itemsLoading || row.folder.items?.any { item ->
+                row.items is DataState.Loading || row.resolvedItems?.any { item ->
                     item is Track ||
                             item is Artist ||
                             item is Album ||
@@ -287,11 +286,11 @@ internal fun getCategories(
                     category = ItemCategory(
                         id = row.folder.itemId,
                         title = row.folder.displayName.toDisplayString(),
-                        items = row.folder.items.orEmpty(),
+                        items = row.resolvedItems.orEmpty(),
                         lazyListKey = row.folder.lazyListKey(),
                         tag = HomeScreenSemantics.rowTag(row.folder.itemId),
                     ),
-                    loading = row.itemsLoading,
+                    loading = row.items is DataState.Loading,
                 )
             }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -253,7 +253,9 @@ fun HomeScreen(
 internal data class HomeRow(
     val category: ItemCategory<Nothing>,
     val loading: Boolean,
-)
+) : IdProvider {
+    override val id: String get() = category.id
+}
 
 // Internal so HomeScreenCategoriesTest can pin the row visibility rules: loading
 // rows stay, resolved-empty rows are hidden.
@@ -314,9 +316,7 @@ internal fun getCategories(
         emptyList()
     }
 
-    return reconcileHomeRows(baseList, homeRowsConfig, onTop = SHORTCUTS_CATEGORY_ID) {
-        it.category.id
-    }
+    return reconcileHomeRows(baseList, homeRowsConfig, onTop = SHORTCUTS_CATEGORY_ID)
 }
 
 private const val SHORTCUTS_CATEGORY_ID = "shortcuts"

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
@@ -13,10 +13,10 @@ import io.music_assistant.client.data.model.client.QueueOption
 import io.music_assistant.client.data.model.client.Shortcut
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Genre
-import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.data.model.server.ServerUser
 import io.music_assistant.client.data.repository.MediaItemRepository
+import io.music_assistant.client.data.repository.RecommendationRow
 import io.music_assistant.client.player.sendspin.SendspinState
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.compose.common.DataState
@@ -26,12 +26,14 @@ import io.music_assistant.client.utils.AuthProcessState
 import io.music_assistant.client.utils.DataConnectionState
 import io.music_assistant.client.utils.SessionState
 import io.music_assistant.client.utils.resultAs
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.sample
@@ -207,38 +209,36 @@ class HomeScreenViewModel(
         }
 
         loadDataJob = viewModelScope.launch {
-            _state.update {
-                it.copy(
-                    recommendations = DataState.Loading(),
-                    shortcuts = DataState.Loading(),
-                )
-            }
-
-            val recommendations = getList<RecommendationFolder>(Request.Library.recommendations())
-            val shortcutUris = apiClient.sendRequest(Request(APICommands.AUTH_ME))
-                .resultAs<ServerUser>()?.preferences?.shortcuts
-
-            if (recommendations != null) {
-                val shortcuts = shortcutUris?.mapNotNull {
-                    mediaItemRepository.fetchMediaItem(
-                        Request(
-                            command = APICommands.MUSIC_ITEM_BY_URI,
-                            args = buildJsonObject {
-                                put("uri", JsonPrimitive(it))
-                            },
-                        ),
-                    ).getOrNull()
-                }?.map { Shortcut(it) }
-
-                _state.update {
-                    it.copy(
-                        recommendations = DataState.Data(recommendations),
-                        shortcuts = if (shortcuts != null) DataState.Data(shortcuts) else DataState.NoData(),
-                    )
+            launch { loadShortcuts() }
+            mediaItemRepository.recommendationRows()
+                .catch { error ->
+                    if (error is CancellationException) throw error
+                    Logger.e("Error fetching recommendations: $error")
+                    _state.update { it.copy(recommendations = DataState.Error()) }
                 }
-            } else {
-                _state.update { it.copy(recommendations = DataState.Error()) }
-            }
+                .collect { rows ->
+                    _state.update { it.copy(recommendations = DataState.Data(rows)) }
+                }
+        }
+    }
+
+    private suspend fun loadShortcuts() {
+        val shortcutUris = apiClient.sendRequest(Request(APICommands.AUTH_ME))
+            .resultAs<ServerUser>()?.preferences?.shortcuts
+        val shortcuts = shortcutUris?.mapNotNull {
+            mediaItemRepository.fetchMediaItem(
+                Request(
+                    command = APICommands.MUSIC_ITEM_BY_URI,
+                    args = buildJsonObject {
+                        put("uri", JsonPrimitive(it))
+                    },
+                ),
+            ).getOrNull()
+        }?.map { Shortcut(it) }
+        _state.update {
+            it.copy(
+                shortcuts = if (shortcuts != null) DataState.Data(shortcuts) else DataState.NoData(),
+            )
         }
     }
 
@@ -266,26 +266,19 @@ class HomeScreenViewModel(
     }
 
     private fun updateRecommendationsIfNeeded(changed: Track) {
-        val recommendationsData =
-            (_state.value.recommendations as? DataState.Data)?.data
-                ?: return
-        val updated = recommendationsData.map { row ->
-            row.items?.let { itemsList ->
-                val updatedItems = itemsList.map { item ->
+        // Read-and-map inside the update lambda so a concurrent recommendations
+        // write can never be clobbered with rows derived from a stale read.
+        _state.update { state ->
+            val rows = (state.recommendations as? DataState.Data)?.data
+                ?: return@update state
+            val updated = rows.map { row ->
+                val items = row.folder.items ?: return@map row
+                val updatedItems = items.map { item ->
                     if (item is Track && item.hasAnyMappingFrom(changed)) changed else item
                 }
-                RecommendationFolder(
-                    itemId = row.itemId,
-                    provider = row.provider,
-                    name = row.displayName,
-                    uri = row.uri,
-                    images = row.images,
-                    items = updatedItems,
-                )
-            } ?: row
-        }
-        _state.update {
-            it.copy(recommendations = DataState.Data(updated))
+                row.copy(folder = row.folder.copy(items = updatedItems))
+            }
+            state.copy(recommendations = DataState.Data(updated))
         }
     }
 
@@ -373,16 +366,6 @@ class HomeScreenViewModel(
 
     private fun onOpenExternalLink(url: String) = viewModelScope.launch { _links.emit(url) }
 
-    @Suppress("UNCHECKED_CAST")
-    private suspend fun <T : AppMediaItem> getList(
-        request: Request,
-    ): List<T>? = mediaItemRepository.fetchMediaItems(request).let { result ->
-        if (result.isFailure) {
-            Logger.e("Error fetching list for request $request: ${result.exceptionOrNull()}")
-        }
-        result.getOrNull()?.mapNotNull { it as? T }
-    }
-
     /**
      * Persists the edited working list. Prefs for folders not currently present
      * on the server (e.g. temporarily item-less, so absent from the working list)
@@ -396,7 +379,7 @@ class HomeScreenViewModel(
 
     data class State(
         val shortcuts: DataState<List<Shortcut>>,
-        val recommendations: DataState<List<RecommendationFolder>>,
+        val recommendations: DataState<List<RecommendationRow>>,
         val homeRowsConfig: List<SettingsRepository.HomeRowPref> = emptyList(),
     )
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
@@ -17,7 +17,6 @@ import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.data.model.server.ServerUser
 import io.music_assistant.client.data.repository.MediaItemRepository
-import io.music_assistant.client.data.repository.needPerRowItemFetch
 import io.music_assistant.client.player.sendspin.SendspinState
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.compose.common.DataState
@@ -223,7 +222,7 @@ class HomeScreenViewModel(
             return
         }
 
-        if (!folders.needPerRowItemFetch()) {
+        if (!mediaItemRepository.supportsRecommendationRowItems()) {
             setRecommendationRows(
                 folders.map { RecommendationRowState(it, DataState.Data(it.items.orEmpty())) },
             )
@@ -231,19 +230,10 @@ class HomeScreenViewModel(
         }
 
         // Show every row as a loading placeholder, then fetch each row's items
-        // as its own job. The first row doubles as a probe — if it fails, skip
-        // the rest (see [needPerRowItemFetch]).
+        // as its own job.
         setRecommendationRows(folders.map { RecommendationRowState(it, DataState.Loading()) })
-        val probeItems = mediaItemRepository.fetchRecommendationRowItems(folders.first())
-        if (probeItems == null) {
-            setRecommendationRows(
-                folders.map { RecommendationRowState(it, DataState.Data(emptyList())) },
-            )
-            return
-        }
-        setRowItems(folders.first(), probeItems)
         coroutineScope {
-            folders.drop(1).forEach { folder ->
+            folders.forEach { folder ->
                 launch {
                     setRowItems(
                         folder,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
@@ -13,10 +13,11 @@ import io.music_assistant.client.data.model.client.QueueOption
 import io.music_assistant.client.data.model.client.Shortcut
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Genre
+import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.data.model.server.ServerUser
 import io.music_assistant.client.data.repository.MediaItemRepository
-import io.music_assistant.client.data.repository.RecommendationRow
+import io.music_assistant.client.data.repository.needPerRowItemFetch
 import io.music_assistant.client.player.sendspin.SendspinState
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.compose.common.DataState
@@ -29,11 +30,11 @@ import io.music_assistant.client.utils.resultAs
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.sample
@@ -210,15 +211,65 @@ class HomeScreenViewModel(
 
         loadDataJob = viewModelScope.launch {
             launch { loadShortcuts() }
-            mediaItemRepository.recommendationRows()
-                .catch { error ->
-                    if (error is CancellationException) throw error
-                    Logger.e("Error fetching recommendations: $error")
-                    _state.update { it.copy(recommendations = DataState.Error()) }
+            loadRecommendations()
+        }
+    }
+
+    private suspend fun loadRecommendations() {
+        val folders = mediaItemRepository.fetchRecommendationRows().getOrElse { error ->
+            if (error is CancellationException) throw error
+            Logger.e("Error fetching recommendations: $error")
+            _state.update { it.copy(recommendations = DataState.Error()) }
+            return
+        }
+
+        if (!folders.needPerRowItemFetch()) {
+            setRecommendationRows(
+                folders.map { RecommendationRowState(it, DataState.Data(it.items.orEmpty())) },
+            )
+            return
+        }
+
+        // Show every row as a loading placeholder, then fetch each row's items
+        // as its own job. The first row doubles as a probe — if it fails, skip
+        // the rest (see [needPerRowItemFetch]).
+        setRecommendationRows(folders.map { RecommendationRowState(it, DataState.Loading()) })
+        val probeItems = mediaItemRepository.fetchRecommendationRowItems(folders.first())
+        if (probeItems == null) {
+            setRecommendationRows(
+                folders.map { RecommendationRowState(it, DataState.Data(emptyList())) },
+            )
+            return
+        }
+        setRowItems(folders.first(), probeItems)
+        coroutineScope {
+            folders.drop(1).forEach { folder ->
+                launch {
+                    setRowItems(
+                        folder,
+                        mediaItemRepository.fetchRecommendationRowItems(folder).orEmpty(),
+                    )
                 }
-                .collect { rows ->
-                    _state.update { it.copy(recommendations = DataState.Data(rows)) }
+            }
+        }
+    }
+
+    private fun setRecommendationRows(rows: List<RecommendationRowState>) {
+        _state.update { it.copy(recommendations = DataState.Data(rows)) }
+    }
+
+    private fun setRowItems(folder: RecommendationFolder, items: List<AppMediaItem>) {
+        _state.update { state ->
+            val rows = (state.recommendations as? DataState.Data)?.data
+                ?: return@update state
+            val updated = rows.map { row ->
+                if (row.folder.itemId == folder.itemId && row.folder.provider == folder.provider) {
+                    row.copy(items = DataState.Data(items))
+                } else {
+                    row
                 }
+            }
+            state.copy(recommendations = DataState.Data(updated))
         }
     }
 
@@ -272,11 +323,11 @@ class HomeScreenViewModel(
             val rows = (state.recommendations as? DataState.Data)?.data
                 ?: return@update state
             val updated = rows.map { row ->
-                val items = row.folder.items ?: return@map row
+                val items = (row.items as? DataState.Data)?.data ?: return@map row
                 val updatedItems = items.map { item ->
                     if (item is Track && item.hasAnyMappingFrom(changed)) changed else item
                 }
-                row.copy(folder = row.folder.copy(items = updatedItems))
+                row.copy(items = DataState.Data(updatedItems))
             }
             state.copy(recommendations = DataState.Data(updated))
         }
@@ -379,7 +430,7 @@ class HomeScreenViewModel(
 
     data class State(
         val shortcuts: DataState<List<Shortcut>>,
-        val recommendations: DataState<List<RecommendationRow>>,
+        val recommendations: DataState<List<RecommendationRowState>>,
         val homeRowsConfig: List<SettingsRepository.HomeRowPref> = emptyList(),
     )
 
@@ -400,4 +451,17 @@ class HomeScreenViewModel(
     private companion object {
         private const val BUFFER_REAL_INTERVAL = 500L
     }
+}
+
+/**
+ * One home-page recommendation row: the folder identity plus its items as an
+ * independently loading [DataState], so each row can render a placeholder
+ * while its contents are fetched.
+ */
+data class RecommendationRowState(
+    val folder: RecommendationFolder,
+    val items: DataState<List<AppMediaItem>>,
+) {
+    /** The row's items when resolved, or null while still loading (or on error). */
+    val resolvedItems: List<AppMediaItem>? get() = (items as? DataState.Data)?.data
 }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/StubServiceClient.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/StubServiceClient.kt
@@ -11,7 +11,7 @@ import io.music_assistant.client.webrtc.model.RemoteId
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
-class StubServiceClient : ServiceClient {
+open class StubServiceClient : ServiceClient {
     override val sessionState: StateFlow<SessionState>
         get() = TODO("Not yet implemented")
 

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/repository/RecommendationFoldersCompatTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/repository/RecommendationFoldersCompatTest.kt
@@ -2,13 +2,19 @@ package io.music_assistant.client.data.repository
 
 import io.music_assistant.client.api.APICommands
 import io.music_assistant.client.api.Answer
+import io.music_assistant.client.api.ConnectionInfo
 import io.music_assistant.client.api.Request
 import io.music_assistant.client.data.factory.MediaItemFactory
 import io.music_assistant.client.data.model.client.items.Track
+import io.music_assistant.client.data.model.server.ServerInfo
 import io.music_assistant.client.data.model.server.StubServiceClient
 import io.music_assistant.client.data.model.server.events.Event
+import io.music_assistant.client.utils.ConnectionData
+import io.music_assistant.client.utils.SessionState
 import io.music_assistant.client.utils.myJson
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.buildJsonObject
@@ -21,11 +27,17 @@ import kotlin.test.fail
 
 /**
  * [MediaItemRepository.fetchRecommendationFolders] must bridge both shapes of
- * the `music/recommendations` response: rows with their items embedded, and
- * item-less rows whose contents come from a per-row
- * `music/recommendations/items` call.
+ * the `music/recommendations` response, selected by the server's schema
+ * version: rows with their items embedded, and item-less rows whose contents
+ * come from a per-row `music/recommendations/items` call.
  */
 class RecommendationFoldersCompatTest {
+    private companion object {
+        // Last schema with embedded row items, and the first without.
+        const val EMBEDDED_ROWS_SCHEMA = 38
+        const val ITEM_LESS_ROWS_SCHEMA = 39
+    }
+
     private fun folderJson(itemId: String, provider: String, itemsJson: String?) = """
         {"item_id":"$itemId","provider":"$provider","name":"Row $itemId",
          "media_type":"folder","uri":null${itemsJson?.let { ""","items":$it""" } ?: ""}}
@@ -40,10 +52,20 @@ class RecommendationFoldersCompatTest {
         private val rowsJson: String,
         private val itemsJsonFor: (provider: String, itemId: String) -> Result<String>,
         private val rowsError: Exception? = null,
+        schemaVersion: Int = ITEM_LESS_ROWS_SCHEMA,
     ) : StubServiceClient() {
         val itemsRequests = mutableListOf<Pair<String, String>>()
 
         override val events: Flow<Event<out Any>> = emptyFlow()
+
+        override val sessionState: StateFlow<SessionState> = MutableStateFlow(
+            SessionState.Connected.Direct(
+                connectionInfo = ConnectionInfo(host = "test", port = 8095, isTls = false),
+                connectionData = ConnectionData(
+                    serverInfo = ServerInfo(serverId = "test", schemaVersion = schemaVersion),
+                ),
+            ),
+        )
 
         override suspend fun sendRequest(request: Request): Result<Answer> =
             when (request.command) {
@@ -81,7 +103,8 @@ class RecommendationFoldersCompatTest {
                 [${folderJson("row1", "library", "[${trackJson("t1")}]")},
                  ${folderJson("row2", "spotify", "[]")}]
             """.trimIndent(),
-            itemsJsonFor = { _, _ -> fail("embedded-items response must not trigger items calls") },
+            itemsJsonFor = { _, _ -> fail("embedded-items schema must not trigger items calls") },
+            schemaVersion = EMBEDDED_ROWS_SCHEMA,
         )
 
         val folders = repository(client).fetchRecommendationFolders().getOrThrow()
@@ -134,43 +157,25 @@ class RecommendationFoldersCompatTest {
         assertEquals(emptyList(), folders[1].items)
     }
 
-    // A server that embeds items has no items command; a failing RPC there raises
-    // a user-visible error toast per call. The first row is probed alone so that
-    // worst case is a single failing call, not one per row.
+    // A server on the embedded-items schema has no items command; rows that are
+    // legitimately empty there must not trigger calls to it (each failing call
+    // would raise a user-visible error toast).
     @Test
-    fun failedProbeReturnsRowsAsIsWithoutFurtherCalls() = runTest {
+    fun emptyRowsOnEmbeddedSchemaIssueNoItemCalls() = runTest {
         val client = FakeClient(
             rowsJson = """
                 [${folderJson("row1", "library", "[]")},
                  ${folderJson("row2", "spotify", "[]")}]
             """.trimIndent(),
-            itemsJsonFor = { _, _ -> Result.failure(IllegalStateException("Unknown command")) },
-        )
-
-        val folders = repository(client).fetchRecommendationFolders().getOrThrow()
-
-        assertEquals(listOf("library" to "row1"), client.itemsRequests)
-        assertEquals(listOf("row1", "row2"), folders.map { it.itemId })
-        assertTrue(folders.all { it.items.isNullOrEmpty() })
-    }
-
-    // A single populated row marks the whole response as the embedded shape;
-    // its empty siblings stay empty instead of triggering per-row fetches.
-    @Test
-    fun mixedRowsAreTreatedAsEmbedded() = runTest {
-        val client = FakeClient(
-            rowsJson = """
-                [${folderJson("row1", "library", "[]")},
-                 ${folderJson("row2", "spotify", "[${trackJson("t1")}]")}]
-            """.trimIndent(),
-            itemsJsonFor = { _, _ -> fail("mixed rows must not trigger items calls") },
+            itemsJsonFor = { _, _ -> fail("embedded-items schema must not trigger items calls") },
+            schemaVersion = EMBEDDED_ROWS_SCHEMA,
         )
 
         val folders = repository(client).fetchRecommendationFolders().getOrThrow()
 
         assertTrue(client.itemsRequests.isEmpty())
-        assertEquals(emptyList(), folders[0].items)
-        assertEquals(listOf("t1"), folders[1].items?.map { it.itemId })
+        assertEquals(listOf("row1", "row2"), folders.map { it.itemId })
+        assertTrue(folders.all { it.items.isNullOrEmpty() })
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/repository/RecommendationFoldersCompatTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/repository/RecommendationFoldersCompatTest.kt
@@ -10,21 +10,19 @@ import io.music_assistant.client.data.model.server.events.Event
 import io.music_assistant.client.utils.myJson
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
 /**
  * [MediaItemRepository.fetchRecommendationFolders] must bridge both shapes of
- * the `music/recommendations` response: rows with their items embedded (servers
- * before 2.10), and item-less rows (2.10+) whose contents come from a per-row
+ * the `music/recommendations` response: rows with their items embedded, and
+ * item-less rows whose contents come from a per-row
  * `music/recommendations/items` call.
  */
 class RecommendationFoldersCompatTest {
@@ -188,64 +186,6 @@ class RecommendationFoldersCompatTest {
         assertTrue(client.itemsRequests.isEmpty())
     }
 
-    // --- streaming (recommendationRows) behavior ---
-
-    @Test
-    fun embeddedRowsStreamASingleResolvedSnapshot() = runTest {
-        val client = FakeClient(
-            rowsJson = "[${folderJson("row1", "library", "[${trackJson("t1")}]")}]",
-            itemsJsonFor = { _, _ -> fail("embedded-items response must not trigger items calls") },
-        )
-
-        val snapshots = repository(client).recommendationRows().toList()
-
-        assertEquals(1, snapshots.size)
-        assertTrue(snapshots.single().none { it.itemsLoading })
-        assertEquals(listOf("t1"), snapshots.single()[0].folder.items?.map { it.itemId })
-    }
-
-    @Test
-    fun itemLessRowsStreamLoadingThenPerRowResolution() = runTest {
-        val client = FakeClient(
-            rowsJson = """
-                [${folderJson("row1", "library", "[]")},
-                 ${folderJson("row2", "spotify", "[]")}]
-            """.trimIndent(),
-            itemsJsonFor = { _, itemId -> Result.success("[${trackJson("item-of-$itemId")}]") },
-        )
-
-        val snapshots = repository(client).recommendationRows().toList()
-
-        // initial (all loading) + probe row resolved + remaining row resolved
-        assertEquals(3, snapshots.size)
-        // Asserted after collection completed: also pins that emitted snapshots are
-        // immutable copies, not views of the mutable list later resolutions write to.
-        assertTrue(snapshots.first().all { it.itemsLoading })
-        val final = snapshots.last()
-        assertTrue(final.none { it.itemsLoading })
-        assertEquals(listOf("item-of-row1"), final[0].folder.items?.map { it.itemId })
-        assertEquals(listOf("item-of-row2"), final[1].folder.items?.map { it.itemId })
-    }
-
-    @Test
-    fun failedProbeStreamResolvesAllRowsAsReceived() = runTest {
-        val client = FakeClient(
-            rowsJson = """
-                [${folderJson("row1", "library", "[]")},
-                 ${folderJson("row2", "spotify", "[]")}]
-            """.trimIndent(),
-            itemsJsonFor = { _, _ -> Result.failure(IllegalStateException("Unknown command")) },
-        )
-
-        val snapshots = repository(client).recommendationRows().toList()
-
-        assertEquals(2, snapshots.size)
-        assertTrue(snapshots.first().all { it.itemsLoading })
-        assertTrue(snapshots.last().none { it.itemsLoading })
-        assertTrue(snapshots.last().all { it.folder.items.isNullOrEmpty() })
-        assertEquals(listOf("library" to "row1"), client.itemsRequests)
-    }
-
     @Test
     fun rowsCallFailureSurfacesAsErrorWithoutItemCalls() = runTest {
         val client = FakeClient(
@@ -255,8 +195,8 @@ class RecommendationFoldersCompatTest {
         )
         val repo = repository(client)
 
-        assertFailsWith<IllegalStateException> { repo.recommendationRows().toList() }
         assertTrue(repo.fetchRecommendationFolders().isFailure)
+        assertTrue(repo.fetchRecommendationRows().isFailure)
         assertTrue(client.itemsRequests.isEmpty())
     }
 }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/repository/RecommendationFoldersCompatTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/repository/RecommendationFoldersCompatTest.kt
@@ -26,10 +26,10 @@ import kotlin.test.assertTrue
 import kotlin.test.fail
 
 /**
- * [MediaItemRepository.fetchRecommendationFolders] must bridge both shapes of
- * the `music/recommendations` response, selected by the server's schema
- * version: rows with their items embedded, and item-less rows whose contents
- * come from a per-row `music/recommendations/items` call.
+ * Covers [MediaItemRepository.fetchRecommendationFolders]
+ * It must bridge both shapes of the `music/recommendations` response, selected
+ * by the server's schema version: rows with their items embedded, and item-less
+ * rows whose contents come from a per-row `music/recommendations/items` call.
  */
 class RecommendationFoldersCompatTest {
     private companion object {
@@ -155,40 +155,6 @@ class RecommendationFoldersCompatTest {
 
         assertEquals(listOf("item-of-row1"), folders[0].items?.map { it.itemId })
         assertEquals(emptyList(), folders[1].items)
-    }
-
-    // A server on the embedded-items schema has no items command; rows that are
-    // legitimately empty there must not trigger calls to it (each failing call
-    // would raise a user-visible error toast).
-    @Test
-    fun emptyRowsOnEmbeddedSchemaIssueNoItemCalls() = runTest {
-        val client = FakeClient(
-            rowsJson = """
-                [${folderJson("row1", "library", "[]")},
-                 ${folderJson("row2", "spotify", "[]")}]
-            """.trimIndent(),
-            itemsJsonFor = { _, _ -> fail("embedded-items schema must not trigger items calls") },
-            schemaVersion = EMBEDDED_ROWS_SCHEMA,
-        )
-
-        val folders = repository(client).fetchRecommendationFolders().getOrThrow()
-
-        assertTrue(client.itemsRequests.isEmpty())
-        assertEquals(listOf("row1", "row2"), folders.map { it.itemId })
-        assertTrue(folders.all { it.items.isNullOrEmpty() })
-    }
-
-    @Test
-    fun emptyRowListIssuesNoItemCalls() = runTest {
-        val client = FakeClient(
-            rowsJson = "[]",
-            itemsJsonFor = { _, _ -> fail("empty row list must not trigger items calls") },
-        )
-
-        val folders = repository(client).fetchRecommendationFolders().getOrThrow()
-
-        assertTrue(folders.isEmpty())
-        assertTrue(client.itemsRequests.isEmpty())
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/repository/RecommendationFoldersCompatTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/repository/RecommendationFoldersCompatTest.kt
@@ -1,0 +1,262 @@
+package io.music_assistant.client.data.repository
+
+import io.music_assistant.client.api.APICommands
+import io.music_assistant.client.api.Answer
+import io.music_assistant.client.api.Request
+import io.music_assistant.client.data.factory.MediaItemFactory
+import io.music_assistant.client.data.model.client.items.Track
+import io.music_assistant.client.data.model.server.StubServiceClient
+import io.music_assistant.client.data.model.server.events.Event
+import io.music_assistant.client.utils.myJson
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * [MediaItemRepository.fetchRecommendationFolders] must bridge both shapes of
+ * the `music/recommendations` response: rows with their items embedded (servers
+ * before 2.10), and item-less rows (2.10+) whose contents come from a per-row
+ * `music/recommendations/items` call.
+ */
+class RecommendationFoldersCompatTest {
+    private fun folderJson(itemId: String, provider: String, itemsJson: String?) = """
+        {"item_id":"$itemId","provider":"$provider","name":"Row $itemId",
+         "media_type":"folder","uri":null${itemsJson?.let { ""","items":$it""" } ?: ""}}
+    """.trimIndent()
+
+    private fun trackJson(itemId: String) = """
+        {"item_id":"$itemId","provider":"library","name":"Track $itemId",
+         "media_type":"track","is_playable":true}
+    """.trimIndent()
+
+    private class FakeClient(
+        private val rowsJson: String,
+        private val itemsJsonFor: (provider: String, itemId: String) -> Result<String>,
+        private val rowsError: Exception? = null,
+    ) : StubServiceClient() {
+        val itemsRequests = mutableListOf<Pair<String, String>>()
+
+        override val events: Flow<Event<out Any>> = emptyFlow()
+
+        override suspend fun sendRequest(request: Request): Result<Answer> =
+            when (request.command) {
+                APICommands.MUSIC_RECOMMENDATIONS ->
+                    rowsError?.let { Result.failure(it) } ?: Result.success(answer(rowsJson))
+
+                APICommands.MUSIC_RECOMMENDATIONS_ITEMS -> {
+                    val args = request.args ?: fail("items request missing args")
+                    val provider = args["provider"]?.jsonPrimitive?.content
+                        ?: fail("items request missing provider arg")
+                    val itemId = args["item_id"]?.jsonPrimitive?.content
+                        ?: fail("items request missing item_id arg")
+                    itemsRequests += provider to itemId
+                    itemsJsonFor(provider, itemId).map(::answer)
+                }
+
+                else -> fail("unexpected command ${request.command}")
+            }
+
+        private fun answer(resultJson: String) = Answer(
+            buildJsonObject {
+                put("message_id", "test")
+                put("result", myJson.parseToJsonElement(resultJson))
+            },
+        )
+    }
+
+    private fun repository(client: FakeClient) =
+        MediaItemRepository(client, MediaItemFactory(client))
+
+    @Test
+    fun embeddedRowItemsAreUsedDirectly() = runTest {
+        val client = FakeClient(
+            rowsJson = """
+                [${folderJson("row1", "library", "[${trackJson("t1")}]")},
+                 ${folderJson("row2", "spotify", "[]")}]
+            """.trimIndent(),
+            itemsJsonFor = { _, _ -> fail("embedded-items response must not trigger items calls") },
+        )
+
+        val folders = repository(client).fetchRecommendationFolders().getOrThrow()
+
+        assertEquals(listOf("row1", "row2"), folders.map { it.itemId })
+        assertEquals(listOf("t1"), folders[0].items?.map { it.itemId })
+        assertTrue(client.itemsRequests.isEmpty())
+    }
+
+    @Test
+    fun itemLessRowsGetItemsFetchedPerRow() = runTest {
+        val client = FakeClient(
+            rowsJson = """
+                [${folderJson("row1", "library", "[]")},
+                 ${folderJson("row2", "spotify", null)}]
+            """.trimIndent(),
+            itemsJsonFor = { _, itemId -> Result.success("[${trackJson("item-of-$itemId")}]") },
+        )
+
+        val folders = repository(client).fetchRecommendationFolders().getOrThrow()
+
+        assertEquals(
+            setOf("library" to "row1", "spotify" to "row2"),
+            client.itemsRequests.toSet(),
+        )
+        assertEquals(listOf("item-of-row1"), folders[0].items?.map { it.itemId })
+        assertEquals(listOf("item-of-row2"), folders[1].items?.map { it.itemId })
+        assertTrue(folders[0].items?.single() is Track)
+    }
+
+    @Test
+    fun failedItemsFetchDegradesToEmptyRow() = runTest {
+        val client = FakeClient(
+            rowsJson = """
+                [${folderJson("row1", "library", "[]")},
+                 ${folderJson("row2", "spotify", "[]")}]
+            """.trimIndent(),
+            itemsJsonFor = { provider, itemId ->
+                if (provider == "spotify") {
+                    Result.failure(IllegalStateException("row fetch failed"))
+                } else {
+                    Result.success("[${trackJson("item-of-$itemId")}]")
+                }
+            },
+        )
+
+        val folders = repository(client).fetchRecommendationFolders().getOrThrow()
+
+        assertEquals(listOf("item-of-row1"), folders[0].items?.map { it.itemId })
+        assertEquals(emptyList(), folders[1].items)
+    }
+
+    // A server that embeds items has no items command; a failing RPC there raises
+    // a user-visible error toast per call. The first row is probed alone so that
+    // worst case is a single failing call, not one per row.
+    @Test
+    fun failedProbeReturnsRowsAsIsWithoutFurtherCalls() = runTest {
+        val client = FakeClient(
+            rowsJson = """
+                [${folderJson("row1", "library", "[]")},
+                 ${folderJson("row2", "spotify", "[]")}]
+            """.trimIndent(),
+            itemsJsonFor = { _, _ -> Result.failure(IllegalStateException("Unknown command")) },
+        )
+
+        val folders = repository(client).fetchRecommendationFolders().getOrThrow()
+
+        assertEquals(listOf("library" to "row1"), client.itemsRequests)
+        assertEquals(listOf("row1", "row2"), folders.map { it.itemId })
+        assertTrue(folders.all { it.items.isNullOrEmpty() })
+    }
+
+    // A single populated row marks the whole response as the embedded shape;
+    // its empty siblings stay empty instead of triggering per-row fetches.
+    @Test
+    fun mixedRowsAreTreatedAsEmbedded() = runTest {
+        val client = FakeClient(
+            rowsJson = """
+                [${folderJson("row1", "library", "[]")},
+                 ${folderJson("row2", "spotify", "[${trackJson("t1")}]")}]
+            """.trimIndent(),
+            itemsJsonFor = { _, _ -> fail("mixed rows must not trigger items calls") },
+        )
+
+        val folders = repository(client).fetchRecommendationFolders().getOrThrow()
+
+        assertTrue(client.itemsRequests.isEmpty())
+        assertEquals(emptyList(), folders[0].items)
+        assertEquals(listOf("t1"), folders[1].items?.map { it.itemId })
+    }
+
+    @Test
+    fun emptyRowListIssuesNoItemCalls() = runTest {
+        val client = FakeClient(
+            rowsJson = "[]",
+            itemsJsonFor = { _, _ -> fail("empty row list must not trigger items calls") },
+        )
+
+        val folders = repository(client).fetchRecommendationFolders().getOrThrow()
+
+        assertTrue(folders.isEmpty())
+        assertTrue(client.itemsRequests.isEmpty())
+    }
+
+    // --- streaming (recommendationRows) behavior ---
+
+    @Test
+    fun embeddedRowsStreamASingleResolvedSnapshot() = runTest {
+        val client = FakeClient(
+            rowsJson = "[${folderJson("row1", "library", "[${trackJson("t1")}]")}]",
+            itemsJsonFor = { _, _ -> fail("embedded-items response must not trigger items calls") },
+        )
+
+        val snapshots = repository(client).recommendationRows().toList()
+
+        assertEquals(1, snapshots.size)
+        assertTrue(snapshots.single().none { it.itemsLoading })
+        assertEquals(listOf("t1"), snapshots.single()[0].folder.items?.map { it.itemId })
+    }
+
+    @Test
+    fun itemLessRowsStreamLoadingThenPerRowResolution() = runTest {
+        val client = FakeClient(
+            rowsJson = """
+                [${folderJson("row1", "library", "[]")},
+                 ${folderJson("row2", "spotify", "[]")}]
+            """.trimIndent(),
+            itemsJsonFor = { _, itemId -> Result.success("[${trackJson("item-of-$itemId")}]") },
+        )
+
+        val snapshots = repository(client).recommendationRows().toList()
+
+        // initial (all loading) + probe row resolved + remaining row resolved
+        assertEquals(3, snapshots.size)
+        // Asserted after collection completed: also pins that emitted snapshots are
+        // immutable copies, not views of the mutable list later resolutions write to.
+        assertTrue(snapshots.first().all { it.itemsLoading })
+        val final = snapshots.last()
+        assertTrue(final.none { it.itemsLoading })
+        assertEquals(listOf("item-of-row1"), final[0].folder.items?.map { it.itemId })
+        assertEquals(listOf("item-of-row2"), final[1].folder.items?.map { it.itemId })
+    }
+
+    @Test
+    fun failedProbeStreamResolvesAllRowsAsReceived() = runTest {
+        val client = FakeClient(
+            rowsJson = """
+                [${folderJson("row1", "library", "[]")},
+                 ${folderJson("row2", "spotify", "[]")}]
+            """.trimIndent(),
+            itemsJsonFor = { _, _ -> Result.failure(IllegalStateException("Unknown command")) },
+        )
+
+        val snapshots = repository(client).recommendationRows().toList()
+
+        assertEquals(2, snapshots.size)
+        assertTrue(snapshots.first().all { it.itemsLoading })
+        assertTrue(snapshots.last().none { it.itemsLoading })
+        assertTrue(snapshots.last().all { it.folder.items.isNullOrEmpty() })
+        assertEquals(listOf("library" to "row1"), client.itemsRequests)
+    }
+
+    @Test
+    fun rowsCallFailureSurfacesAsErrorWithoutItemCalls() = runTest {
+        val client = FakeClient(
+            rowsJson = "unused",
+            rowsError = IllegalStateException("rows call failed"),
+            itemsJsonFor = { _, _ -> fail("failed rows call must not trigger items calls") },
+        )
+        val repo = repository(client)
+
+        assertFailsWith<IllegalStateException> { repo.recommendationRows().toList() }
+        assertTrue(repo.fetchRecommendationFolders().isFailure)
+        assertTrue(client.itemsRequests.isEmpty())
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/HomeRowsConfigTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/HomeRowsConfigTest.kt
@@ -1,25 +1,18 @@
 package io.music_assistant.client.ui.compose.home
 
 import io.music_assistant.client.settings.SettingsRepository.HomeRowPref
-import io.music_assistant.client.ui.compose.common.items.ItemCategory
-import io.music_assistant.client.ui.compose.common.toDisplayString
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class HomeRowsConfigTest {
-    private fun itemCategory(id: String) = ItemCategory<Nothing>(
-        id = id,
-        title = id.toDisplayString(),
-        items = emptyList(),
-        lazyListKey = id,
-    )
+    private data class Row(override val id: String) : IdProvider
 
     private fun reconcile(
         serverIds: List<String>,
         config: List<HomeRowPref>,
         onTop: String? = null,
     ): List<Pair<String, Boolean>> {
-        return reconcileHomeRows(serverIds.map { itemCategory(it) }, config, onTop) { it.id }
+        return reconcileHomeRows(serverIds.map { Row(it) }, config, onTop)
             .map { it.first.id to it.second }
     }
 

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/HomeRowsConfigTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/HomeRowsConfigTest.kt
@@ -19,7 +19,7 @@ class HomeRowsConfigTest {
         config: List<HomeRowPref>,
         onTop: String? = null,
     ): List<Pair<String, Boolean>> {
-        return reconcileHomeRows(serverIds.map { itemCategory(it) }, config, onTop)
+        return reconcileHomeRows(serverIds.map { itemCategory(it) }, config, onTop) { it.id }
             .map { it.first.id to it.second }
     }
 

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenCategoriesTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenCategoriesTest.kt
@@ -1,0 +1,124 @@
+package io.music_assistant.client.ui.compose.home
+
+import io.music_assistant.client.data.model.client.Shortcut
+import io.music_assistant.client.data.model.client.items.AppMediaItem
+import io.music_assistant.client.data.model.client.items.RecommendationFolder
+import io.music_assistant.client.data.model.client.testTrack
+import io.music_assistant.client.data.repository.RecommendationRow
+import io.music_assistant.client.ui.compose.common.DataState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the home-page row visibility rules of [getCategories]:
+ * rows whose items are still loading stay visible (as placeholders), rows that
+ * resolved without renderable items are hidden, duplicates collapse, and the
+ * shortcuts row is appended from its own state.
+ */
+class HomeScreenCategoriesTest {
+    private fun folder(
+        itemId: String,
+        provider: String = "library",
+        items: List<AppMediaItem>? = null,
+    ) = RecommendationFolder(
+        itemId = itemId,
+        provider = provider,
+        name = itemId,
+        uri = null,
+        images = emptyMap(),
+        items = items,
+    )
+
+    private fun categories(
+        rows: List<RecommendationRow>,
+        shortcuts: DataState<List<Shortcut>> = DataState.NoData(),
+    ) = getCategories(DataState.Data(rows), shortcuts, homeRowsConfig = emptyList())
+
+    @Test
+    fun loadingRowsStayVisibleAsPlaceholders() {
+        val result = categories(listOf(RecommendationRow(folder("a"), itemsLoading = true)))
+
+        assertEquals(listOf("a"), result.map { it.first.category.id })
+        assertTrue(result.single().first.loading)
+    }
+
+    @Test
+    fun rowsResolvedWithoutRenderableItemsAreHidden() {
+        val result = categories(
+            listOf(
+                RecommendationRow(folder("empty", items = emptyList()), itemsLoading = false),
+                RecommendationRow(folder("itemless", items = null), itemsLoading = false),
+            ),
+        )
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun rowsResolvedWithPlayableItemsAreShown() {
+        val result = categories(
+            listOf(
+                RecommendationRow(
+                    folder("a", items = listOf(testTrack())),
+                    itemsLoading = false,
+                ),
+            ),
+        )
+
+        val row = result.single().first
+        assertFalse(row.loading)
+        assertEquals(1, row.category.items.size)
+    }
+
+    @Test
+    fun rowsWithTheSameIdentityCollapseToOne() {
+        val duplicated = RecommendationRow(
+            folder("a", items = listOf(testTrack())),
+            itemsLoading = false,
+        )
+
+        val result = categories(listOf(duplicated, duplicated))
+
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun sameItemIdFromDifferentProvidersStaysDistinct() {
+        val result = categories(
+            listOf(
+                RecommendationRow(folder("a", provider = "library"), itemsLoading = true),
+                RecommendationRow(folder("a", provider = "spotify"), itemsLoading = true),
+            ),
+        )
+
+        assertEquals(2, result.size)
+    }
+
+    @Test
+    fun shortcutsRowIsAppendedOnTopWhenUnconfigured() {
+        val result = categories(
+            rows = listOf(
+                RecommendationRow(
+                    folder("a", items = listOf(testTrack())),
+                    itemsLoading = false,
+                ),
+            ),
+            shortcuts = DataState.Data(listOf(Shortcut(testTrack()))),
+        )
+
+        assertEquals(listOf("shortcuts", "a"), result.map { it.first.category.id })
+    }
+
+    @Test
+    fun nonDataRecommendationsYieldNoRows() {
+        val result = getCategories(
+            recommendationsState = DataState.Loading(),
+            shortcutsState = DataState.Data(listOf(Shortcut(testTrack()))),
+            homeRowsConfig = emptyList(),
+        )
+
+        assertTrue(result.isEmpty())
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenCategoriesTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenCategoriesTest.kt
@@ -4,7 +4,6 @@ import io.music_assistant.client.data.model.client.Shortcut
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.data.model.client.testTrack
-import io.music_assistant.client.data.repository.RecommendationRow
 import io.music_assistant.client.ui.compose.common.DataState
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -21,24 +20,32 @@ class HomeScreenCategoriesTest {
     private fun folder(
         itemId: String,
         provider: String = "library",
-        items: List<AppMediaItem>? = null,
     ) = RecommendationFolder(
         itemId = itemId,
         provider = provider,
         name = itemId,
         uri = null,
         images = emptyMap(),
-        items = items,
+        items = null,
     )
 
+    private fun loadingRow(itemId: String, provider: String = "library") =
+        RecommendationRowState(folder(itemId, provider), DataState.Loading())
+
+    private fun resolvedRow(
+        itemId: String,
+        items: List<AppMediaItem>,
+        provider: String = "library",
+    ) = RecommendationRowState(folder(itemId, provider), DataState.Data(items))
+
     private fun categories(
-        rows: List<RecommendationRow>,
+        rows: List<RecommendationRowState>,
         shortcuts: DataState<List<Shortcut>> = DataState.NoData(),
     ) = getCategories(DataState.Data(rows), shortcuts, homeRowsConfig = emptyList())
 
     @Test
     fun loadingRowsStayVisibleAsPlaceholders() {
-        val result = categories(listOf(RecommendationRow(folder("a"), itemsLoading = true)))
+        val result = categories(listOf(loadingRow("a")))
 
         assertEquals(listOf("a"), result.map { it.first.category.id })
         assertTrue(result.single().first.loading)
@@ -46,26 +53,14 @@ class HomeScreenCategoriesTest {
 
     @Test
     fun rowsResolvedWithoutRenderableItemsAreHidden() {
-        val result = categories(
-            listOf(
-                RecommendationRow(folder("empty", items = emptyList()), itemsLoading = false),
-                RecommendationRow(folder("itemless", items = null), itemsLoading = false),
-            ),
-        )
+        val result = categories(listOf(resolvedRow("empty", items = emptyList())))
 
         assertTrue(result.isEmpty())
     }
 
     @Test
     fun rowsResolvedWithPlayableItemsAreShown() {
-        val result = categories(
-            listOf(
-                RecommendationRow(
-                    folder("a", items = listOf(testTrack())),
-                    itemsLoading = false,
-                ),
-            ),
-        )
+        val result = categories(listOf(resolvedRow("a", items = listOf(testTrack()))))
 
         val row = result.single().first
         assertFalse(row.loading)
@@ -74,10 +69,7 @@ class HomeScreenCategoriesTest {
 
     @Test
     fun rowsWithTheSameIdentityCollapseToOne() {
-        val duplicated = RecommendationRow(
-            folder("a", items = listOf(testTrack())),
-            itemsLoading = false,
-        )
+        val duplicated = resolvedRow("a", items = listOf(testTrack()))
 
         val result = categories(listOf(duplicated, duplicated))
 
@@ -88,8 +80,8 @@ class HomeScreenCategoriesTest {
     fun sameItemIdFromDifferentProvidersStaysDistinct() {
         val result = categories(
             listOf(
-                RecommendationRow(folder("a", provider = "library"), itemsLoading = true),
-                RecommendationRow(folder("a", provider = "spotify"), itemsLoading = true),
+                loadingRow("a", provider = "library"),
+                loadingRow("a", provider = "spotify"),
             ),
         )
 
@@ -99,12 +91,7 @@ class HomeScreenCategoriesTest {
     @Test
     fun shortcutsRowIsAppendedOnTopWhenUnconfigured() {
         val result = categories(
-            rows = listOf(
-                RecommendationRow(
-                    folder("a", items = listOf(testTrack())),
-                    itemsLoading = false,
-                ),
-            ),
+            rows = listOf(resolvedRow("a", items = listOf(testTrack()))),
             shortcuts = DataState.Data(listOf(Shortcut(testTrack()))),
         )
 

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
@@ -252,7 +252,7 @@ object KmpHelper : KoinComponent {
 
     fun fetchRecommendations(completion: (List<AppMediaItem>?) -> Unit) {
         launchFetch("recommendations", completion) {
-            mediaItemRepository.fetchMediaItems(Request.Library.recommendations()).getOrNull()
+            mediaItemRepository.fetchRecommendationFolders().getOrNull()
                 ?: emptyList()
         }
     }
@@ -261,8 +261,7 @@ object KmpHelper : KoinComponent {
         completion: (List<RecommendationFolder>?) -> Unit,
     ) {
         launchFetch("recommendationFolders", completion) {
-            mediaItemRepository.fetchMediaItems(Request.Library.recommendations()).getOrNull()
-                ?.filterIsInstance<RecommendationFolder>()
+            mediaItemRepository.fetchRecommendationFolders().getOrNull()
                 ?: emptyList()
         }
     }


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

Server 2.10 splits music/recommendations into a rows listing without embedded items plus a per-row music/recommendations/items command. The home page filtered out rows without playable items, so it rendered empty against 2.10 (beta) servers. Older servers keep embedding items.

MediaItemRepository.recommendationRows() bridges both response shapes as one snapshot stream: embedded rows pass through as a single resolved snapshot; item-less rows emit an immediate all-loading snapshot, then resolve per row in parallel. The first row is probed alone so an old server that returned only empty rows costs at most one failing RPC (RPC errors surface to the user as toasts). CarPlay consumes the same flow through a one-shot merged variant.

The home screen renders each row through CategoryRow's DataState overload: shimmer placeholders while a row's items load, auto-hide for rows that resolve empty, so the slowest provider no longer gates the whole page. reconcileHomeRows is generic over the row type, letting loading rows reconcile by identity before their items arrive. Shortcuts load concurrently instead of gating on recommendations.

Covered by RecommendationFoldersCompatTest (both server shapes, probe behavior, streaming snapshots, failure paths) and HomeScreenCategoriesTest (row visibility rules).

## Are there any additional changes not related to the issue above?

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

