### PR TITLE
Add installation method field to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,6 +10,7 @@ assignees: ''
  - Operating system and version:
  - App version:
  - Music Assistant server version:
+ - Music Assistant server installation method (Home Assistant App or Docker image):
 
 ### Problem description
 


### PR DESCRIPTION
Added a line to specify the installation method for the Music Assistant server in the bug report template. Might be useful when trying to reproduce filed issues.

<!-- 
Before submitting this PR, please read
https://github.com/music-assistant/mobile-app/blob/main/docs/CONTRIBUTING.md
-->

## Is there anything about the code changes here that should be highlighted?
No
## Are there any additional changes not related to the issue above?
No
## Before submitting this PR, make sure you have:
- [x] Given this PR a readable name that can be used in the app's changelog
- [ ] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

