### PR TITLE
Add CarPlay play from here support

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/CarActionPrefs.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/CarActionPrefs.kt
@@ -44,9 +44,9 @@ fun DefaultClickOption.isCarSupported(platform: CarPlatform, kind: ItemKind): Bo
 
     return if (this == DefaultClickOption.PLAY_FROM_HERE) {
         // Needs a parent container + start track, only resolvable for a TRACK tap inside an
-        // album/playlist drilldown — and only AA threads that context through (see AutoLibrary).
+        // album/playlist drilldown. Android Auto and CarPlay both thread that parent context.
         // Tap-only: TRACK is never a browsable bulk kind, so this also keeps it out of bulk lists.
-        platform == CarPlatform.ANDROID_AUTO && kind == ItemKind.TRACK
+        kind == ItemKind.TRACK
     } else {
         when (platform) {
             CarPlatform.ANDROID_AUTO -> true
@@ -68,6 +68,45 @@ fun Map<ItemKind, List<DefaultClickOption>>.carBulkActions(
     platform: CarPlatform,
 ): List<DefaultClickOption> =
     (this[kind] ?: defaultCarBulkActions).filter { it.isCarSupported(platform, kind) }
+
+/** Fully resolved media payload for a car-item tap. */
+data class CarItemDispatch(
+    val mediaUris: List<String>,
+    val option: QueueOption,
+    val radioMode: Boolean,
+    val startItem: String? = null,
+)
+
+/**
+ * Resolve a configured car tap into an MA play-media payload. PLAY_FROM_HERE targets the parent
+ * album/playlist URI and starts at the tapped track; plain actions target the tapped item's URI.
+ * Returns null instead of degrading PLAY_FROM_HERE to single-track playback when context is absent.
+ */
+fun planCarItemDispatch(
+    action: DefaultClickOption,
+    itemUri: String?,
+    itemId: String?,
+    parentUri: String?,
+): CarItemDispatch? {
+    if (action == DefaultClickOption.PLAY_FROM_HERE) {
+        val containerUri = parentUri ?: return null
+        val startItem = itemId ?: return null
+        return CarItemDispatch(
+            mediaUris = listOf(containerUri),
+            option = QueueOption.REPLACE,
+            radioMode = false,
+            startItem = startItem,
+        )
+    }
+
+    val mediaUri = itemUri ?: return null
+    val dispatch = action.toCarDispatch()
+    return CarItemDispatch(
+        mediaUris = listOf(mediaUri),
+        option = dispatch.option,
+        radioMode = dispatch.radioMode,
+    )
+}
 
 /** How a [DefaultClickOption] is dispatched to a player: queue option + radio-mode flag. */
 data class CarDispatch(val option: QueueOption, val radioMode: Boolean)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/CarActionPrefs.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/CarActionPrefs.kt
@@ -119,7 +119,7 @@ fun DefaultClickOption.toCarDispatch(): CarDispatch = when (this) {
     DefaultClickOption.ADD_TO_QUEUE -> CarDispatch(QueueOption.ADD, radioMode = false)
     DefaultClickOption.START_RADIO -> CarDispatch(QueueOption.REPLACE, radioMode = true)
     // PLAY_FROM_HERE isn't a plain queue-option dispatch — it needs a parent URI + start item,
-    // so it's resolved at the AA call site (AutoLibrary.play), never here.
+    // so Android Auto and CarPlay resolve it through their parent-aware call sites, never here.
     DefaultClickOption.PLAY_FROM_HERE ->
         throw IllegalArgumentException("$name must be handled at the call site, not toCarDispatch")
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/CarActionPrefs.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/CarActionPrefs.kt
@@ -79,8 +79,8 @@ data class CarItemDispatch(
 
 /**
  * Resolve a configured car tap into an MA play-media payload. PLAY_FROM_HERE targets the parent
- * album/playlist URI and starts at the tapped track; plain actions target the tapped item's URI.
- * Returns null instead of degrading PLAY_FROM_HERE to single-track playback when context is absent.
+ * album/playlist URI and starts at the tapped track when full context is available. If that context
+ * is incomplete, it falls back to replacing the queue with the tapped track, matching Android Auto.
  */
 fun planCarItemDispatch(
     action: DefaultClickOption,
@@ -89,13 +89,22 @@ fun planCarItemDispatch(
     parentUri: String?,
 ): CarItemDispatch? {
     if (action == DefaultClickOption.PLAY_FROM_HERE) {
-        val containerUri = parentUri ?: return null
-        val startItem = itemId ?: return null
+        parentUri?.let { containerUri ->
+            itemId?.let { startItem ->
+                return CarItemDispatch(
+                    mediaUris = listOf(containerUri),
+                    option = QueueOption.REPLACE,
+                    radioMode = false,
+                    startItem = startItem,
+                )
+            }
+        }
+
+        val mediaUri = itemUri ?: return null
         return CarItemDispatch(
-            mediaUris = listOf(containerUri),
+            mediaUris = listOf(mediaUri),
             option = QueueOption.REPLACE,
             radioMode = false,
-            startItem = startItem,
         )
     }
 

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/settings/CarActionPrefsTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/settings/CarActionPrefsTest.kt
@@ -115,7 +115,7 @@ class CarActionPrefsTest {
 
     @Test
     fun toCarDispatchRejectsPlayFromHere() {
-        // It's resolved at the AA call site (parent URI + start item), never via toCarDispatch.
+        // Parent-aware Android Auto and CarPlay call sites resolve this; toCarDispatch never does.
         val error = runCatching { DefaultClickOption.PLAY_FROM_HERE.toCarDispatch() }.exceptionOrNull()
         assertTrue(error is IllegalArgumentException)
     }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/settings/CarActionPrefsTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/settings/CarActionPrefsTest.kt
@@ -76,7 +76,7 @@ class CarActionPrefsTest {
     }
 
     @Test
-    fun playFromHereRejectsMissingParentContext() {
+    fun playFromHereFallsBackToTappedTrackWhenParentContextIsMissing() {
         val dispatch = planCarItemDispatch(
             action = DefaultClickOption.PLAY_FROM_HERE,
             itemUri = "library://track/7",
@@ -84,11 +84,14 @@ class CarActionPrefsTest {
             parentUri = null,
         )
 
-        assertEquals(null, dispatch)
+        assertEquals(listOf("library://track/7"), dispatch?.mediaUris)
+        assertEquals(null, dispatch?.startItem)
+        assertEquals(QueueOption.REPLACE, dispatch?.option)
+        assertFalse(dispatch?.radioMode ?: true)
     }
 
     @Test
-    fun playFromHereRejectsMissingStartItem() {
+    fun playFromHereFallsBackToTappedTrackWhenStartItemIsMissing() {
         val dispatch = planCarItemDispatch(
             action = DefaultClickOption.PLAY_FROM_HERE,
             itemUri = "library://track/7",
@@ -96,7 +99,10 @@ class CarActionPrefsTest {
             parentUri = "library://album/42",
         )
 
-        assertEquals(null, dispatch)
+        assertEquals(listOf("library://track/7"), dispatch?.mediaUris)
+        assertEquals(null, dispatch?.startItem)
+        assertEquals(QueueOption.REPLACE, dispatch?.option)
+        assertFalse(dispatch?.radioMode ?: true)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/settings/CarActionPrefsTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/settings/CarActionPrefsTest.kt
@@ -8,16 +8,16 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class CarActionPrefsTest {
-    // PLAY_FROM_HERE needs a parent container + start track, only resolvable for a TRACK tap
-    // inside an album/playlist drilldown — and only Android Auto threads that context through.
+    // PLAY_FROM_HERE needs a parent container + start track, resolvable for a TRACK tap
+    // inside an album/playlist drilldown on both Android Auto and CarPlay.
     @Test
-    fun playFromHereSupportedOnlyForAndroidAutoTrackTap() {
-        assertTrue(
-            DefaultClickOption.PLAY_FROM_HERE.isCarSupported(CarPlatform.ANDROID_AUTO, ItemKind.TRACK),
-        )
-        assertFalse(
-            DefaultClickOption.PLAY_FROM_HERE.isCarSupported(CarPlatform.CARPLAY, ItemKind.TRACK),
-        )
+    fun playFromHereSupportedForTrackTapsOnBothCarPlatforms() {
+        CarPlatform.entries.forEach { platform ->
+            assertTrue(
+                DefaultClickOption.PLAY_FROM_HERE.isCarSupported(platform, ItemKind.TRACK),
+                "PLAY_FROM_HERE should be supported for TRACK on $platform",
+            )
+        }
     }
 
     @Test
@@ -56,6 +56,61 @@ class CarActionPrefsTest {
         val offered = DefaultClickOption.entries
             .filter { it.isCarSupported(CarPlatform.ANDROID_AUTO, ItemKind.TRACK) }
         assertTrue(DefaultClickOption.PLAY_FROM_HERE in offered)
+    }
+
+    @Test
+    fun playFromHereBuildsParentAwareDispatchForAlbumAndPlaylist() {
+        listOf("library://album/42", "library://playlist/9").forEach { parentUri ->
+            val dispatch = planCarItemDispatch(
+                action = DefaultClickOption.PLAY_FROM_HERE,
+                itemUri = "library://track/7",
+                itemId = "track-7",
+                parentUri = parentUri,
+            )
+
+            assertEquals(listOf(parentUri), dispatch?.mediaUris)
+            assertEquals("track-7", dispatch?.startItem)
+            assertEquals(QueueOption.REPLACE, dispatch?.option)
+            assertFalse(dispatch?.radioMode ?: true)
+        }
+    }
+
+    @Test
+    fun playFromHereRejectsMissingParentContext() {
+        val dispatch = planCarItemDispatch(
+            action = DefaultClickOption.PLAY_FROM_HERE,
+            itemUri = "library://track/7",
+            itemId = "track-7",
+            parentUri = null,
+        )
+
+        assertEquals(null, dispatch)
+    }
+
+    @Test
+    fun playFromHereRejectsMissingStartItem() {
+        val dispatch = planCarItemDispatch(
+            action = DefaultClickOption.PLAY_FROM_HERE,
+            itemUri = "library://track/7",
+            itemId = null,
+            parentUri = "library://album/42",
+        )
+
+        assertEquals(null, dispatch)
+    }
+
+    @Test
+    fun plainCarActionUsesLeafUriAndIgnoresParentContext() {
+        val dispatch = planCarItemDispatch(
+            action = DefaultClickOption.ADD_TO_QUEUE,
+            itemUri = "library://track/7",
+            itemId = "track-7",
+            parentUri = "library://playlist/9",
+        )
+
+        assertEquals(listOf("library://track/7"), dispatch?.mediaUris)
+        assertEquals(null, dispatch?.startItem)
+        assertEquals(QueueOption.ADD, dispatch?.option)
     }
 
     @Test

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
@@ -39,6 +39,7 @@ import io.music_assistant.client.settings.DefaultClickOption
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.settings.carBulkActions
 import io.music_assistant.client.settings.carTapAction
+import io.music_assistant.client.settings.planCarItemDispatch
 import io.music_assistant.client.settings.toCarDispatch
 import io.music_assistant.client.ui.compose.library.LibraryCategory
 import io.music_assistant.client.ui.compose.library.carTabCategories
@@ -437,13 +438,27 @@ object KmpHelper : KoinComponent {
         dispatchLocal(item, option, radioMode = false)
 
     private fun dispatchLocal(item: AppMediaItem, option: QueueOption, radioMode: Boolean): Boolean {
+        return dispatchLocal(
+            mediaUris = listOfNotNull(item.mediaUri),
+            option = option,
+            radioMode = radioMode,
+        )
+    }
+
+    private fun dispatchLocal(
+        mediaUris: List<String>,
+        option: QueueOption,
+        radioMode: Boolean,
+        startItem: String? = null,
+    ): Boolean {
         val player = mainDataSource.localPlayer.value?.player
         val plan = planLocalPlayerDispatch(
             localPlayerId = player?.id,
             localPlayerSyncedTo = player?.syncedTo,
-            mediaUris = listOfNotNull(item.mediaUri),
+            mediaUris = mediaUris,
             option = option,
             radioMode = radioMode,
+            startItem = startItem,
         ) ?: return false
         plan.detachFrom?.let { syncedToId ->
             log.i { "dispatchLocal($option, radio=$radioMode): detaching ${plan.playerId} from $syncedToId" }
@@ -482,12 +497,28 @@ object KmpHelper : KoinComponent {
      * dispatched DefaultClickAction.name so Swift can decide whether to push Now Playing, or null
      * on failure / no playable URI.
      */
-    fun playCarDefaultTap(item: AppMediaItem): String? {
+    fun playCarDefaultTap(item: AppMediaItem, parent: AppMediaItem?): String? {
         val action = item.mediaType.toItemKind()
             ?.let { settingsRepository.carPlayableClickActions.value.carTapAction(it) }
             ?: DefaultClickOption.PLAY_NOW
-        val dispatch = action.toCarDispatch()
-        return if (dispatchLocal(item, dispatch.option, dispatch.radioMode)) action.name else null
+        val dispatch = planCarItemDispatch(
+            action = action,
+            itemUri = item.mediaUri,
+            itemId = item.itemId,
+            parentUri = parent?.mediaUri,
+        ) ?: return null
+        return if (
+            dispatchLocal(
+                mediaUris = dispatch.mediaUris,
+                option = dispatch.option,
+                radioMode = dispatch.radioMode,
+                startItem = dispatch.startItem,
+            )
+        ) {
+            action.name
+        } else {
+            null
+        }
     }
 
     /**

--- a/iosApp/iosApp/CarPlay/CarPlayContentManager.swift
+++ b/iosApp/iosApp/CarPlay/CarPlayContentManager.swift
@@ -181,8 +181,10 @@ class CarPlayContentManager {
     /// Dispatch the per-kind configured tap action. Returns the dispatched action name (so the
     /// caller can decide whether to push Now Playing), or nil on failure.
     @discardableResult
-    func playWithDefault(_ item: AppMediaItem) -> String? {
-        guard let name = KmpHelper.shared.playCarDefaultTap(item: item) else { return nil }
+    func playWithDefault(_ item: AppMediaItem, parent: AppMediaItem? = nil) -> String? {
+        guard let name = KmpHelper.shared.playCarDefaultTap(item: item, parent: parent) else {
+            return nil
+        }
         SiriIntentHandler.donatePlayed(item)
         return name
     }

--- a/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
+++ b/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
@@ -568,10 +568,10 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
 
     // MARK: - Item Selection
 
-    private func attachHandlers(to items: [CPListItem]) {
+    private func attachHandlers(to items: [CPListItem], parent: AppMediaItem? = nil) {
         for item in items {
             item.handler = { [weak self] listItem, completion in
-                self?.handleItemSelection(listItem)
+                self?.handleItemSelection(listItem, parent: parent)
                 completion()
             }
         }
@@ -580,7 +580,10 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     /// Type-aware dispatch: container items (Artist, Album, Playlist, Podcast) drill
     /// in to their contained items; leaf items (Track, RadioStation, Audiobook,
     /// PodcastEpisode) play and push Now Playing.
-    private func handleItemSelection(_ item: CPSelectableListItem) {
+    private func handleItemSelection(
+        _ item: CPSelectableListItem,
+        parent: AppMediaItem? = nil
+    ) {
         // Drop offline taps with a visible alert.
         guard isReady else { showOfflineAlert(); return }
         guard
@@ -600,7 +603,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
             // Track / RadioStation / Audiobook / PodcastEpisode — leaf items run the per-kind
             // configured tap action. Only push Now Playing when it actually starts playback
             // (a configured "add to queue" tap is non-disruptive).
-            let dispatched = CarPlayContentManager.shared.playWithDefault(mediaItem)
+            let dispatched = CarPlayContentManager.shared.playWithDefault(mediaItem, parent: parent)
             if let name = dispatched, Self.actionStartsPlayback(name) {
                 pushNowPlayingTemplate(animated: true)
             }
@@ -665,7 +668,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
                 if items.isEmpty {
                     template.updateSections([self.emptyStateSection(text: strings.empty)])
                 } else {
-                    self.attachHandlers(to: items)
+                    self.attachHandlers(to: items, parent: bulkActionParent)
                     let prefix = self.bulkActionRows(for: bulkActionParent)
                     template.updateSections([CPListSection(items: prefix + items)])
                 }


### PR DESCRIPTION
Closes #867

## Summary
- enable `PLAY_FROM_HERE` for CarPlay track taps
- preserve the album or playlist parent through CarPlay drilldown handlers
- dispatch the parent media URI with the tapped track ID as `start_item`
- fall back to replacing the queue with the tapped track when parent/start-item context is missing, matching Android Auto

Reconnect/session restoration is intentionally excluded from this PR.

## Test-driven development
- changed the missing-context planner expectations first and observed the expected failures
- added planner coverage for album and playlist parents, missing parent, missing start item, and unchanged plain-action dispatch

## Validation
- `CI=true ./gradlew detektAll`
- `./gradlew :composeApp:testAndroidHostTest`
- `./gradlew :androidApp:testDebug`
- `./gradlew :androidApp:assembleDebug`
- `./gradlew :androidApp:lintDebug`
- independent read-only diff review: passed with no security or logic errors

The existing PR workflow will run the Kotlin/Native test target and unsigned iOS simulator compile on macOS.
