### PR TITLE
Fix CarPlay authoritative state refresh

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -76,6 +76,18 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
 
+/** Preserve newer event/optimistic state when a delayed full snapshot arrives. */
+internal fun mergeFullQueueSnapshot(
+    retained: List<QueueInfo>,
+    incoming: List<QueueInfo>,
+): List<QueueInfo> {
+    val retainedById = retained.associateBy { it.id }
+    return incoming.map { candidate ->
+        val current = retainedById[candidate.id]
+        if (current != null && candidate.isBefore(current)) current else candidate
+    }
+}
+
 @OptIn(FlowPreview::class)
 class MainDataSource(
     private val settings: SettingsRepository,
@@ -923,6 +935,15 @@ class MainDataSource(
         _userSelectedPlayerId.update { player.id }
     }
 
+    /**
+     * Re-read authoritative player/queue state when CarPlay attaches.
+     * This reuses the existing read-only refresh path and never issues playback commands.
+     */
+    fun refreshCarPlayNowPlayingState() {
+        log.i { "CarPlay attached: refreshing authoritative player and queue state" }
+        updatePlayersAndQueues()
+    }
+
     /** `null` if this event is older than what `_queueInfos` already holds for the same id. */
     private fun QueueInfo.takeIfNotStale(label: String): QueueInfo? {
         val existing = _queueInfos.value.find { it.id == id } ?: return this
@@ -1472,8 +1493,11 @@ class MainDataSource(
         launch {
             apiClient.sendRequest(Request.Queue.all())
                 .resultAs<List<ServerQueue>>()?.let { queueFactory.createList(it) }?.let { list ->
-                    _queueInfos.update { list }
-                    list.forEach { queueInfo ->
+                    var mergedSnapshot = list
+                    _queueInfos.update { retained ->
+                        mergeFullQueueSnapshot(retained, list).also { mergedSnapshot = it }
+                    }
+                    mergedSnapshot.forEach { queueInfo ->
                         queueInfo.elapsedTime?.let { elapsed ->
                             val player = (_serverPlayers.value as? DataState.Data)
                                 ?.data?.find { it.queueId == queueInfo.id }
@@ -1491,7 +1515,7 @@ class MainDataSource(
                     val localPlayerId = settings.sendspinClientId.value
                     val localQueueId = (_serverPlayers.value as? DataState.Data)?.data
                         ?.find { it.id == localPlayerId }?.queueId
-                    list.find { it.id == localPlayerId || it.id == localQueueId }
+                    mergedSnapshot.find { it.id == localPlayerId || it.id == localQueueId }
                         ?.let { localPlayerController.onServerQueueUpdate(it) }
                 }
         }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -935,12 +935,9 @@ class MainDataSource(
         _userSelectedPlayerId.update { player.id }
     }
 
-    /**
-     * Re-read authoritative player/queue state when CarPlay attaches.
-     * This reuses the existing read-only refresh path and never issues playback commands.
-     */
-    fun refreshCarPlayNowPlayingState() {
-        log.i { "CarPlay attached: refreshing authoritative player and queue state" }
+    /** Re-read authoritative player and queue state without issuing playback commands. */
+    fun refreshPlayersAndQueues() {
+        log.i { "Refreshing authoritative player and queue state" }
         updatePlayersAndQueues()
     }
 

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/CarPlayQueueSnapshotMergeTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/CarPlayQueueSnapshotMergeTest.kt
@@ -1,0 +1,41 @@
+package io.music_assistant.client.data
+
+import io.music_assistant.client.data.model.client.QueueInfo
+import io.music_assistant.client.data.model.client.RepeatMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CarPlayQueueSnapshotMergeTest {
+    private fun queue(id: String, stamp: Double, elapsed: Double) = QueueInfo(
+        id = id,
+        available = true,
+        currentIndex = null,
+        shuffleEnabled = false,
+        repeatMode = RepeatMode.OFF,
+        elapsedTime = elapsed,
+        elapsedTimeLastUpdated = stamp,
+        currentItem = null,
+        radioSource = emptyList(),
+        autoPlayEnabled = false,
+    )
+
+    @Test
+    fun `delayed full refresh cannot overwrite newer retained queue state`() {
+        val retained = queue("local", stamp = 200.0, elapsed = 75.0)
+        val delayed = queue("local", stamp = 100.0, elapsed = 20.0)
+
+        assertEquals(listOf(retained), mergeFullQueueSnapshot(listOf(retained), listOf(delayed)))
+    }
+
+    @Test
+    fun `full refresh accepts newer state and newly discovered queues`() {
+        val retained = queue("local", stamp = 100.0, elapsed = 20.0)
+        val fresh = queue("local", stamp = 200.0, elapsed = 75.0)
+        val discovered = queue("kitchen", stamp = 50.0, elapsed = 10.0)
+
+        assertEquals(
+            listOf(fresh, discovered),
+            mergeFullQueueSnapshot(listOf(retained), listOf(fresh, discovered)),
+        )
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/FullQueueSnapshotMergeTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/FullQueueSnapshotMergeTest.kt
@@ -5,7 +5,7 @@ import io.music_assistant.client.data.model.client.RepeatMode
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class CarPlayQueueSnapshotMergeTest {
+class FullQueueSnapshotMergeTest {
     private fun queue(id: String, stamp: Double, elapsed: Double) = QueueInfo(
         id = id,
         available = true,

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
@@ -125,6 +125,7 @@ object KmpHelper : KoinComponent {
 
     fun onExternalConsumerActive() = serviceClient.onExternalConsumerActive()
     fun onExternalConsumerInactive() = serviceClient.onExternalConsumerInactive()
+    fun refreshCarPlayNowPlayingState() = mainDataSource.refreshCarPlayNowPlayingState()
 
     // MARK: - Artwork loader (Swift-callable)
     //

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/di/KmpHelper.kt
@@ -125,7 +125,7 @@ object KmpHelper : KoinComponent {
 
     fun onExternalConsumerActive() = serviceClient.onExternalConsumerActive()
     fun onExternalConsumerInactive() = serviceClient.onExternalConsumerInactive()
-    fun refreshCarPlayNowPlayingState() = mainDataSource.refreshCarPlayNowPlayingState()
+    fun refreshCarPlayNowPlayingState() = mainDataSource.refreshPlayersAndQueues()
 
     // MARK: - Artwork loader (Swift-callable)
     //

--- a/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
+++ b/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
@@ -94,6 +94,8 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
         }
         didAttachExternalConsumer = true
         KmpHelper.shared.onExternalConsumerActive()
+        // Rehydrate Now Playing from the server; attaching alone never authorizes playback.
+        KmpHelper.shared.refreshCarPlayNowPlayingState()
         // Resolve localized strings before building templates: CarPlay template
         // titles are immutable after construction, so the active-locale strings
         // must be known up front. Subscribing to readiness inside the completion


### PR DESCRIPTION
## Summary
- refresh authoritative player and queue state when CarPlay attaches
- preserve newer event/optimistic queue state when a delayed full queue snapshot arrives
- use the stale-safe merged snapshot for position tracking and local-player forwarding

## Scope
- read-only refresh only; no playback, seek, or queue mutation added
- no Sendspin reconnect, route-loss, or playback-authorization changes
- no Android behavior changes

## Validation
- complete Android-host test target passed (296 tests, 0 failures)
- focused CarPlay queue snapshot merge and existing Now Playing/remote-command tests passed
- `:composeApp:compileKotlinIosSimulatorArm64` passed
- `git diff --check` passed
- blocker-only conformity review passed

## Physical validation
Physical iPhone/CarPlay validation was not performed because no Apple Developer signing path is available. This remains explicitly unverified.