### PR TITLE
Bump supported API version

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerInfo.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerInfo.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** Highest server schema_version this client is built and tested against. */
-const val LOCAL_SCHEMA_VERSION = 43
+const val LOCAL_SCHEMA_VERSION = 45
 
 @Serializable
 data class ServerInfo(


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

I verified that 44 and 45 are both optional / not applicable, and work with our existing app

## Are there any additional changes not related to the issue above?

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

