### PR TITLE
Bump verified-compatible server API version to 43

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerInfo.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerInfo.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** Highest server schema_version this client is built and tested against. */
-const val LOCAL_SCHEMA_VERSION = 39
+const val LOCAL_SCHEMA_VERSION = 43
 
 @Serializable
 data class ServerInfo(


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

I have verified that we are wire-compatible with MA server API versions up through 43.

## Are there any additional changes not related to the issue above?
n/a

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

