### PR TITLE
Support dynamic radio stations

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/factory/MediaItemFactory.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/factory/MediaItemFactory.kt
@@ -151,6 +151,7 @@ class MediaItemFactory(
                 images = resolveImageInfo(image, metadata),
                 version = version,
                 isPlayable = isPlayable == true,
+                isDynamic = isDynamic == true,
             )
 
             MediaType.AUDIOBOOK -> Audiobook(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/RadioStation.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/RadioStation.kt
@@ -19,6 +19,7 @@ data class RadioStation(
     override val images: Map<ImageType, ImageInfo>,
     override val version: String?,
     override val isPlayable: Boolean,
+    val isDynamic: Boolean,
 ) : AppMediaItem(), PlayableItem {
     override val mediaType: MediaType = MediaType.RADIO
     override val duration: Double? = null

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerInfo.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerInfo.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** Highest server schema_version this client is built and tested against. */
-const val LOCAL_SCHEMA_VERSION = 45
+const val LOCAL_SCHEMA_VERSION = 49
 
 @Serializable
 data class ServerInfo(

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/TestMediaItems.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/TestMediaItems.kt
@@ -39,9 +39,10 @@ internal fun testPlaylist(isDynamic: Boolean = false) = Playlist(
     favorite = null, uri = null, images = emptyMap(), isEditable = true, isDynamic = isDynamic,
 )
 
-internal fun testRadio(isPlayable: Boolean = true) = RadioStation(
+internal fun testRadio(isPlayable: Boolean = true, isDynamic: Boolean = false) = RadioStation(
     itemId = "id", provider = "test", name = "name", providerMappings = null, metadata = null,
     favorite = null, uri = null, images = emptyMap(), version = null, isPlayable = isPlayable,
+    isDynamic = isDynamic,
 )
 
 internal fun testPodcastEpisode(isPlayable: Boolean = true) = PodcastEpisode(

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/ServerMediaItemSerializationTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/ServerMediaItemSerializationTest.kt
@@ -77,10 +77,12 @@ class ServerMediaItemSerializationTest {
 
     @Test
     fun factoryPreservesDynamicRadioFlag() {
-        val item = myJson.decodeFromString<ServerMediaItem>("""
-            {"item_id":"radio-1","provider":"provider","name":"Dynamic Radio",
-             "media_type":"radio","is_dynamic":true,"is_playable":true}
-        """.trimIndent())
+        val item = myJson.decodeFromString<ServerMediaItem>(
+            """
+                {"item_id":"radio-1","provider":"provider","name":"Dynamic Radio",
+                 "media_type":"radio","is_dynamic":true,"is_playable":true}
+            """.trimIndent(),
+        )
 
         assertEquals(true, item.isDynamic)
         assertEquals(true, (factory.create(item) as RadioStation).isDynamic)

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/ServerMediaItemSerializationTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/ServerMediaItemSerializationTest.kt
@@ -2,6 +2,7 @@ package io.music_assistant.client.data.model.server
 
 import io.music_assistant.client.data.factory.MediaItemFactory
 import io.music_assistant.client.data.model.client.MediaType
+import io.music_assistant.client.data.model.client.items.RadioStation
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.utils.myJson
 import kotlin.test.Test
@@ -72,5 +73,16 @@ class ServerMediaItemSerializationTest {
 
         assertEquals(listOf("Ashley Elston", "Plain String Author"), item.authors)
         assertEquals(listOf("Nora Narrator"), item.narrators)
+    }
+
+    @Test
+    fun factoryPreservesDynamicRadioFlag() {
+        val item = myJson.decodeFromString<ServerMediaItem>("""
+            {"item_id":"radio-1","provider":"provider","name":"Dynamic Radio",
+             "media_type":"radio","is_dynamic":true,"is_playable":true}
+        """.trimIndent())
+
+        assertEquals(true, item.isDynamic)
+        assertEquals(true, (factory.create(item) as RadioStation).isDynamic)
     }
 }


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

This is purely internal, we don't actually do anything different in the app based on isDynamic being set, at least not yet.

## Are there any additional changes not related to the issue above?

Bump LOCAL_SCHEMA_VERSION to 49

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

